### PR TITLE
feature: add the build option of the client in the local environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ target
 .cache/
 .go/
 release/
+bin/
 
 #df-daemon
 

--- a/Makefile
+++ b/Makefile
@@ -104,4 +104,11 @@ uninstall:
 build-client: check-client build-dfget build-dfdaemon
 .PHONY: build-client
 
+# Create for the tool of generate docs of the client.
+build-client-local: build-dirs
+	./hack/build-client-local.sh
+.PHONY: build-client-local
+
+# Use the technology of the container to build binary files, so that developers
+# don't need to worry about the inconsistency between the CI and the local environment.
 build: check-client build-dfget build-dfdaemon check-supernode build-supernode

--- a/hack/build-client-local.sh
+++ b/hack/build-client-local.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+DFDAEMON_BINARY_NAME=dfdaemon
+DFGET_BINARY_NAME=dfget
+
+curDir=$(cd "$(dirname "$0")" && pwd)
+cd "${curDir}" || return
+BUILD_SOURCE_HOME=$(cd ".." && pwd)
+BIN_DIR="${BUILD_SOURCE_HOME}/bin"
+
+. ./env.sh
+
+build-dfdaemon-local() {	
+    echo "BUILD: dfdaemon in ${BIN_DIR}/${DFDAEMON_BINARY_NAME}" 
+    test -f "${BIN_DIR}/${DFDAEMON_BINARY_NAME}" && rm -f "${BIN_DIR}/${DFDAEMON_BINARY_NAME}"	
+    cd "${BUILD_SOURCE_HOME}/cmd/dfdaemon" || return	
+    go build -o "${BIN_DIR}/${DFDAEMON_BINARY_NAME}"	
+    chmod a+x "${BIN_DIR}/${DFDAEMON_BINARY_NAME}"
+}
+
+build-dfget-local() {	
+    echo "BUILD: dfget in ${BIN_DIR}/${DFGET_BINARY_NAME}"	
+    test -f "${BIN_DIR}/${DFGET_BINARY_NAME}" && rm -f "${BIN_DIR}/${DFGET_BINARY_NAME}"	
+    cd "${BUILD_SOURCE_HOME}/cmd/dfget"	|| return
+    go build -o "${BIN_DIR}/${DFGET_BINARY_NAME}"	
+    chmod a+x "${BIN_DIR}/${DFGET_BINARY_NAME}"	
+}
+
+main() {
+    case "$1" in
+        build-dfdaemon-local)
+            build-dfdaemon-local
+        ;;
+        build-dfget-local)
+            build-dfget-local
+        ;;
+        *)
+            build-dfget-local
+            build-dfdaemon-local
+        ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
Signed-off-by: fengzixu <hnustphoenix@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


1. add the script to build the client in the local env other than docker
2. add the build option in the Makefile

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixed https://github.com/dragonflyoss/Dragonfly/issues/313

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

Just makefile and a script of building the client

### Ⅳ. Describe how to verify it

Run two commands:

1. cd hack && ./build-client-local.sh
2. make build-client-local

### Ⅴ. Special notes for reviews


