### PR TITLE
Rewrite dockerfile to make the image smaller

### DIFF
--- a/dfdaemon/initializer/initializer.go
+++ b/dfdaemon/initializer/initializer.go
@@ -199,7 +199,7 @@ func initParam(options *options.Options) {
 		log.Errorf("dfpath:%s not found", options.DfPath)
 		os.Exit(constant.CodeExitDfgetNotFound)
 	}
-	cmd := exec.Command(options.DfPath, "-v")
+	cmd := exec.Command(options.DfPath, "version")
 	version, _ := cmd.CombinedOutput()
 
 	log.Infof("dfget version:%s", string(version))


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
It used to take a long time to download the image because it was so big. As title described, to make the image smaller built by the Dockerfile, I rewrite the Dockerfile using multi-stage builds. Now 

```
# docker images
REPOSITORY                                                 TAG                 IMAGE ID            CREATED             SIZE
dfclient                                                   latest              b1a01a3df1a9        12 minutes ago      28.5MB
dragonflyoss/dfclient                                      v0.3.0_dev          79cf3514b9dc        3 weeks ago         842MB
```
Finally, the program also runs normally and the mirror size is significantly reduced

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
just Dockerfile


### Ⅳ. Describe how to verify it
```
# docker build -t build .

# docker run -d -p 65001:65001 dfclient

# docker ps
CONTAINER ID        IMAGE                                                            COMMAND             CREATED             STATUS              PORTS                              NAMES
e69a9b472edc        b1a01a3df1a9                                                     "./dfdaemon"        14 minutes ago      Up 14 minutes       0.0.0.0:65001->65001/tcp           wizardly_meitner

# curl 127.0.0.1:65001/env
map[dfPattern:[] home:/root/ param:{DfPath:/dfclient/dfget DFRepo:/root/.small-dragonfly/dfdaemon/data/ RateLimit:20M CallSystem:com_ops_dragonfly URLFilter:Signature&Expires&OSSAccessKeyId Notbs:true HostIP:127.0.0.1 Registry:}]
```

### Ⅴ. Special notes for reviews


By the way , `dfdaemon` will use `dfget -v` to test whether `dfget` is as expected, you will get error with that, use `dfget version`  instead.