### PR TITLE
fix: unreachable supernode ip in p2p-network

### DIFF
--- a/docs/quick_start/README.md
+++ b/docs/quick_start/README.md
@@ -25,6 +25,8 @@ You have started your Docker container.
     ```bash
     # Replace ${imageName} with the real image name
     docker run -d -p 8001:8001 -p 8002:8002 ${imageName}
+    # if you run docker in macOS, please use this command:
+    docker run -d -p 8001:8001 -p 8002:8002 ${imageName} -Dsupernode.advertiseIp=127.0.0.1
     ```
 
 For example, if you're in China, run the following commands:

--- a/src/supernode/src/main/docker/Dockerfile
+++ b/src/supernode/src/main/docker/Dockerfile
@@ -23,5 +23,6 @@ ADD supernode.jar supernode.jar
 
 EXPOSE 8001 8002
 
-ENTRYPOINT ["/root/start.sh"]
+CMD ["-Dsupernode.advertiseIp="]
+ENTRYPOINT /root/start.sh $0 $@
 

--- a/src/supernode/src/main/docker/sources/start.sh
+++ b/src/supernode/src/main/docker/sources/start.sh
@@ -2,4 +2,4 @@
 
 nginx
 
-java -Djava.security.egd=file:/dev/./urandom -jar supernode.jar
+java -Djava.security.egd=file:/dev/./urandom "$@" -jar supernode.jar


### PR DESCRIPTION
Signed-off-by: lowzj <zj3142063@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Make it possible for users to set the supernode's ip that we advertiese to other peers in the p2p-network, the property is: `advertieseIp`

```bash
java -Dsupernode.advertieseIp=10.1.1.1 -jar supernode.jar
```

By default, the first non-loop address of the host is advertied.

### Ⅱ. Does this pull request fix one issue?
fixes: #252 
