### PR TITLE
fix: dead image link in hugo pages

### DIFF
--- a/docs/.build/prepare.sh
+++ b/docs/.build/prepare.sh
@@ -11,6 +11,14 @@ echo "copy contents to docs/.build/content"
 test -d ./content || mkdir ./content
 cp -r ../* ./content/
 rm -rf ./content/zh
+
+if [ "$(uname)" == "Darwin" ]; then
+  find ./content -name '*.md' -exec sed -i '' 's#../images#/images#g' {} \;
+else
+  find ./content -name '*.md' -exec sed -i 's#../images#/images#g' {} \;
+fi
+
+
 echo "copy images"
 test -d ./static || mkdir ./static
 mv ./content/images ./static/


### PR DESCRIPTION
Signed-off-by: lowzj <zj3142063@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Relative path of image in markdown files are not suitable for generated hugo html pages.
This pull request replaces all the relative path with absolute path.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


