### PR TITLE
feature: implement dfget uploader server

### DIFF
--- a/cmd/dfget/app/root.go
+++ b/cmd/dfget/app/root.go
@@ -105,7 +105,7 @@ func initLog() {
 	if cfg.Ctx.Console {
 		util.AddConsoleLog(cfg.Ctx.ClientLogger)
 	}
-	if cfg.Ctx.Pattern == "p2p" {
+	if cfg.Ctx.Pattern == cfg.PatternP2P {
 		cfg.Ctx.ServerLogger = util.CreateLogger(logPath, "dfserver.log", logLevel, cfg.Ctx.Sign)
 	}
 }

--- a/dfget/core/downloader/p2p_downloader.go
+++ b/dfget/core/downloader/p2p_downloader.go
@@ -300,17 +300,18 @@ func (p2p *P2PDownloader) processPiece(response *types.PullPieceTaskResponse,
 }
 
 func (p2p *P2PDownloader) finishTask(response *types.PullPieceTaskResponse, clientWriter *ClientWriter) {
+	// wait client writer finished
 	p2p.Ctx.ClientLogger.Infof("remaining writed piece count:%d", p2p.clientQueue.Len())
 	p2p.clientQueue.Put(last)
 	waitStart := time.Now().Unix()
 	clientWriter.Wait()
-
 	p2p.Ctx.ClientLogger.Infof("wait client writer finish cost %d,main qu size:%d,client qu size:%d", time.Now().Unix()-waitStart, p2p.queue.Len(), p2p.clientQueue.Len())
 
 	if p2p.Ctx.BackSourceReason > 0 {
 		return
 	}
 
+	// get the temp path where the downloaded file exists.
 	var src string
 	if clientWriter.acrossWrite {
 		src = p2p.Ctx.RV.TempTarget
@@ -325,6 +326,7 @@ func (p2p *P2PDownloader) finishTask(response *types.PullPieceTaskResponse, clie
 		src = p2p.clientFilePath
 	}
 
+	// move file to the target file path.
 	if err := moveFile(src, p2p.targetFile, p2p.Ctx.Md5, p2p.Ctx.ClientLogger); err != nil {
 		return
 	}

--- a/dfget/core/uploader/uploader.go
+++ b/dfget/core/uploader/uploader.go
@@ -18,3 +18,188 @@
 // - peer - in P2P pattern that will wait for other P2PDownloader to download
 // its downloaded files.
 package uploader
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strconv"
+	"sync"
+
+	"github.com/dragonflyoss/Dragonfly/dfget/config"
+	"github.com/dragonflyoss/Dragonfly/dfget/util"
+	"github.com/dragonflyoss/Dragonfly/version"
+
+	"github.com/gorilla/mux"
+)
+
+const (
+	ctype = "application/octet-stream"
+)
+
+var (
+	syncTaskMap sync.Map
+)
+
+// peerServer offer file-block to other clients
+type peerServer struct {
+	ctx *config.Context
+
+	// server related fields
+	host   string
+	port   int
+	server *http.Server
+}
+
+// taskConfig refers to some info about peer task.
+type taskConfig struct {
+	taskID    string
+	cid       string
+	dataDir   string
+	superNode string
+	finished  bool
+}
+
+// uploadParam refers to all params needed in the handler of upload.
+type uploadParam struct {
+	pieceLen int64
+	start    int64
+	readLen  int64
+}
+
+// LaunchPeerServer launch a server to send piece data
+func LaunchPeerServer(ctx *config.Context) (int, error) {
+	taskFileName := ctx.RV.TaskFileName
+
+	// retrieve peer port from meta file: config.Ctx.RV.MetaPath
+	if sevicePort, err := getPort(ctx.RV.MetaPath); err == nil {
+		// check the peer port(config.Ctx.RV.PeerPort) whether is available
+		url := fmt.Sprintf("http://%s:%d%s%s", ctx.RV.LocalIP, sevicePort, config.LocalHTTPPathCheck, taskFileName)
+		result, err := checkPort(url, ctx.RV.TargetDir, util.DefaultTimeout)
+		if err == nil {
+			ctx.ServerLogger.Infof("local http result:%s for path:%s", result, config.LocalHTTPPathCheck)
+
+			// reuse exist service port
+			if result == taskFileName {
+				ctx.ServerLogger.Infof("reuse exist service with port:%d", sevicePort)
+				return sevicePort, nil
+			}
+			ctx.ServerLogger.Warnf("not found process on port:%d, version:%s", sevicePort, version.DFGetVersion)
+		}
+		ctx.ServerLogger.Warnf("request local http path:%s, error:%v", config.LocalHTTPPathCheck, err)
+	}
+	// TODO: start a goroutine to check alive and sever gc.
+
+	sevicePort := generatePort()
+	p2pServer, err := newPeerServer(ctx, sevicePort)
+	if err != nil {
+		return 0, err
+	}
+
+	// TODO: start a new server and roolback if any errors happened.
+
+	// persist the new peer port into meta file
+	// NOTE: we should truncates the meta file before service down.
+	err = ioutil.WriteFile(ctx.RV.MetaPath, []byte(strconv.Itoa(sevicePort)), 0666)
+	if err != nil {
+		return 0, err
+	}
+	ctx.ServerLogger.Infof("server on host: %s, port: %d", p2pServer.host, p2pServer.port)
+
+	return sevicePort, nil
+}
+
+// newPeerServer return a new P2PServer.
+func newPeerServer(ctx *config.Context, port int) (*peerServer, error) {
+	s := &peerServer{
+		host: ctx.RV.LocalIP,
+		port: port,
+	}
+
+	// init router
+	r := mux.NewRouter()
+	r.HandleFunc(config.PeerHTTPPathPrefix+"{taskFileName:.*}", s.uploadHandler).Methods("GET")
+	r.HandleFunc(config.LocalHTTPPathRate+"{taskFileName:.*}", s.parseRateHandler).Methods("GET")
+	r.HandleFunc(config.LocalHTTPPathCheck+"{taskFileName:.*}", s.checkHandler).Methods("GET")
+	r.HandleFunc(config.LocalHTTPPathClient+"finish", s.oneFinishHandler).Methods("GET")
+
+	s.server = &http.Server{
+		Addr:    net.JoinHostPort(s.host, strconv.Itoa(port)),
+		Handler: r,
+	}
+
+	return s, nil
+}
+
+// uploadHandler use to upload a task file when other peers download from it.
+func (ps *peerServer) uploadHandler(w http.ResponseWriter, r *http.Request) {
+	// Step1: parse param
+	taskFileName := mux.Vars(r)["taskFileName"]
+	rangeStr := r.Header.Get("range")
+	params, err := parseRange(rangeStr)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, err.Error())
+		ps.ctx.ServerLogger.Errorf("failed to parse param from request %v, %v", r, err)
+	}
+
+	// Step2: get task file
+	f, err := getTaskFile(taskFileName)
+	if f == nil {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, err.Error())
+		ps.ctx.ServerLogger.Errorf("failed to open TaskFile %s, %v", taskFileName, err)
+	}
+	defer f.Close()
+
+	// Step3: write header
+	w.Header().Set("Content-Length", strconv.FormatInt(params.pieceLen, 10))
+	sendSuccess(w)
+
+	// Step4: tans task file
+	if err := transFile(f, w, params.start, params.readLen); err != nil {
+		ps.ctx.ServerLogger.Errorf("send range:%s error: %v", rangeStr, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "read task file failed: %v", err)
+	}
+}
+
+// TODO: implement it.
+func (ps *peerServer) parseRateHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "not implemented yet")
+}
+
+// checkHandler use to check the server status.
+func (ps *peerServer) checkHandler(w http.ResponseWriter, r *http.Request) {
+	sendSuccess(w)
+
+	// get parameters
+	taskFileName := mux.Vars(r)["taskFileName"]
+	dataDir := r.Header.Get("dataDir")
+
+	param := &taskConfig{
+		dataDir:  dataDir,
+		finished: false,
+	}
+	syncTaskMap.LoadOrStore(taskFileName, param)
+	fmt.Fprintf(w, "%s@%s", taskFileName, version.DFGetVersion)
+}
+
+// oneFinishHandler use to update the status of peer task.
+func (ps *peerServer) oneFinishHandler(w http.ResponseWriter, r *http.Request) {
+	taskFileName := mux.Vars(r)["taskFileName"]
+	param := &taskConfig{
+		taskID:    mux.Vars(r)["taskId"],
+		cid:       mux.Vars(r)["cid"],
+		superNode: mux.Vars(r)["superNode"],
+		finished:  true,
+	}
+	syncTaskMap.LoadOrStore(taskFileName, param)
+	fmt.Fprintf(w, "success")
+}
+
+func sendSuccess(w http.ResponseWriter) {
+	w.Header().Set("Content-type", ctype)
+	w.WriteHeader(http.StatusOK)
+}

--- a/dfget/core/uploader/uploader_util.go
+++ b/dfget/core/uploader/uploader_util.go
@@ -1,0 +1,174 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uploader
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/dragonflyoss/Dragonfly/dfget/config"
+	"github.com/dragonflyoss/Dragonfly/dfget/core/helper"
+	"github.com/dragonflyoss/Dragonfly/dfget/util"
+	"github.com/dragonflyoss/Dragonfly/version"
+
+	"github.com/valyala/fasthttp"
+)
+
+// uploader helper
+
+// getTaskFile find the taskFile and return the File object.
+func getTaskFile(taskFileName string) (*os.File, error) {
+	v, ok := syncTaskMap.Load(taskFileName)
+	if !ok {
+		return nil, fmt.Errorf("failed to get taskPath: %s", taskFileName)
+	}
+	tc, ok := v.(*taskConfig)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert: %s", taskFileName)
+	}
+
+	taskPath := helper.GetServiceFile(taskFileName, tc.dataDir)
+	taskFile, err := os.Open(taskPath)
+	if err != nil {
+		return nil, fmt.Errorf("file:%s not found", taskPath)
+	}
+	return taskFile, nil
+}
+
+// parseRange validates the parameter range and parses it
+func parseRange(rangeStr string) (*uploadParam, error) {
+	if strings.Count(rangeStr, "-") != 1 {
+		return nil, fmt.Errorf("invaild range: %s", rangeStr)
+	}
+	rangeArr := strings.Split(rangeStr, "-")
+	start, err := strconv.ParseInt(rangeArr[0], 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	end, err := strconv.ParseInt(rangeArr[1], 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	if end <= start {
+		return nil, fmt.Errorf("The end of range: %d is less than or equal to the start: %d", end, start)
+	}
+	pieceLen := end - start + 1
+
+	return &uploadParam{
+		start:    start,
+		pieceLen: pieceLen,
+		readLen:  pieceLen,
+	}, nil
+}
+
+// transFile send the file to the remote.
+func transFile(f *os.File, w http.ResponseWriter, start, readLen int64) error {
+	var total int64
+	f.Seek(start, 0)
+
+	remain := readLen
+	bufSize := int64(256 * 1024)
+	buf := make([]byte, bufSize)
+
+	// TODO: limit the read rate.
+	for remain > 0 {
+		// read len(buf) of data
+		num, err := f.Read(buf)
+		if err != nil && err != io.EOF {
+			return err
+		}
+
+		if num == 0 {
+			if total == 0 {
+				return fmt.Errorf("content is empty")
+			}
+			return nil
+		}
+
+		if int64(num) > remain {
+			w.Write(buf[:remain])
+		} else {
+			w.Write(buf[:num])
+		}
+
+		total += int64(num)
+		remain = readLen - total
+
+		if num < len(buf) {
+			break
+		}
+	}
+	return nil
+}
+
+// LaunchPeerServer helper
+
+// checkPort check if the server is available。
+func checkPort(url, dataDir string, timeout int) (string, error) {
+	// construct request
+	req := fasthttp.AcquireRequest()
+	req.SetRequestURI(url)
+	req.Header.Add("dataDir", dataDir)
+	resp := fasthttp.AcquireResponse()
+	if timeout <= 0 {
+		timeout = util.DefaultTimeout
+	}
+
+	// send request
+	if err := fasthttp.DoTimeout(req, resp, time.Duration(timeout)*time.Millisecond); err != nil {
+		return "", err
+	}
+
+	// get resp result
+	statusCode := resp.StatusCode()
+	if statusCode != config.Success {
+		return "", fmt.Errorf("Unexpected status code: %d", statusCode)
+	}
+
+	bodyBytes := resp.Body()
+
+	// parse resp result
+	result := string(bodyBytes[:])
+	resultSuffix := "@" + version.DFGetVersion
+	if strings.HasSuffix(result, resultSuffix) {
+		return result[:len(result)-len(resultSuffix)], nil
+	}
+	return "", nil
+}
+
+// generatePort generate a port
+// TODO: ensure the port is available.
+func generatePort() int {
+	lowerLimit := config.ServerPortLowerLimit
+	upperLimit := config.ServerPortUpperLimit
+	return int(time.Now().Unix()/300)%(upperLimit-lowerLimit) + lowerLimit
+}
+
+// get port from meta file.
+func getPort(metaPath string) (int, error) {
+	portByte, err := ioutil.ReadFile(metaPath)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(string(portByte))
+}

--- a/dfget/core/uploader/uploader_util_test.go
+++ b/dfget/core/uploader/uploader_util_test.go
@@ -1,0 +1,230 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uploader
+
+import (
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"strconv"
+	"testing"
+
+	"github.com/dragonflyoss/Dragonfly/dfget/config"
+	"github.com/dragonflyoss/Dragonfly/version"
+
+	"github.com/go-check/check"
+	"github.com/gorilla/mux"
+)
+
+var (
+	taskFileName    = "testFile"
+	tempFileCOntent = "hello File"
+)
+
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
+
+type UploadUtilTestSuite struct {
+	dataDir     string
+	servicePath string
+	host        string
+	ln          net.Listener
+}
+
+func init() {
+	check.Suite(&UploadUtilTestSuite{})
+}
+
+func (s *UploadUtilTestSuite) SetUpSuite(c *check.C) {
+	s.dataDir, _ = ioutil.TempDir("/tmp", "dfget-UploadUtilTestSuite-")
+	tc := &taskConfig{dataDir: s.dataDir}
+	s.servicePath = path.Join(s.dataDir, taskFileName+".service")
+
+	createTestFile(s.servicePath)
+	syncTaskMap.Store(taskFileName, tc)
+
+	// run a server
+	s.host = fmt.Sprintf("127.0.0.1:%d", rand.Intn(1000)+63000)
+	s.ln, _ = net.Listen("tcp", s.host)
+	checkHandler := func(w http.ResponseWriter, r *http.Request) {
+		fileName := mux.Vars(r)["taskFileName"]
+		fmt.Fprintf(w, "%s@%s", fileName, version.DFGetVersion)
+	}
+	r := mux.NewRouter()
+	r.HandleFunc(config.LocalHTTPPathCheck+"{taskFileName:.*}", checkHandler).Methods("GET")
+	go http.Serve(s.ln, r)
+}
+
+func (s *UploadUtilTestSuite) TearDownSuite(c *check.C) {
+	s.ln.Close()
+
+	if s.dataDir != "" {
+		if err := os.RemoveAll(s.dataDir); err != nil {
+			fmt.Printf("remove path:%s error", s.dataDir)
+		}
+	}
+}
+
+// TestGetTaskFile
+func (s *UploadUtilTestSuite) TestGetTaskFile(c *check.C) {
+	f, err := getTaskFile(taskFileName)
+	defer f.Close()
+
+	// check get file correctly
+	c.Assert(err, check.IsNil)
+	c.Assert(f, check.NotNil)
+
+	// check read file correctly
+	result, err := ioutil.ReadAll(f)
+	c.Assert(err, check.IsNil)
+	c.Assert(string(result), check.Equals, tempFileCOntent)
+}
+
+func (s *UploadUtilTestSuite) TestTransFile(c *check.C) {
+	f, _ := getTaskFile(taskFileName)
+	defer f.Close()
+
+	// normal test when start offset equals zero
+	rr := httptest.NewRecorder()
+	err := transFile(f, rr, 0, 10)
+	c.Check(err, check.IsNil)
+	c.Check(rr.Body.String(), check.Equals, tempFileCOntent)
+
+	// normal test when start offset not equals zero
+	rr = httptest.NewRecorder()
+	err = transFile(f, rr, 1, 5)
+	c.Check(err, check.IsNil)
+	c.Check(rr.Body.String(), check.Equals, tempFileCOntent[1:6])
+
+	// readLen more than file data test
+	rr = httptest.NewRecorder()
+	err = transFile(f, rr, 0, 20)
+	c.Check(err, check.IsNil)
+	c.Check(rr.Body.String(), check.Equals, tempFileCOntent)
+
+	// readLen less than file data test
+	rr = httptest.NewRecorder()
+	err = transFile(f, rr, 0, 5)
+	c.Check(err, check.IsNil)
+	c.Check(rr.Body.String(), check.Equals, tempFileCOntent[:5])
+
+}
+
+func (s *UploadUtilTestSuite) TestCheckPort(c *check.C) {
+	// normal test
+	url := fmt.Sprintf("http://%s%s%s", s.host, config.LocalHTTPPathCheck, taskFileName)
+	result, err := checkPort(url, s.dataDir, 10)
+	c.Check(err, check.IsNil)
+	c.Check(result, check.Equals, taskFileName)
+
+	// timeout equals zero test
+	url = fmt.Sprintf("http://%s%s%s", s.host, config.LocalHTTPPathCheck, taskFileName)
+	result, err = checkPort(url, s.dataDir, 0)
+	c.Check(err, check.IsNil)
+	c.Check(result, check.Equals, taskFileName)
+
+	// error url test
+	url = fmt.Sprintf("http://%s%s%s", s.host+"error", config.LocalHTTPPathCheck, taskFileName)
+	result, err = checkPort(url, s.dataDir, 0)
+	c.Check(err, check.NotNil)
+	c.Check(result, check.Equals, "")
+}
+
+func (s *UploadUtilTestSuite) TestParseRange(c *check.C) {
+	type args struct {
+		rangeStr string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *uploadParam
+		wantErr bool
+	}{
+		{
+			name: "normalTest",
+			args: args{
+				rangeStr: "0-65575",
+			},
+			want: &uploadParam{
+				start:    0,
+				pieceLen: 65576,
+				readLen:  65576,
+			},
+			wantErr: false,
+		},
+		{
+			name: "MultDashesTest",
+			args: args{
+				rangeStr: "0-65-575",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "NotIntTest",
+			args: args{
+				rangeStr: "0-hello",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "EndLessStartTest",
+			args: args{
+				rangeStr: "65575-0",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		got, err := parseRange(tt.args.rangeStr)
+		if tt.wantErr {
+			c.Check(err, check.NotNil)
+		} else {
+			c.Check(err, check.IsNil)
+		}
+		c.Check(got, check.DeepEquals, tt.want)
+	}
+}
+
+func (s *UploadUtilTestSuite) TestGetPort(c *check.C) {
+	metaPath := path.Join(s.dataDir, "meta")
+	servicePort := 8080
+	ioutil.WriteFile(metaPath, []byte(strconv.Itoa(servicePort)), 0666)
+	port, err := getPort(metaPath)
+	c.Check(err, check.IsNil)
+	c.Check(port, check.Equals, servicePort)
+}
+
+// createTestFile create a temp file and write a string.
+func createTestFile(path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	f.WriteString(tempFileCOntent)
+	return nil
+}

--- a/dfget/util/http_util.go
+++ b/dfget/util/http_util.go
@@ -37,6 +37,9 @@ const (
 	// RequestTag is the tag name for parsing structure to query parameters.
 	// see function ParseQuery.
 	RequestTag = "request"
+
+	// DefaultTimeout is the default timeout to check connect.
+	DefaultTimeout = 500
 )
 
 // DefaultHTTPClient is the default implementation of SimpleHTTPClient.
@@ -147,7 +150,7 @@ func ParseQuery(query interface{}) string {
 // returns localIP
 func CheckConnect(ip string, port int, timeout int) (localIP string, e error) {
 	if timeout <= 0 {
-		timeout = 500
+		timeout = DefaultTimeout
 	}
 
 	var conn net.Conn


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
implement the basic handler of uploader, at present, the http server of uploader exposes  four apis currently as follows:
1. /peer/file/{taskFileName},  trans the piece content  that dfget wants to get;
2. /rate/{taskFileName}, update the read rate limit; 
3. /check/{taskFileName}, check the server status to decide whether to restart a new server;
4. /client/finish, when a dfget downloaded a piece from uploader server, update the status of finished.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

added.

### Ⅳ. Describe how to verify it
not now.

### Ⅴ. Special notes for reviews

We still have something to do as follows:
1. limit read rate
2. check alive and sever gc
3. start the server with a new process
