### PR TITLE
fix: remove redundant log and output correct file length

### DIFF
--- a/cmd/dfget/app/root.go
+++ b/cmd/dfget/app/root.go
@@ -35,7 +35,6 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			os.Exit(err.Code)
 		}
-		util.Printer.Println(resultMsg(cfg.Ctx, time.Now(), err))
 		os.Exit(0)
 	},
 }

--- a/dfget/config/config.go
+++ b/dfget/config/config.go
@@ -263,6 +263,7 @@ func NewContext() *Context {
 		ctx.WorkHome = path.Join(currentUser.HomeDir, ".small-dragonfly")
 		ctx.RV.MetaPath = path.Join(ctx.WorkHome, "meta", "host.meta")
 		ctx.RV.SystemDataDir = path.Join(ctx.WorkHome, "data")
+		ctx.RV.FileLength = -1
 	} else {
 		panic(fmt.Errorf("get user error: %s", err))
 	}
@@ -274,7 +275,9 @@ func NewContext() *Context {
 func AssertContext(ctx *Context) {
 	util.PanicIfNil(ctx, "runtime context is not initialized")
 	util.PanicIfNil(ctx.ClientLogger, "client log is not initialized")
-	util.PanicIfNil(ctx.ServerLogger, "server log is not initialized")
+	if ctx.Pattern == "p2p" {
+		util.PanicIfNil(ctx.ServerLogger, "server log is not initialized")
+	}
 
 	defer func() {
 		if err := recover(); err != nil {

--- a/dfget/core/core.go
+++ b/dfget/core/core.go
@@ -159,6 +159,10 @@ func downloadFile(ctx *config.Context, supernodeAPI api.SupernodeAPI,
 	if err != nil {
 		ctx.ClientLogger.Error(err)
 		success = "FAIL"
+	} else if ctx.RV.FileLength < 0 && util.IsRegularFile(ctx.RV.RealTarget) {
+		if info, err := os.Stat(ctx.RV.RealTarget); err == nil {
+			ctx.RV.FileLength = info.Size()
+		}
 	}
 	os.Remove(ctx.RV.TempTarget)
 	ctx.ClientLogger.Infof("download %s cost:%.3fs length:%d reason:%d",

--- a/dfget/core/downloader/p2p_downloader.go
+++ b/dfget/core/downloader/p2p_downloader.go
@@ -319,7 +319,7 @@ func (p2p *P2PDownloader) finishTask(response *types.PullPieceTaskResponse, clie
 			p2p.Ctx.ClientLogger.Infof("client file path:%s not found", p2p.clientFilePath)
 			if e := util.Link(p2p.serviceFilePath, p2p.clientFilePath); e != nil {
 				p2p.Ctx.ClientLogger.Warnln("link failed, instead of use copy")
-				// TODO copy file
+				util.CopyFile(p2p.serviceFilePath, p2p.clientFilePath)
 			}
 		}
 		src = p2p.clientFilePath


### PR DESCRIPTION
Signed-off-by: lowzj <zj3142063@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
The `dfget` will output twice result message and the downloaded file's length is not correct.

```bash
--2018-12-26 19:51:37--  https://www.taobao.com
dfget version:0.3.0
workspace:/Users/zj/.small-dragonfly sign:51733-1545825097.015
client:127.0.0.1 connected to node:127.0.0.1
start download by dragonfly
download SUCCESS(0) cost:0.052s length:-1 reason:0
download SUCCESS(0) cost:0.052s length:-1 reason:0
```


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


