### PR TITLE
fix: don't write service file if downloading pattern isn't p2p

### DIFF
--- a/dfget/core/core.go
+++ b/dfget/core/core.go
@@ -140,6 +140,7 @@ func registerToSuperNode(cfg *config.Config, register regist.SupernodeRegister) 
 	if cfg.Pattern == config.PatternP2P {
 		if e := launchPeerServer(cfg); e != nil {
 			cfg.ClientLogger.Warnf("start peer server error:%v, change to CDN pattern", e)
+			cfg.Pattern = config.PatternCDN
 		}
 	}
 

--- a/dfget/core/downloader/p2p_downloader.go
+++ b/dfget/core/downloader/p2p_downloader.go
@@ -323,7 +323,7 @@ func (p2p *P2PDownloader) finishTask(response *types.PullPieceTaskResponse, clie
 
 	// get the temp path where the downloaded file exists.
 	var src string
-	if clientWriter.acrossWrite {
+	if clientWriter.acrossWrite || !helper.IsP2P(p2p.Cfg.Pattern) {
 		src = p2p.Cfg.RV.TempTarget
 	} else {
 		if _, err := os.Stat(p2p.clientFilePath); err != nil {

--- a/dfget/core/helper/helper_test.go
+++ b/dfget/core/helper/helper_test.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package helper
+
+import (
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/dragonflyoss/Dragonfly/dfget/config"
+	"github.com/go-check/check"
+)
+
+// ----------------------------------------------------------------------------
+// initialize
+
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
+
+type HelperTestSuite struct {
+}
+
+func init() {
+	check.Suite(&HelperTestSuite{})
+}
+
+// ----------------------------------------------------------------------------
+// Tests
+
+func (s *HelperTestSuite) TestDownloadPattern(c *check.C) {
+	var cases = []struct {
+		f        func(string) bool
+		pattern  string
+		expected bool
+	}{
+		{IsP2P, config.PatternP2P, true},
+		{IsP2P, strings.ToUpper(config.PatternP2P), true},
+		{IsP2P, config.PatternCDN, false},
+		{IsP2P, config.PatternSource, false},
+
+		{IsCDN, config.PatternCDN, true},
+		{IsCDN, strings.ToUpper(config.PatternCDN), true},
+		{IsCDN, config.PatternP2P, false},
+		{IsCDN, config.PatternSource, false},
+
+		{IsSource, config.PatternSource, true},
+		{IsSource, strings.ToUpper(config.PatternSource), true},
+		{IsSource, config.PatternCDN, false},
+		{IsSource, config.PatternP2P, false},
+	}
+
+	var name = func(f interface{}) string {
+		return runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name()
+	}
+
+	for _, v := range cases {
+		c.Assert(v.f(v.pattern), check.Equals, v.expected,
+			check.Commentf("f:%v pattern:%s", name(v.f), v.pattern))
+	}
+}

--- a/dfget/core/helper/util_helper.go
+++ b/dfget/core/helper/util_helper.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package helper
+
+import (
+	"strings"
+
+	"github.com/dragonflyoss/Dragonfly/dfget/config"
+)
+
+// IsP2P returns whether the pattern is PatternP2P.
+func IsP2P(pattern string) bool {
+	return strings.ToLower(pattern) == config.PatternP2P
+}
+
+// IsCDN returns whether the pattern is PatternCDN.
+func IsCDN(pattern string) bool {
+	return strings.ToLower(pattern) == config.PatternCDN
+}
+
+// IsSource returns whether the pattern is PatternSource.
+func IsSource(pattern string) bool {
+	return strings.ToLower(pattern) == config.PatternSource
+}


### PR DESCRIPTION
Signed-off-by: lowzj <zj3142063@gmail.com>

### Ⅰ. Describe what this PR did

When downloading pattern is not `p2p`, `dfget` should not write service file for uploading, because they're useless.

This pull request makes `dfget` only write downloading data to target directory. It will reduce write disk times.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


