### PR TITLE
ci: add gocyclo support in circle CI test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
       - run:
           name: use gometalinter to check gocode of this project.
           command: |
-            gometalinter --disable-all --skip vendor -E gofmt -E goimports -E golint -E misspell -E vet -E goconst ./...
+            gometalinter --disable-all --cyclo-over=20 --skip vendor -E gofmt -E goimports -E golint -E misspell -E vet -E goconst -E gocyclo ./...
       - run:
           name: detect deadcode without test folder
           command: |


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Project Dragonfly pays lots of attention on the cyclomatic complexities of functions in Go source code. Reasonable cyclomatic complexities could be able to make the code much more readable. We must support this at the very beginning of the golang refactoring. Then it could be a fundamental feature of Dragonfly.

Here we take advantages of [gocyclo](https://github.com/alecthomas/gocyclo) in [gometalinter](https://github.com/alecthomas/gometalinter). Please see the code update about the circle CI config file.

Currently we set the gocyclo limit is 20. Any functions which have more than 20 cyclos will trigger the CI failure.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
none


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
no need.


### Ⅳ. Describe how to verify it
none

### Ⅴ. Special notes for reviews
none

