### PR TITLE
fix: cannot use dragonfly to download an empty file

### DIFF
--- a/dfget/core/downloader/power_client.go
+++ b/dfget/core/downloader/power_client.go
@@ -73,7 +73,7 @@ func (pc *PowerClient) Run() (err error) {
 		}
 		defer resp.Body.Close()
 
-		buf := make([]byte, 256*1024)
+		buf := make([]byte, 0, 256*1024)
 		pieceCont := bytes.NewBuffer(buf)
 		reader := NewLimitReader(resp.Body, pc.cfg.LocalLimit, pieceMD5 != "")
 		total, err := pieceCont.ReadFrom(reader)

--- a/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/service/cdn/Downloader.java
+++ b/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/service/cdn/Downloader.java
@@ -137,6 +137,10 @@ public class Downloader implements Callable<Boolean> {
                         beforeTime = System.currentTimeMillis();
                         rateLimiter.acquire(bufSize, true);
                     }
+                    if (realFileLength == 0) {
+                        bb.flip();
+                        qu.put(ProtocolContent.buildPieceContent(bb, 0));
+                    }
 
                     String realMd5 = Hex.encodeHexString(fileM5.digest());
                     boolean isSuccess = true;

--- a/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/service/cdn/SuperWriter.java
+++ b/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/service/cdn/SuperWriter.java
@@ -84,9 +84,10 @@ public class SuperWriter implements Runnable {
 
                 int threadSize = CdnConstants.WRITER_THREAD_LIMIT;
                 Integer pieceSize = task.getPieceSize();
-                if (httpFileLen != null && httpFileLen > 0) {
+                if (httpFileLen != null && httpFileLen >= 0) {
                     int tmpSize = (int)((httpFileLen + pieceSize - 1) / pieceSize);
                     threadSize = tmpSize >= threadSize ? threadSize : tmpSize;
+                    threadSize = threadSize > 0 ? threadSize : 1;
                 }
                 downLatch = new CountDownLatch(threadSize);
                 AtomicInteger sucCount = new AtomicInteger(0);


### PR DESCRIPTION
Signed-off-by: lowzj <zj3142063@gmail.com>


### Ⅰ. Describe what this PR did
Dragonfly cannot download an empty file because that supernode don't write and cache data if the file length less and equals zero.

fix `0.2.x`: #351 

### Ⅱ. Does this pull request fix one issue?

fixes: #44 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it
Prepare an empty file, start supernode, and use dfget to download it, here is the repaired logs:

**supernode**
```
2019-01-24 17:41:07.959  INFO 28083 --- [http-nio-8080-exec-1] c.d.d.s.repository.TaskRepository        : get file length:0 from http client about taskId:5b1c283943dc1c8da0865907038b0401ce7f5f50b4a7bb2b8f8b7bcf7dda5d00
2019-01-24 17:41:07.961  INFO 28083 --- [http-nio-8080-exec-1] c.d.d.s.service.impl.CdnManagerImpl      : do trigger cdn start for taskId:5b1c283943dc1c8da0865907038b0401ce7f5f50b4a7bb2b8f8b7bcf7dda5d00,httpLen:0
2019-01-24 17:41:07.970  INFO 28083 --- [Thread-14] c.d.d.s.c.util.NetConfigNotification     : current rate limiter count is 1
2019-01-24 17:41:07.971  INFO 28083 --- [Thread-14] c.d.d.s.service.impl.CdnManagerImpl      : do trigger cdn success for taskId:5b1c283943dc1c8da0865907038b0401ce7f5f50b4a7bb2b8f8b7bcf7dda5d00
2019-01-24 17:41:07.984  INFO 28083 --- [pool-1-thread-1] c.d.d.supernode.service.cdn.Downloader   : taskId:5b1c283943dc1c8da0865907038b0401ce7f5f50b4a7bb2b8f8b7bcf7dda5d00 fileUrl:http://127.0.0.1:8001/a.test on downloader
2019-01-24 17:41:07.999  INFO 28083 --- [pool-6-thread-1] c.d.d.s.c.util.NetConfigNotification     : current rate limiter count is 2
2019-01-24 17:41:08.001  INFO 28083 --- [Thread-15] c.d.d.s.service.impl.CdnReporterImpl     : taskId:5b1c283943dc1c8da0865907038b0401ce7f5f50b4a7bb2b8f8b7bcf7dda5d00 fileLength:5 status:SUCCESS from:local
2019-01-24 17:41:08.001  INFO 28083 --- [Thread-15] c.d.d.supernode.service.cdn.SuperWriter  : taskId:5b1c283943dc1c8da0865907038b0401ce7f5f50b4a7bb2b8f8b7bcf7dda5d00 readCost:0,totalCost:17,fileLength:0,realMd5:d41d8cd98f00b204e9800998ecf8427e
```

**dfclient.log**
```
2019-01-24 17:41:08.004 INFO sign:28090-1548322867.751 : do register result:{"code":200,"data":{"taskId":"5b1c283943dc1c8da0865907038b0401ce7f5f50b4a7bb2b8f8b7bcf7dda5d00","fileLength":0,"pieceSize":4194304}} and cost:0.248s
2019-01-24 17:41:08.005 INFO sign:28090-1548322867.751 : P2P download:{"taskID":"5b1c283943dc1c8da0865907038b0401ce7f5f50b4a7bb2b8f8b7bcf7dda5d00","superNode":"127.0.0.1","dstCid":"","range":"","result":502,"status":700,"pieceSize":0,"pieceNum":0}
2019-01-24 17:41:08.028 INFO sign:28090-1548322867.751 : get pieceCont total: 5
2019-01-24 17:41:08.028 INFO sign:28090-1548322867.751 : P2P download:{"taskID":"5b1c283943dc1c8da0865907038b0401ce7f5f50b4a7bb2b8f8b7bcf7dda5d00","superNode":"127.0.0.1","dstCid":"cdnnode:127.0.0.1~5b1c283943dc1c8da0865907038b0401ce7f5f50b4a7bb2b8f8b7bcf7dda5d00","range":"0-4194303","result":503,"status":701,"pieceSize":4194304,"pieceNum":0}
2019-01-24 17:41:08.040 INFO sign:28090-1548322867.751 : Remaining writed piece count:0
2019-01-24 17:41:08.040 INFO sign:28090-1548322867.751 : Wait client writer finish cost 0,main qu size:0,client qu size:0
2019-01-24 17:41:08.041 INFO sign:28090-1548322867.751 : move src:/Users/zj/.small-dragonfly/data/a.test-28090-1548322867.751 to dst:/tmp/test/a.test result:true cost:0.001
2019-01-24 17:41:08.041 INFO sign:28090-1548322867.751 : Download successfully from dragonfly
2019-01-24 17:41:08.042 INFO sign:28090-1548322867.751 : download SUCCESS cost:0.291s length:0 reason:0
```

### Ⅴ. Special notes for reviews


