### PR TITLE
Merge pull request #288 from pouchrobot/auto-doc-2018-12-31

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -530,9 +530,9 @@ definitions:
         description: |
           filter is used to filter request queries in URL.
           For example, when a user wants to start to download a task which has a remote URL of 
-          http://a.b.com/fileA?user=xxx&auth=yyy, user can add a filter parameter ["user", "auth"]
-          to filter the url to http://a.b.com/fileA. Then this parameter can potentially avoid repeatable
-          downloads, if there is already a task http://a.b.com/fileA.
+          "http://a.b.com/fileA?user=xxx&auth=yyy", user can add a filter parameter ["user", "auth"]
+          to filter the url to "http://a.b.com/fileA". Then this parameter can potentially avoid repeatable
+          downloads, if there is already a task "http://a.b.com/fileA".
         items:
           type: "string"
 

--- a/apis/types/task_create_request.go
+++ b/apis/types/task_create_request.go
@@ -38,9 +38,9 @@ type TaskCreateRequest struct {
 
 	// filter is used to filter request queries in URL.
 	// For example, when a user wants to start to download a task which has a remote URL of
-	// http://a.b.com/fileA?user=xxx&auth=yyy, user can add a filter parameter ["user", "auth"]
-	// to filter the url to http://a.b.com/fileA. Then this parameter can potentially avoid repeatable
-	// downloads, if there is already a task http://a.b.com/fileA.
+	// "http://a.b.com/fileA?user=xxx&auth=yyy", user can add a filter parameter ["user", "auth"]
+	// to filter the url to "http://a.b.com/fileA". Then this parameter can potentially avoid repeatable
+	// downloads, if there is already a task "http://a.b.com/fileA".
 	//
 	Filter []string `json:"filter"`
 

--- a/docs/apis.md
+++ b/docs/apis.md
@@ -96,6 +96,33 @@ dfget sends request to register in Supernode as a peer node
 |**500**|An unexpected server error occurred.|[Error](#error)|
 
 
+<a name="peers-get"></a>
+### get all peers
+```
+GET /peers
+```
+
+
+#### Description
+dfget sends request to register in Supernode as a peer node
+
+
+#### Parameters
+
+|Type|Name|Description|Schema|
+|---|---|---|---|
+|**Body**|**body**  <br>*optional*|request body which contains peer registrar information.|[PeerCreateRequest](#peercreaterequest)|
+
+
+#### Responses
+
+|HTTP Code|Description|Schema|
+|---|---|---|
+|**201**|no error|[PeerCreateResponse](#peercreateresponse)|
+|**400**|bad parameter|[Error](#error)|
+|**500**|An unexpected server error occurred.|[Error](#error)|
+
+
 <a name="peers-id-get"></a>
 ### get a peer in supernode
 ```
@@ -137,8 +164,8 @@ DELETE /peers/{id}
 
 #### Description
 dfget stops playing a role as a peer in peer network constructed by supernode.
-when dfget lasts in five minutes without downloading or uploading task, dfget
-automatically sends a DELETE /peers/{id} request.
+when dfget lasts in five minutes without downloading or uploading task, uploader of dfget
+automatically sends a DELETE /peers/{id} request to supernode.
 
 
 #### Parameters
@@ -155,80 +182,6 @@ automatically sends a DELETE /peers/{id} request.
 |**204**|no error|No Content|
 |**404**|no such peer|[4ErrorResponse](#4errorresponse)|
 |**500**|An unexpected server error occurred.|[Error](#error)|
-
-
-<a name="pieces-id-get"></a>
-### Get a piece
-```
-GET /pieces/{id}
-```
-
-
-#### Description
-Get detailed information of a piece in supernode.
-
-
-#### Parameters
-
-|Type|Name|Description|Schema|
-|---|---|---|---|
-|**Path**|**id**  <br>*required*|ID of piece|string|
-
-
-#### Responses
-
-|HTTP Code|Description|Schema|
-|---|---|---|
-|**200**|no error|< [PieceInfo](#pieceinfo) > array|
-|**404**|no such task|[4ErrorResponse](#4errorresponse)|
-|**500**|An unexpected server error occurred.|[Error](#error)|
-
-
-#### Produces
-
-* `application/json`
-
-
-<a name="pieces-id-put"></a>
-### Update a piece
-```
-PUT /pieces/{id}
-```
-
-
-#### Description
-Update some information of piece. When peer A finishes to download
-piece B, A must send request to supernode to update piece B's info
-to mark that peer A has the complete piece B. Then when other peers 
-request to download this piece B, supernode could schedule peer A
-to those peers.
-
-
-#### Parameters
-
-|Type|Name|Description|Schema|
-|---|---|---|---|
-|**Path**|**id**  <br>*required*|ID of piece|string|
-|**Body**|**PieceUpdateRequest**  <br>*optional*|request body which contains task update information|[PieceUpdateRequest](#pieceupdaterequest)|
-
-
-#### Responses
-
-|HTTP Code|Description|Schema|
-|---|---|---|
-|**200**|no error|No Content|
-|**404**|An unexpected 404 error occurred.|[Error](#error)|
-|**500**|An unexpected server error occurred.|[Error](#error)|
-
-
-#### Consumes
-
-* `application/json`
-
-
-#### Produces
-
-* `application/json`
 
 
 <a name="preheats-post"></a>
@@ -382,8 +335,10 @@ PUT /tasks/{id}
 
 
 #### Description
-update information of a task. When a peer finishes to download all pieces of a task,
-it must update peer downloading status of this task in supernode.
+Update information of a task.
+This endpoint is mainly for operation usage. When the peer network or peer
+meet some load issues, operation team can update a task directly, such as pause
+a downloading task to ease the situation.
 
 
 #### Parameters
@@ -413,6 +368,36 @@ it must update peer downloading status of this task in supernode.
 * `application/json`
 
 
+<a name="tasks-id-delete"></a>
+### delete a task
+```
+DELETE /tasks/{id}
+```
+
+
+#### Description
+delete a peer-to-peer task in supernode.
+This endpoint is mainly for operation usage. When the peer network or peer
+meet some load issues, operation team can delete a task directly to ease
+the situation.
+
+
+#### Parameters
+
+|Type|Name|Description|Schema|
+|---|---|---|---|
+|**Path**|**id**  <br>*required*|ID of task|string|
+
+
+#### Responses
+
+|HTTP Code|Description|Schema|
+|---|---|---|
+|**204**|no error|No Content|
+|**404**|no such task|[4ErrorResponse](#4errorresponse)|
+|**500**|An unexpected server error occurred.|[Error](#error)|
+
+
 <a name="tasks-id-pieces-get"></a>
 ### Get pieces in task
 ```
@@ -431,6 +416,7 @@ the pirces. The request piece number is set in query.
 |Type|Name|Description|Schema|
 |---|---|---|---|
 |**Path**|**id**  <br>*required*|ID of task|string|
+|**Query**|**cid**  <br>*required*|When dfget needs to get pieces of specific task, it must mark which peer it plays role of.|string|
 |**Query**|**num**  <br>*optional*|Request number of pieces of task. If request number is larger than the total pieces in supernode,<br>supernode returns the total pieces of task. If not set, supernode will set 4 by default.|integer (int64)|
 
 
@@ -441,6 +427,49 @@ the pirces. The request piece number is set in query.
 |**200**|no error|< [PieceInfo](#pieceinfo) > array|
 |**404**|no such task|[4ErrorResponse](#4errorresponse)|
 |**500**|An unexpected server error occurred.|[Error](#error)|
+
+
+#### Produces
+
+* `application/json`
+
+
+<a name="tasks-id-pieces-piecerange-put"></a>
+### Update a piece
+```
+PUT /tasks/{id}/pieces/{pieceRange}
+```
+
+
+#### Description
+Update some information of piece. When peer A finishes to download
+piece B, A must send request to supernode to update piece B's info
+to mark that peer A has the complete piece B. Then when other peers 
+request to download this piece B, supernode could schedule peer A
+to those peers.
+
+
+#### Parameters
+
+|Type|Name|Description|Schema|
+|---|---|---|---|
+|**Path**|**id**  <br>*required*|ID of task|string|
+|**Path**|**pieceRange**  <br>*required*|the range of specific piece in the task, example "0-45565".|string|
+|**Body**|**PieceUpdateRequest**  <br>*optional*|request body which contains task update information.|[PieceUpdateRequest](#pieceupdaterequest)|
+
+
+#### Responses
+
+|HTTP Code|Description|Schema|
+|---|---|---|
+|**200**|no error|No Content|
+|**404**|An unexpected 404 error occurred.|[Error](#error)|
+|**500**|An unexpected server error occurred.|[Error](#error)|
+
+
+#### Consumes
+
+* `application/json`
 
 
 #### Produces
@@ -481,7 +510,6 @@ it will send PeerCreateRequest to supernode.
 
 |Name|Description|Schema|
 |---|---|---|
-|**ID**  <br>*optional*|Peer ID of dfget client. Every peer has a unique ID among peer network.|string|
 |**IP**  <br>*optional*|IP address which peer client carries|string (ipv4)|
 |**hostName**  <br>*optional*|host name of peer client node, as a valid RFC 1123 hostname.  <br>**Minimum length** : `1`|string (hostname)|
 |**port**  <br>*optional*|when registering, dfget will setup one uploader process. <br>This one acts as a server for peer pulling tasks.<br>This port is which this server listens on.  <br>**Minimum value** : `15000`  <br>**Maximum value** : `65000`|integer (int32)|
@@ -495,7 +523,7 @@ ID of created peer.
 
 |Name|Description|Schema|
 |---|---|---|
-|**ID**  <br>*optional*|ID of created peer.|string|
+|**ID**  <br>*optional*|Peer ID of the node which dfget locates on. <br>Every peer has a unique ID among peer network.<br>It is generated via host's hostname and IP address.|string|
 
 
 <a name="peerinfo"></a>
@@ -506,7 +534,7 @@ The detailed information of a peer in supernode.
 |Name|Description|Schema|
 |---|---|---|
 |**ID**  <br>*optional*|ID of peer|string|
-|**IP**  <br>*optional*|IP address which peer client carries|string (ipv4)|
+|**IP**  <br>*optional*|IP address which peer client carries.<br>(TODO) make IP field contain more information, for example<br>WAN/LAN IP address for supernode to recoganize.|string (ipv4)|
 |**hostName**  <br>*optional*|host name of peer client node, as a valid RFC 1123 hostname.  <br>**Minimum length** : `1`|string (hostname)|
 |**port**  <br>*optional*|when registering, dfget will setup one uploader process. <br>This one acts as a server for peer pulling tasks.<br>This port is which this server listens on.  <br>**Minimum value** : `15000`  <br>**Maximum value** : `65000`|integer (int32)|
 |**version**  <br>*optional*|version number of dfget binary|string|
@@ -519,17 +547,26 @@ Peer's detailed information in supernode.
 
 |Name|Description|Schema|
 |---|---|---|
-|**ID**  <br>*optional*|ID of the peer|string|
+|**cID**  <br>*optional*|ID of the downloading task from dfget|string|
+|**path**  <br>*optional*|The URL path to download the specific piece from the target peer's uploader.|string|
+|**peerIP**  <br>*optional*|When dfget needs to download a piece from another peer. Supernode will return a PieceInfo<br>that contains a peerIP. This peerIP represents the IP of this dfget's target peer.|string|
+|**peerPort**  <br>*optional*|When dfget needs to download a piece from another peer. Supernode will return a PieceInfo<br>that contains a peerPort. This peerPort represents the port of this dfget's target peer's uploader.|integer|
+|**pieceMD5**  <br>*optional*|the MD5 information of piece which is generated by supernode when doing CDN cache.<br>This value will be returned to dfget in order to validate the piece's completeness.|string|
+|**pieceRange**  <br>*optional*|the range of specific piece in the task, example "0-45565".|string|
+|**pieceSize**  <br>*optional*|The size of pieces which is calculated as per the following strategy<br>1. If file's total size is less than 200MB, then the piece size is 4MB by default.<br>2. Otherwise, it equals to the smaller value between totalSize/100MB + 2 MB and 15MB.|integer (int32)|
 
 
 <a name="pieceupdaterequest"></a>
 ### PieceUpdateRequest
-request peer uses to update its status of downloading piece in supernode.
+request used to update piece attributes.
 
 
 |Name|Description|Schema|
 |---|---|---|
-|**PeerID**  <br>*optional*|contains the peer ID.|string|
+|**dstCid**  <br>*optional*|the uploader cid|string|
+|**result**  <br>*optional*|result It indicates whether the peer task successfully download the piece. <br>It's only useful when `status` is `RUNNING`.|enum (FAILED, SUCCESS, INVALID, SEMISUC)|
+|**srcCid**  <br>*optional*|the downloader cid|string|
+|**status**  <br>*optional*|status indicates whether the peer task is running.|enum (STARTED, RUNNING, FINISHED)|
 
 
 <a name="preheatcreaterequest"></a>
@@ -575,14 +612,15 @@ task because that an image may have more than one layer.
 
 |Name|Description|Schema|
 |---|---|---|
+|**cID**  <br>*optional*|CID means the client ID. It maps to the specific dfget process. <br>When user wishes to download an image/file, user would start a dfget process to do this. <br>This dfget is treated a client and carries a client ID. <br>Thus, multiple dfget processes on the same peer have different CIDs.|string|
 |**callSystem**  <br>*optional*|This field is for debugging. When caller of dfget is using it to files, he can pass callSystem<br>name to dfget. When this field is passing to supernode, supernode has ability to filter them via <br>some black/white list to guarantee security, or some other purposes.  <br>**Minimum length** : `1`|string|
 |**dfdaemon**  <br>*optional*|tells whether it is a call from dfdaemon. dfdaemon is a long running<br>process which works for container engines. It translates the image<br>pulling request into raw requests into those dfget recganises.|boolean|
+|**filter**  <br>*optional*|filter is used to filter request queries in URL.<br>For example, when a user wants to start to download a task which has a remote URL of <br>http://a.b.com/fileA?user=xxx&auth=yyy, user can add a filter parameter ["user", "auth"]<br>to filter the url to http://a.b.com/fileA. Then this parameter can potentially avoid repeatable<br>downloads, if there is already a task http://a.b.com/fileA.|< string > array|
 |**headers**  <br>*optional*|extra HTTP headers sent to the rawURL.<br>This field is carried with the request to supernode. <br>Supernode will extract these HTTP headers, and set them in HTTP downloading requests<br>from source server as user's wish.|< string, string > map|
 |**identifier**  <br>*optional*|special attribute of remote source file. This field is used with taskURL to generate new taskID to<br>indetify different downloading task of remote source file. For example, if user A and user B uses<br>the same taskURL and taskID to download file, A and B will share the same peer network to distribute files.<br>If user A additionally adds an indentifier with taskURL, while user B still carries only taskURL, then A's<br>generated taskID is different from B, and the result is that two users use different peer networks.|string|
 |**md5**  <br>*optional*|md5 checksum for the resource to distribute. dfget catches this parameter from dfget's CLI<br>and passes it to supernode. When supernode finishes downloading file/image from the source location,<br>it will validate the source file with this md5 value to check whether this is a valid file.|string|
 |**path**  <br>*optional*|path is used in one peer A for uploading functionality. When peer B hopes<br>to get piece C from peer A, B must provide a URL for piece C.<br>Then when creating a task in supernode, peer A must provide this URL in request.|string|
 |**rawURL**  <br>*optional*|The is the resource's URL which user uses dfget to download. The location of URL can be anywhere, LAN or WAN.<br>For image distribution, this is image layer's URL in image registry.<br>The resource url is provided by command line parameter.|string|
-|**taskURL**  <br>*optional*|taskURL is generated from rawURL. rawURL may contains some queries or parameter, dfget will filter some queries via<br>--filter parameter of dfget. The usage of it is that different rawURL may generate the same taskID.|string|
 
 
 <a name="taskcreateresponse"></a>
@@ -592,9 +630,9 @@ response get from task creation request.
 
 |Name|Description|Schema|
 |---|---|---|
-|**FileLength**  <br>*optional*|The length of the file dfget requests to download in bytes.|integer (int64)|
 |**ID**  <br>*optional*|ID of the created task.|string|
-|**PieceSize**  <br>*optional*|The size of pieces which is calculated as per the following strategy<br>1. If file's total size is less than 200MB, then the piece size is 4MB by default.<br>2. Otherwise, it equals to the smaller value between totalSize/100MB + 2 MB and 15MB.|integer (int32)|
+|**fileLength**  <br>*optional*|The length of the file dfget requests to download in bytes.|integer (int64)|
+|**pieceSize**  <br>*optional*|The size of pieces which is calculated as per the following strategy<br>1. If file's total size is less than 200MB, then the piece size is 4MB by default.<br>2. Otherwise, it equals to the smaller value between totalSize/100MB + 2 MB and 15MB.|integer (int32)|
 
 
 <a name="taskinfo"></a>
@@ -604,17 +642,17 @@ detailed information about task in supernode.
 
 |Name|Description|Schema|
 |---|---|---|
-|**CdnStatus**  <br>*optional*|The status of the created task related to CDN functionality.|enum (WAITING, RUNNING, FAILED, SUCCESS, SOURCE_ERROR)|
-|**FileLength**  <br>*optional*|The length of the file dfget requests to download in bytes.|integer (int64)|
 |**ID**  <br>*optional*|ID of the task.|string|
-|**PieceSize**  <br>*optional*|The size of pieces which is calculated as per the following strategy<br>1. If file's total size is less than 200MB, then the piece size is 4MB by default.<br>2. Otherwise, it equals to the smaller value between totalSize/100MB + 2 MB and 15MB.|integer (int32)|
-|**PieceTotal**  <br>*optional*||integer (int32)|
 |**callSystem**  <br>*optional*|This field is for debugging. When caller of dfget is using it to files, he can pass callSystem<br>name to dfget. When this field is passing to supernode, supernode has ability to filter them via <br>some black/white list to guarantee security, or some other purposes.  <br>**Minimum length** : `1`|string|
+|**cdnStatus**  <br>*optional*|The status of the created task related to CDN functionality.|enum (WAITING, RUNNING, FAILED, SUCCESS, SOURCE_ERROR)|
 |**dfdaemon**  <br>*optional*|tells whether it is a call from dfdaemon. dfdaemon is a long running<br>process which works for container engines. It translates the image<br>pulling request into raw requests into those dfget recganises.|boolean|
+|**fileLength**  <br>*optional*|The length of the file dfget requests to download in bytes.|integer (int64)|
 |**headers**  <br>*optional*|extra HTTP headers sent to the rawURL.<br>This field is carried with the request to supernode. <br>Supernode will extract these HTTP headers, and set them in HTTP downloading requests<br>from source server as user's wish.|< string, string > map|
 |**identifier**  <br>*optional*|special attribute of remote source file. This field is used with taskURL to generate new taskID to<br>indetify different downloading task of remote source file. For example, if user A and user B uses<br>the same taskURL and taskID to download file, A and B will share the same peer network to distribute files.<br>If user A additionally adds an indentifier with taskURL, while user B still carries only taskURL, then A's<br>generated taskID is different from B, and the result is that two users use different peer networks.|string|
 |**md5**  <br>*optional*|md5 checksum for the resource to distribute. dfget catches this parameter from dfget's CLI<br>and passes it to supernode. When supernode finishes downloading file/image from the source location,<br>it will validate the source file with this md5 value to check whether this is a valid file.|string|
 |**path**  <br>*optional*|path is used in one peer A for uploading functionality. When peer B hopes<br>to get piece C from peer A, B must provide a URL for piece C.<br>Then when creating a task in supernode, peer A must provide this URL in request.|string|
+|**pieceSize**  <br>*optional*|The size of pieces which is calculated as per the following strategy<br>1. If file's total size is less than 200MB, then the piece size is 4MB by default.<br>2. Otherwise, it equals to the smaller value between totalSize/100MB + 2 MB and 15MB.|integer (int32)|
+|**pieceTotal**  <br>*optional*||integer (int32)|
 |**rawURL**  <br>*optional*|The is the resource's URL which user uses dfget to download. The location of URL can be anywhere, LAN or WAN.<br>For image distribution, this is image layer's URL in image registry.<br>The resource url is provided by command line parameter.|string|
 |**taskURL**  <br>*optional*|taskURL is generated from rawURL. rawURL may contains some queries or parameter, dfget will filter some queries via<br>--filter parameter of dfget. The usage of it is that different rawURL may generate the same taskID.|string|
 
@@ -626,7 +664,7 @@ request used to update task attributes.
 
 |Name|Description|Schema|
 |---|---|---|
-|**PeerID**  <br>*optional*|ID of the peer which has finished to download the whole task.|string|
+|**peerID**  <br>*optional*|ID of the peer which has finished to download the whole task.|string|
 
 
 


### PR DESCRIPTION
docs: auto generate Dragonfly cli/api docs via code
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

We found that when we added some invalid links in swagger.yml, the generated markdown documents will contain the invalid link, then the [markdown-link-check](https://github.com/tcort/markdown-link-check) tool will not pass the CI to show the failure:

```
FILE: ./docs/apis.md
[✖] http://a.b.com/fileA?user=xxx&amp;auth=yyy
[✖] http://a.b.com/fileA

ERROR: dead links found!
```

This pr tries to fix the invalid link checking to use a link trimming the prefix of `http(s)://`.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
no need.


### Ⅳ. Describe how to verify it
none

### Ⅴ. Special notes for reviews
none 

