### PR TITLE
refator: use error instead of panic

### DIFF
--- a/dfget/config/constants.go
+++ b/dfget/config/constants.go
@@ -101,3 +101,24 @@ const (
 	LocalHTTPPathClient = "/client/"
 	LocalHTTPPathRate   = "/rate/"
 )
+
+/* errors code */
+const (
+	// CodePrepareError represents failed to prepare.
+	CodePrepareError = 1100
+
+	// CodeInitLogError represents failed to init log.
+	CodeInitLogError = 1101
+
+	// CodeAssertContextError ssertContextFailed represents failed to assert context.
+	CodeAssertContextError = 1102
+
+	// CodeGetUserError represents failed to get current user.
+	CodeGetUserError = 1103
+
+	// CodeRegisterError represents failed to get current user.
+	CodeRegisterError = 1200
+
+	// CodeDownloadError represents failed to download file.
+	CodeDownloadError = 1300
+)

--- a/dfget/core/core_test.go
+++ b/dfget/core/core_test.go
@@ -85,16 +85,16 @@ func (s *CoreTestSuite) TestRegisterToSupernode(c *check.C) {
 		}
 	}
 
-	f(config.BackSourceReasonNodeEmpty, true, nil)
+	f(config.BackSourceReasonNodeEmpty, false, nil)
 
 	ctx.Pattern = config.PatternSource
-	f(config.BackSourceReasonUserSpecified, true, nil)
+	f(config.BackSourceReasonUserSpecified, false, nil)
 
 	ctx.Pattern = config.PatternP2P
 
 	ctx.Node = []string{"x"}
 	ctx.URL = "http://x.com"
-	f(config.BackSourceReasonRegisterFail, true, nil)
+	f(config.BackSourceReasonRegisterFail, false, nil)
 
 	ctx.Node = []string{"x"}
 	ctx.URL = "http://taobao.com"

--- a/dfget/errors/errors.go
+++ b/dfget/errors/errors.go
@@ -19,6 +19,25 @@ package errors
 
 import (
 	"fmt"
+
+	errpkg "github.com/pkg/errors"
+)
+
+var (
+	// ErrInvalidValue represents the value is invalid.
+	ErrInvalidValue = &DFGetError{codeInvalidValue, "invalid value"}
+
+	// ErrNotInitialized represents the object is not initialized.
+	ErrNotInitialized = &DFGetError{codeNotInitialized, "not initialized"}
+
+	// ErrConvertFailed represents failed to convert.
+	ErrConvertFailed = &DFGetError{codeConvertFailed, "convert failed"}
+)
+
+const (
+	codeInvalidValue = iota
+	codeNotInitialized
+	codeConvertFailed
 )
 
 // New function creates a DFGetError.
@@ -46,4 +65,36 @@ type DFGetError struct {
 
 func (e *DFGetError) Error() string {
 	return fmt.Sprintf("{\"Code\":%d,\"Msg\":\"%s\"}", e.Code, e.Msg)
+}
+
+// IsNilError check the error is nil or not.
+func IsNilError(err error) bool {
+	if err == nil {
+		return true
+	}
+	return false
+}
+
+// IsInvalidValue check the error is the value is invalid or not.
+func IsInvalidValue(err error) bool {
+	fmt.Printf("err: %v", err)
+	return checkError(err, codeInvalidValue)
+}
+
+// IsNotInitialized check the error is the object is not initialized or not.
+func IsNotInitialized(err error) bool {
+	return checkError(err, codeNotInitialized)
+}
+
+// IsConvertFailed check the error is a conversion error or not.
+func IsConvertFailed(err error) bool {
+	return checkError(err, codeConvertFailed)
+}
+
+func checkError(err error, code int) bool {
+	errCause := errpkg.Cause(err)
+	if errTemp, ok := errCause.(*DFGetError); ok && errTemp.Code == code {
+		return true
+	}
+	return false
 }

--- a/dfget/util/log.go
+++ b/dfget/util/log.go
@@ -31,27 +31,29 @@ import (
 const DefaultLogTimeFormat = "2006-01-02 15:04:05.000"
 
 // CreateLogger creates a logger.
-func CreateLogger(logPath string, logName string, logLevel string, sign string) *log.Logger {
-	var (
-		logger      *log.Logger
-		logFilePath = path.Join(logPath, logName)
-		level, err  = log.ParseLevel(logLevel)
-	)
+func CreateLogger(logPath string, logName string, logLevel string, sign string) (*log.Logger, error) {
+
+	logFilePath := path.Join(logPath, logName)
+	level, err := log.ParseLevel(logLevel)
 	if err != nil {
 		level = log.InfoLevel
 	}
-	if err = os.MkdirAll(filepath.Dir(logFilePath), 0755); err == nil {
-		var logFile *os.File
-		if logFile, err = os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644); err == nil {
-			logFile.Seek(0, 2)
-			logger = log.New()
-			logger.Out = logFile
-			logger.Formatter = &DragonflyFormatter{TimestampFormat: DefaultLogTimeFormat, Sign: sign}
-			logger.Level = level
-			return logger
-		}
+	if err := os.MkdirAll(filepath.Dir(logFilePath), 0755); err != nil {
+		return nil, err
 	}
-	panic(err)
+
+	logFile, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return nil, err
+	}
+	logFile.Seek(0, 2)
+
+	logger := log.New()
+	logger.Out = logFile
+	logger.Formatter = &DragonflyFormatter{TimestampFormat: DefaultLogTimeFormat, Sign: sign}
+	logger.Level = level
+	return logger, nil
+
 }
 
 // AddConsoleLog will add a ConsoleLog into logger's hooks.

--- a/dfget/util/log_test.go
+++ b/dfget/util/log_test.go
@@ -74,7 +74,7 @@ func (suite *DFGetUtilSuite) TestCreateLogger_differentLevel(c *check.C) {
 	defer os.Remove(path.Join(tmpPath, tmpFileName))
 
 	var testLevel = func(level string, expected logrus.Level) {
-		logger = CreateLogger(tmpPath, tmpFileName, level, "")
+		logger, _ = CreateLogger(tmpPath, tmpFileName, level, "")
 		c.Assert(logger.Level, check.Equals, expected)
 	}
 
@@ -125,7 +125,7 @@ func tempFileAndLogger(level string, sign string) (*logrus.Logger, *os.File, *bu
 	tmpFile, err := ioutil.TempFile(tmpPath, "dfget_test")
 	tmpFileName := strings.TrimLeft(tmpFile.Name(), "/tmp/")
 	r := bufio.NewReader(tmpFile)
-	logger := CreateLogger(tmpPath, tmpFileName, level, sign)
+	logger, _ := CreateLogger(tmpPath, tmpFileName, level, sign)
 	return logger, tmpFile, r, err
 }
 

--- a/dfget/util/util.go
+++ b/dfget/util/util.go
@@ -20,7 +20,6 @@ package util
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"reflect"
 )
@@ -62,20 +61,6 @@ func IsNil(value interface{}) (result bool) {
 		}
 	}
 	return
-}
-
-// PanicIfNil panic if the obj is nil.
-func PanicIfNil(obj interface{}, msg string) {
-	if IsNil(obj) {
-		panic(fmt.Errorf(msg))
-	}
-}
-
-// PanicIfError panic if an error happened.
-func PanicIfError(err error, msg string) {
-	if err != nil {
-		panic(fmt.Errorf("%s: %v", msg, err))
-	}
 }
 
 // JSONString returns json string of the v.

--- a/dfget/util/util_test.go
+++ b/dfget/util/util_test.go
@@ -17,7 +17,6 @@
 package util
 
 import (
-	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -64,39 +63,6 @@ func (suite *DFGetUtilSuite) TestIsNil(c *check.C) {
 
 	var temp *DFGetUtilSuite
 	c.Assert(IsNil(temp), check.Equals, true)
-}
-
-func (suite *DFGetUtilSuite) TestPanicIfNil(c *check.C) {
-	var f = func(v interface{}, msg string) (retMsg string) {
-		defer func() {
-			if r := recover(); r != nil {
-				retMsg = r.(error).Error()
-			}
-		}()
-
-		PanicIfNil(v, msg)
-		return ""
-	}
-
-	c.Assert(f(1, "int"), check.Equals, "")
-	c.Assert(f("", "string"), check.Equals, "")
-	c.Assert(f(nil, "nil"), check.Equals, "nil")
-	c.Assert(f(suite, "*DFGetUtilSuite"), check.Equals, "")
-}
-
-func (suite *DFGetUtilSuite) TestPanicIfError(c *check.C) {
-	var f = func(v error, msg string) (retMsg string) {
-		defer func() {
-			if r := recover(); r != nil {
-				retMsg = r.(error).Error()
-			}
-		}()
-
-		PanicIfError(v, msg)
-		return ""
-	}
-	c.Assert(f(nil, ""), check.Equals, "")
-	c.Assert(f(fmt.Errorf("test"), "error"), check.Equals, "error: test")
 }
 
 func (suite *DFGetUtilSuite) TestJsonString(c *check.C) {

--- a/vendor/github.com/pkg/errors/LICENSE
+++ b/vendor/github.com/pkg/errors/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/pkg/errors/README.md
+++ b/vendor/github.com/pkg/errors/README.md
@@ -1,0 +1,52 @@
+# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![AppVeyor](https://ci.appveyor.com/api/projects/status/b98mptawhudj53ep/branch/master?svg=true)](https://ci.appveyor.com/project/davecheney/errors/branch/master) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors) [![Sourcegraph](https://sourcegraph.com/github.com/pkg/errors/-/badge.svg)](https://sourcegraph.com/github.com/pkg/errors?badge)
+
+Package errors provides simple error handling primitives.
+
+`go get github.com/pkg/errors`
+
+The traditional error handling idiom in Go is roughly akin to
+```go
+if err != nil {
+        return err
+}
+```
+which applied recursively up the call stack results in error reports without context or debugging information. The errors package allows programmers to add context to the failure path in their code in a way that does not destroy the original value of the error.
+
+## Adding context to an error
+
+The errors.Wrap function returns a new error that adds context to the original error. For example
+```go
+_, err := ioutil.ReadAll(r)
+if err != nil {
+        return errors.Wrap(err, "read failed")
+}
+```
+## Retrieving the cause of an error
+
+Using `errors.Wrap` constructs a stack of errors, adding context to the preceding error. Depending on the nature of the error it may be necessary to reverse the operation of errors.Wrap to retrieve the original error for inspection. Any error value which implements this interface can be inspected by `errors.Cause`.
+```go
+type causer interface {
+        Cause() error
+}
+```
+`errors.Cause` will recursively retrieve the topmost error which does not implement `causer`, which is assumed to be the original cause. For example:
+```go
+switch err := errors.Cause(err).(type) {
+case *MyError:
+        // handle specifically
+default:
+        // unknown error
+}
+```
+
+[Read the package documentation for more information](https://godoc.org/github.com/pkg/errors).
+
+## Contributing
+
+We welcome pull requests, bug fixes and issue reports. With that said, the bar for adding new symbols to this package is intentionally set high.
+
+Before proposing a change, please discuss your change by raising an issue.
+
+## License
+
+BSD-2-Clause

--- a/vendor/github.com/pkg/errors/appveyor.yml
+++ b/vendor/github.com/pkg/errors/appveyor.yml
@@ -1,0 +1,32 @@
+version: build-{build}.{branch}
+
+clone_folder: C:\gopath\src\github.com\pkg\errors
+shallow_clone: true # for startup speed
+
+environment:
+  GOPATH: C:\gopath
+
+platform:
+  - x64
+
+# http://www.appveyor.com/docs/installed-software
+install:
+  # some helpful output for debugging builds
+  - go version
+  - go env
+  # pre-installed MinGW at C:\MinGW is 32bit only
+  # but MSYS2 at C:\msys64 has mingw64
+  - set PATH=C:\msys64\mingw64\bin;%PATH%
+  - gcc --version
+  - g++ --version
+
+build_script:
+  - go install -v ./...
+
+test_script:
+  - set PATH=C:\gopath\bin;%PATH%
+  - go test -v ./...
+
+#artifacts:
+#  - path: '%GOPATH%\bin\*.exe'
+deploy: off

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -1,0 +1,282 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//     if err != nil {
+//             return err
+//     }
+//
+// which when applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error by recording a stack trace at the point Wrap is called,
+// together with the supplied message. For example
+//
+//     _, err := ioutil.ReadAll(r)
+//     if err != nil {
+//             return errors.Wrap(err, "read failed")
+//     }
+//
+// If additional control is required, the errors.WithStack and
+// errors.WithMessage functions destructure errors.Wrap into its component
+// operations: annotating an error with a stack trace and with a message,
+// respectively.
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type causer interface {
+//             Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error that does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+//
+// Although the causer interface is not exported by this package, it is
+// considered a part of its stable public interface.
+//
+// Formatted printing of errors
+//
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported:
+//
+//     %s    print the error. If the error has a Cause it will be
+//           printed recursively.
+//     %v    see %s
+//     %+v   extended format. Each Frame of the error's StackTrace will
+//           be printed in detail.
+//
+// Retrieving the stack trace of an error or wrapper
+//
+// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
+// invoked. This information can be retrieved with the following interface:
+//
+//     type stackTracer interface {
+//             StackTrace() errors.StackTrace
+//     }
+//
+// The returned errors.StackTrace type is defined as
+//
+//     type StackTrace []Frame
+//
+// The Frame type represents a call site in the stack trace. Frame supports
+// the fmt.Formatter interface that can be used for printing information about
+// the stack trace of this error. For example:
+//
+//     if err, ok := err.(stackTracer); ok {
+//             for _, f := range err.StackTrace() {
+//                     fmt.Printf("%+s:%d", f)
+//             }
+//     }
+//
+// Although the stackTracer interface is not exported by this package, it is
+// considered a part of its stable public interface.
+//
+// See the documentation for Frame.Format for more details.
+package errors
+
+import (
+	"fmt"
+	"io"
+)
+
+// New returns an error with the supplied message.
+// New also records the stack trace at the point it was called.
+func New(message string) error {
+	return &fundamental{
+		msg:   message,
+		stack: callers(),
+	}
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+// Errorf also records the stack trace at the point it was called.
+func Errorf(format string, args ...interface{}) error {
+	return &fundamental{
+		msg:   fmt.Sprintf(format, args...),
+		stack: callers(),
+	}
+}
+
+// fundamental is an error that has a message and a stack, but no caller.
+type fundamental struct {
+	msg string
+	*stack
+}
+
+func (f *fundamental) Error() string { return f.msg }
+
+func (f *fundamental) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			io.WriteString(s, f.msg)
+			f.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, f.msg)
+	case 'q':
+		fmt.Fprintf(s, "%q", f.msg)
+	}
+}
+
+// WithStack annotates err with a stack trace at the point WithStack was called.
+// If err is nil, WithStack returns nil.
+func WithStack(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+type withStack struct {
+	error
+	*stack
+}
+
+func (w *withStack) Cause() error { return w.error }
+
+func (w *withStack) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v", w.Cause())
+			w.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, w.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", w.Error())
+	}
+}
+
+// Wrap returns an error annotating err with a stack trace
+// at the point Wrap is called, and the supplied message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   message,
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// Wrapf returns an error annotating err with a stack trace
+// at the point Wrapf is called, and the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// WithMessage annotates err with a new message.
+// If err is nil, WithMessage returns nil.
+func WithMessage(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   message,
+	}
+}
+
+// WithMessagef annotates err with the format specifier.
+// If err is nil, WithMessagef returns nil.
+func WithMessagef(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg: fmt.Sprintf(format, args...),
+	}
+}
+
+type withMessage struct {
+	cause error
+	msg   string
+}
+
+func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
+func (w *withMessage) Cause() error  { return w.cause }
+
+func (w *withMessage) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v\n", w.Cause())
+			io.WriteString(s, w.msg)
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		io.WriteString(s, w.Error())
+	}
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}

--- a/vendor/github.com/pkg/errors/stack.go
+++ b/vendor/github.com/pkg/errors/stack.go
@@ -1,0 +1,147 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strings"
+)
+
+// Frame represents a program counter inside a stack frame.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   function name and path of source file relative to the compile time
+//          GOPATH separated by \n\t (<funcname>\n\t<path>)
+//    %+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			pc := f.pc()
+			fn := runtime.FuncForPC(pc)
+			if fn == nil {
+				io.WriteString(s, "unknown")
+			} else {
+				file, _ := fn.FileLine(pc)
+				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
+			}
+		default:
+			io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		fmt.Fprintf(s, "%d", f.line())
+	case 'n':
+		name := runtime.FuncForPC(f.pc()).Name()
+		io.WriteString(s, funcname(name))
+	case 'v':
+		f.Format(s, 's')
+		io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+// Format formats the stack of Frames according to the fmt.Formatter interface.
+//
+//    %s	lists source files for each Frame in the stack
+//    %v	lists the source file and line number for each Frame in the stack
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+v   Prints filename, function, and line number for each Frame in the stack.
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				fmt.Fprintf(s, "\n%+v", f)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			fmt.Fprintf(s, "%v", []Frame(st))
+		}
+	case 's':
+		fmt.Fprintf(s, "%s", []Frame(st))
+	}
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) Format(st fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case st.Flag('+'):
+			for _, pc := range *s {
+				f := Frame(pc)
+				fmt.Fprintf(st, "\n%+v", f)
+			}
+		}
+	}
+}
+
+func (s *stack) StackTrace() StackTrace {
+	f := make([]Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((*s)[i])
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -159,6 +159,12 @@
 			"revisionTime": "2018-01-22T19:00:07Z"
 		},
 		{
+			"checksumSHA1": "DTy0iJ2w5C+FDsN9EnzfhNmvS+o=",
+			"path": "github.com/pkg/errors",
+			"revision": "059132a15dd08d6704c67711dae0cf35ab991756",
+			"revisionTime": "2018-10-23T23:59:46Z"
+		},
+		{
 			"checksumSHA1": "LuFv4/jlrmFNnDb/5SCSEPAM9vU=",
 			"path": "github.com/pmezard/go-difflib/difflib",
 			"revision": "792786c7400a136282c1664665ae0a8db921c6c2",


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
I have open an issue about [Should we use panic or return error?](https://github.com/dragonflyoss/Dragonfly/issues/193) . And maybe error will be better. A simple example as follows:
```
# panic
# dfget --url "http://test" --output ./resource.png --node "127.0.0.1"
panic: invalid url: http://test [recovered]
	panic: (*logrus.Entry) (0x78fe80,0xc42008c870)

goroutine 1 [running]:
github.com/dragonflyoss/Dragonfly/vendor/github.com/sirupsen/logrus.Entry.log(0xc42008c690, 0xc420081dd0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/tmp/dragonfly/build/src/github.com/dragonflyoss/Dragonfly/vendor/github.com/sirupsen/logrus/entry.go:126 +0x318
github.com/dragonflyoss/Dragonfly/vendor/github.com/sirupsen/logrus.(*Entry).Panic(0xc42008c820, 0xc420185d28, 0x1, 0x1)
	/tmp/dragonfly/build/src/github.com/dragonflyoss/Dragonfly/vendor/github.com/sirupsen/logrus/entry.go:196 +0xaa
github.com/dragonflyoss/Dragonfly/vendor/github.com/sirupsen/logrus.(*Logger).Panic(0xc42008c690, 0xc420055d28, 0x1, 0x1)
	/tmp/dragonfly/build/src/github.com/dragonflyoss/Dragonfly/vendor/github.com/sirupsen/logrus/logger.go:244 +0x6d
github.com/dragonflyoss/Dragonfly/dfget/config.AssertContext.func1(0xc420168000)
	/tmp/dragonfly/build/src/github.com/dragonflyoss/Dragonfly/dfget/config/config.go:281 +0x87
panic(0x72c660, 0xc42007ff30)
	/usr/local/go/src/runtime/panic.go:502 +0x229
github.com/dragonflyoss/Dragonfly/dfget/util.PanicIfError(0x7e5f40, 0xc42007ff10, 0x7a22d0, 0xb)
	/tmp/dragonfly/build/src/github.com/dragonflyoss/Dragonfly/dfget/util/util.go:77 +0x105
github.com/dragonflyoss/Dragonfly/dfget/config.AssertContext(0xc420168000)
	/tmp/dragonfly/build/src/github.com/dragonflyoss/Dragonfly/dfget/config/config.go:285 +0x121
github.com/dragonflyoss/Dragonfly/dfget/cli.initialize()
	/tmp/dragonfly/build/src/github.com/dragonflyoss/Dragonfly/dfget/cli/cli.go:50 +0x3b
github.com/dragonflyoss/Dragonfly/dfget/cli.Run()
	/tmp/dragonfly/build/src/github.com/dragonflyoss/Dragonfly/dfget/cli/cli.go:37 +0x26
main.main()
	/tmp/dragonfly/build/src/github.com/dragonflyoss/Dragonfly/cmd/dfget/main.go:28 +0x20


# error
# dfget --url "http://test" --output ./resource.png --node "127.0.0.1"
assert context error: url: {"Code":0,"Msg":"invalid value"}
```

Obviously, if the end user use dfget to download  a file with an incorrect URL, and then a lot of information flooded into my eyes, what happened?  So whatever, return panic is not friendly to the end user. So I submit this pull request. And refactor some code style that doesn't make sense by the way.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #193

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
Have updated.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


