### PR TITLE
feature: implement the rate limit feature

### DIFF
--- a/dfget/core/downloader/back_downloader.go
+++ b/dfget/core/downloader/back_downloader.go
@@ -76,7 +76,7 @@ func (bd *BackDownloader) Run() error {
 	defer resp.Body.Close()
 
 	buf := make([]byte, 512*1024)
-	reader := NewLimitReader(resp.Body, bd.Cfg.LocalLimit, bd.Md5 != "")
+	reader := util.NewLimitReader(resp.Body, bd.Cfg.LocalLimit, bd.Md5 != "")
 	if bd.Total, err = io.CopyBuffer(f, reader, buf); err != nil {
 		return err
 	}

--- a/dfget/core/helper/test_helper.go
+++ b/dfget/core/helper/test_helper.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math/rand"
+	"os"
 	"path"
 
 	"github.com/dragonflyoss/Dragonfly/dfget/config"
@@ -39,7 +41,33 @@ func CreateConfig(writer io.Writer, workHome string) *config.Config {
 
 	logrus.StandardLogger().Out = writer
 	cfg.ClientLogger = logrus.StandardLogger()
+	cfg.ServerLogger = logrus.StandardLogger()
 	return cfg
+}
+
+// CreateTestFile create a temp file and write a string.
+func CreateTestFile(path string, content string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if content != "" {
+		f.WriteString(content)
+	}
+	return nil
+}
+
+// CreateRandomString create a random string of specified length.
+func CreateRandomString(cap int) string {
+	var letterBytes = "abcdefghijklmnopqrstuvwxyz"
+	var length = len(letterBytes)
+
+	b := make([]byte, cap)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(length)]
+	}
+	return string(b)
 }
 
 // ----------------------------------------------------------------------------

--- a/dfget/core/uploader/uploader.go
+++ b/dfget/core/uploader/uploader.go
@@ -48,10 +48,9 @@ const (
 
 var (
 	p2p *peerServer
-
-	syncTaskMap sync.Map
-	aliveQueue  = util.NewQueue(0)
 )
+
+var aliveQueue = util.NewQueue(0)
 
 // TODO: Move this part out of the uploader
 
@@ -122,7 +121,7 @@ func checkPeerServerExist(cfg *config.Config, port int) int {
 	}
 
 	// check the peer server whether is available
-	result, err := checkServer(cfg.RV.LocalIP, port, cfg.RV.TargetDir, taskFileName, 0)
+	result, err := checkServer(cfg.RV.LocalIP, port, cfg.RV.TargetDir, taskFileName, cfg.TotalLimit, 0)
 	cfg.ClientLogger.Infof("local http result:%s err:%v, port:%d path:%s",
 		result, err, port, config.LocalHTTPPathCheck)
 
@@ -258,7 +257,7 @@ func serverGC(cfg *config.Config, interval time.Duration) {
 func deleteExpiredFile(api api.SupernodeAPI, path string, info os.FileInfo,
 	expireTime time.Duration) bool {
 	taskName := helper.GetTaskName(info.Name())
-	if v, ok := syncTaskMap.Load(taskName); ok {
+	if v, ok := p2p.syncTaskMap.Load(taskName); ok {
 		task, ok := v.(*taskConfig)
 		if ok && !task.finished {
 			return false
@@ -268,7 +267,7 @@ func deleteExpiredFile(api api.SupernodeAPI, path string, info os.FileInfo,
 				api.ServiceDown(task.superNode, task.taskID, task.cid)
 			}
 			os.Remove(path)
-			syncTaskMap.Delete(taskName)
+			p2p.syncTaskMap.Delete(taskName)
 			return true
 		}
 	} else {
@@ -331,20 +330,24 @@ func newPeerServer(cfg *config.Config, port int) *peerServer {
 		port:     port,
 	}
 
-	// init router
-	r := mux.NewRouter()
-	r.HandleFunc(config.PeerHTTPPathPrefix+"{taskFileName:.*}", s.uploadHandler).Methods("GET")
-	r.HandleFunc(config.LocalHTTPPathRate+"{taskFileName:.*}", s.parseRateHandler).Methods("GET")
-	r.HandleFunc(config.LocalHTTPPathCheck+"{taskFileName:.*}", s.checkHandler).Methods("GET")
-	r.HandleFunc(config.LocalHTTPPathClient+"finish", s.oneFinishHandler).Methods("GET")
-	r.HandleFunc(config.LocalHTTPPing, s.pingHandler).Methods("GET")
-
+	r := s.initRouter()
 	s.Server = &http.Server{
 		Addr:    net.JoinHostPort(s.host, strconv.Itoa(port)),
 		Handler: r,
 	}
 
 	return s
+}
+
+func (ps *peerServer) initRouter() *mux.Router {
+	r := mux.NewRouter()
+	r.HandleFunc(config.PeerHTTPPathPrefix+"{taskFileName:.*}", ps.uploadHandler).Methods("GET")
+	r.HandleFunc(config.LocalHTTPPathRate+"{taskFileName:.*}", ps.parseRateHandler).Methods("GET")
+	r.HandleFunc(config.LocalHTTPPathCheck+"{taskFileName:.*}", ps.checkHandler).Methods("GET")
+	r.HandleFunc(config.LocalHTTPPathClient+"finish", ps.oneFinishHandler).Methods("GET")
+	r.HandleFunc(config.LocalHTTPPing, ps.pingHandler).Methods("GET")
+
+	return r
 }
 
 // peerServer offer file-block to other clients
@@ -356,11 +359,16 @@ type peerServer struct {
 	host string
 	port int
 	*http.Server
+
+	rateLimiter    *util.RateLimiter
+	totalLimitRate int
+	syncTaskMap    sync.Map
 }
 
 // taskConfig refers to some info about peer task.
 type taskConfig struct {
 	taskID    string
+	rateLimit int
 	cid       string
 	dataDir   string
 	superNode string
@@ -371,7 +379,6 @@ type taskConfig struct {
 type uploadParam struct {
 	pieceLen int64
 	start    int64
-	readLen  int64
 }
 
 // uploadHandler use to upload a task file when other peers download from it.
@@ -379,20 +386,22 @@ func (ps *peerServer) uploadHandler(w http.ResponseWriter, r *http.Request) {
 	aliveQueue.Put(true)
 	// Step1: parse param
 	taskFileName := mux.Vars(r)["taskFileName"]
-	rangeStr := r.Header.Get("range")
+	rangeStr := r.Header.Get("Range")
 	params, err := parseRange(rangeStr)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(w, err.Error())
 		ps.cfg.ServerLogger.Errorf("failed to parse param from request %v, %v", r, err)
+		return
 	}
 
 	// Step2: get task file
-	f, err := getTaskFile(taskFileName)
-	if f == nil {
-		w.WriteHeader(http.StatusNotFound)
+	f, err := ps.getTaskFile(taskFileName, params)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprint(w, err.Error())
 		ps.cfg.ServerLogger.Errorf("failed to open TaskFile %s, %v", taskFileName, err)
+		return
 	}
 	defer f.Close()
 
@@ -401,17 +410,57 @@ func (ps *peerServer) uploadHandler(w http.ResponseWriter, r *http.Request) {
 	sendSuccess(w)
 
 	// Step4: tans task file
-	if err := transFile(f, w, params.start, params.readLen); err != nil {
+	if err := ps.transFile(f, w, params.start, params.pieceLen); err != nil {
 		ps.cfg.ServerLogger.Errorf("send range:%s error: %v", rangeStr, err)
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintf(w, "read task file failed: %v", err)
 	}
 }
 
-// TODO: implement it.
 func (ps *peerServer) parseRateHandler(w http.ResponseWriter, r *http.Request) {
 	aliveQueue.Put(true)
-	fmt.Fprintf(w, "not implemented yet")
+
+	// get params from request
+	taskFileName := mux.Vars(r)["taskFileName"]
+	rateLimit := r.Header.Get("rateLimit")
+	clientRate, err := strconv.Atoi(rateLimit)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, err.Error())
+		ps.cfg.ServerLogger.Errorf("failed to convert rateLimit %v, %v", rateLimit, err)
+		return
+	}
+	sendSuccess(w)
+
+	// update the ratelimit of taskFileName
+	if v, ok := ps.syncTaskMap.Load(taskFileName); ok {
+		param := v.(*taskConfig)
+		param.rateLimit = clientRate
+	}
+
+	// no need to calculate rate when totalLimitRate less than or equals zero.
+	if ps.totalLimitRate <= 0 {
+		fmt.Fprintf(w, rateLimit)
+		return
+	}
+
+	total := 0
+
+	// define a function that Range will call it sequentially
+	// for each key and value present in the map
+	f := func(key, value interface{}) bool {
+		if task, ok := value.(*taskConfig); ok {
+			total += task.rateLimit
+		}
+
+		return true
+	}
+	ps.syncTaskMap.Range(f)
+
+	// calculate the rate limit again according to totalLimit
+	if total > ps.totalLimitRate {
+		clientRate = (clientRate*ps.totalLimitRate + total - 1) / total
+	}
+
+	fmt.Fprintf(w, strconv.Itoa(clientRate))
 }
 
 // checkHandler use to check the server status.
@@ -419,15 +468,26 @@ func (ps *peerServer) checkHandler(w http.ResponseWriter, r *http.Request) {
 	aliveQueue.Put(true)
 	sendSuccess(w)
 
+	// handle totalLimit
+	totalLimit, err := strconv.Atoi(r.Header.Get("totalLimit"))
+	if err == nil && totalLimit > 0 {
+		if ps.rateLimiter == nil {
+			ps.rateLimiter = util.NewRateLimiter(int32(totalLimit), 2)
+		} else {
+			ps.rateLimiter.SetRate(util.TransRate(totalLimit))
+		}
+		ps.totalLimitRate = totalLimit
+		ps.cfg.ServerLogger.Infof("update total limit to %d", totalLimit)
+	}
+
 	// get parameters
 	taskFileName := mux.Vars(r)["taskFileName"]
 	dataDir := r.Header.Get("dataDir")
 
 	param := &taskConfig{
-		dataDir:  dataDir,
-		finished: false,
+		dataDir: dataDir,
 	}
-	syncTaskMap.LoadOrStore(taskFileName, param)
+	ps.syncTaskMap.Store(taskFileName, param)
 	fmt.Fprintf(w, "%s@%s", taskFileName, version.DFGetVersion)
 }
 
@@ -443,7 +503,7 @@ func (ps *peerServer) oneFinishHandler(w http.ResponseWriter, r *http.Request) {
 	taskID := r.FormValue("taskId")
 	cid := r.FormValue("cid")
 	superNode := r.FormValue("superNode")
-	if v, ok := syncTaskMap.Load(taskFileName); ok {
+	if v, ok := ps.syncTaskMap.Load(taskFileName); ok {
 		task := v.(*taskConfig)
 		task.taskID = taskID
 		task.cid = cid

--- a/dfget/core/uploader/uploader_test.go
+++ b/dfget/core/uploader/uploader_test.go
@@ -15,3 +15,188 @@
  */
 
 package uploader
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+
+	"github.com/dragonflyoss/Dragonfly/dfget/config"
+	"github.com/dragonflyoss/Dragonfly/dfget/core/helper"
+	"github.com/dragonflyoss/Dragonfly/dfget/util"
+
+	"github.com/go-check/check"
+)
+
+var (
+	taskFile         = "taskfile"
+	emptyFile        = "emptyfile"
+	fileContent      = helper.CreateRandomString(2000)
+	defaultRateLimit = 1000
+)
+
+type HandlerHelper struct {
+	method  string
+	url     string
+	body    io.Reader
+	headers map[string]string
+}
+
+type UploaderTestSuite struct {
+	workHome string
+}
+
+func init() {
+	check.Suite(&UploaderTestSuite{})
+}
+
+func (u *UploaderTestSuite) SetUpSuite(c *check.C) {
+	u.workHome, _ = ioutil.TempDir("/tmp", "dfget-UploadTestSuite-")
+	newTestPeerServer(u.workHome)
+
+	initHelper(taskFile, u.workHome, fileContent)
+	initHelper(emptyFile, u.workHome, "")
+}
+
+func (u *UploaderTestSuite) TearDownSuite(c *check.C) {
+	if u.workHome != "" {
+		if err := os.RemoveAll(u.workHome); err != nil {
+			fmt.Printf("remove path:%s error", u.workHome)
+		}
+	}
+	p2p = nil
+}
+
+func (u *UploaderTestSuite) TestUploadHandler(c *check.C) {
+	headers := make(map[string]string)
+
+	// normal test
+	headers["range"] = "bytes=0-1999"
+	if rr, err := u.testHandlerHelper(&HandlerHelper{
+		method:  http.MethodGet,
+		url:     config.PeerHTTPPathPrefix + taskFile,
+		headers: headers,
+	}); err == nil {
+		c.Check(rr.Code, check.Equals, http.StatusOK)
+		c.Check(rr.Body.String(), check.Equals, fileContent)
+
+		// TODO: limit read check
+	}
+
+	// insufficient file length test
+	headers["range"] = "bytes=0-1"
+	if rr, err := u.testHandlerHelper(&HandlerHelper{
+		method:  http.MethodGet,
+		url:     config.PeerHTTPPathPrefix + emptyFile,
+		headers: headers,
+	}); err == nil {
+		c.Check(rr.Code, check.Equals, http.StatusInternalServerError)
+	}
+
+	// not found test
+	if rr, err := u.testHandlerHelper(&HandlerHelper{
+		method:  http.MethodGet,
+		url:     config.PeerHTTPPathPrefix + "foo",
+		body:    nil,
+		headers: headers,
+	}); err == nil {
+		c.Check(rr.Code, check.Equals, http.StatusInternalServerError)
+	}
+
+	// bad request test
+	headers["range"] = "bytes=0-x"
+	if rr, err := u.testHandlerHelper(&HandlerHelper{
+		method:  http.MethodGet,
+		url:     config.PeerHTTPPathPrefix + taskFile,
+		headers: headers,
+	}); err == nil {
+		c.Check(rr.Code, check.Equals, http.StatusBadRequest)
+	}
+}
+
+func (u *UploaderTestSuite) TestParseRateHandler(c *check.C) {
+	headers := make(map[string]string)
+
+	// normal test
+	testRateLimit := 1000
+	total := testRateLimit + defaultRateLimit
+	headers["rateLimit"] = strconv.Itoa(testRateLimit)
+	if rr, err := u.testHandlerHelper(&HandlerHelper{
+		method:  http.MethodGet,
+		url:     config.LocalHTTPPathRate + taskFile,
+		headers: headers,
+	}); err == nil {
+		c.Check(rr.Code, check.Equals, http.StatusOK)
+		limit := (testRateLimit*p2p.totalLimitRate + total - 1) / total
+		c.Check(rr.Body.String(), check.Equals, strconv.Itoa(limit))
+	}
+
+	// totalLimitRate zero test
+	p2p.totalLimitRate = 0
+	if rr, err := u.testHandlerHelper(&HandlerHelper{
+		method:  http.MethodGet,
+		url:     config.LocalHTTPPathRate + taskFile,
+		headers: headers,
+	}); err == nil {
+		c.Check(rr.Code, check.Equals, http.StatusOK)
+		c.Check(rr.Body.String(), check.Equals, strconv.Itoa(testRateLimit))
+	}
+	p2p.totalLimitRate = 1000
+
+	// wrong rateLimit test
+	headers["rateLimit"] = "foo"
+	if rr, err := u.testHandlerHelper(&HandlerHelper{
+		method:  http.MethodGet,
+		url:     config.LocalHTTPPathRate + taskFile,
+		headers: headers,
+	}); err == nil {
+		c.Check(rr.Code, check.Equals, http.StatusBadRequest)
+	}
+}
+
+func (u *UploaderTestSuite) testHandlerHelper(hh *HandlerHelper) (*httptest.ResponseRecorder, error) {
+	// Create a request to pass to our handler. We don't have any query parameters for now, so we'll
+	// pass 'nil' as the third parameter.
+	req, err := http.NewRequest(hh.method, hh.url, hh.body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set request headers.
+	for k, v := range hh.headers {
+		req.Header.Set(k, v)
+	}
+
+	// We create a ResponseRecorder
+	// (which satisfies http.ResponseWriter) to record the response.
+	rr := httptest.NewRecorder()
+
+	// Init a router.
+	r := p2p.initRouter()
+	r.ServeHTTP(rr, req)
+
+	return rr, nil
+}
+
+// newTestPeerServer init the peer server for testing.
+func newTestPeerServer(workHome string) {
+	buf := &bytes.Buffer{}
+	cfg := helper.CreateConfig(buf, workHome)
+	p2p = newPeerServer(cfg, 0)
+	p2p.totalLimitRate = 1000
+	p2p.rateLimiter = util.NewRateLimiter(int32(defaultRateLimit), 2)
+}
+
+// initHelper create a temporary file and store it in the syncTaskMap.
+func initHelper(fileName, workHome, content string) {
+	helper.CreateTestFile(helper.GetServiceFile(fileName, workHome), content)
+	p2p.syncTaskMap.Store(fileName, &taskConfig{
+		dataDir:   workHome,
+		rateLimit: defaultRateLimit,
+	})
+}

--- a/dfget/errors/errors.go
+++ b/dfget/errors/errors.go
@@ -32,12 +32,16 @@ var (
 
 	// ErrConvertFailed represents failed to convert.
 	ErrConvertFailed = &DFGetError{codeConvertFailed, "convert failed"}
+
+	// ErrInsufficientFileLength represents the length of file is insufficient.
+	ErrInsufficientFileLength = &DFGetError{codeInsufficientFileLength, "insufficient length"}
 )
 
 const (
 	codeInvalidValue = iota
 	codeNotInitialized
 	codeConvertFailed
+	codeInsufficientFileLength
 )
 
 // New function creates a DFGetError.
@@ -88,6 +92,12 @@ func IsNotInitialized(err error) bool {
 // IsConvertFailed check the error is a conversion error or not.
 func IsConvertFailed(err error) bool {
 	return checkError(err, codeConvertFailed)
+}
+
+// IsInsufficientFileLength check the error is a
+// insufficient file length error or not.
+func IsInsufficientFileLength(err error) bool {
+	return checkError(err, codeInsufficientFileLength)
 }
 
 func checkError(err error, code int) bool {

--- a/dfget/types/pull_piece_task_response.go
+++ b/dfget/types/pull_piece_task_response.go
@@ -78,7 +78,7 @@ type PullPieceTaskResponseFinishData struct {
 type PullPieceTaskResponseContinueData struct {
 	Range     string `json:"range"`
 	PieceNum  int    `json:"pieceNum"`
-	PieceSize int    `json:"pieceSize"`
+	PieceSize int32  `json:"pieceSize"`
 	PieceMd5  string `json:"pieceMd5"`
 	Cid       string `json:"cid"`
 	PeerIP    string `json:"peerIp"`

--- a/dfget/util/rate_limiter.go
+++ b/dfget/util/rate_limiter.go
@@ -137,3 +137,13 @@ func (rl *RateLimiter) blocking(requiredToken int32) {
 	windowCount := int64(Max(requiredToken/rl.ratePerWindow, 1))
 	time.Sleep(time.Duration(windowCount * rl.window * time.Millisecond.Nanoseconds()))
 }
+
+// TransRate trans the rate to multiples of 1000
+// For NewRateLimiter, the production of rate should be division by 1000.
+func TransRate(rate int) int32 {
+	if rate <= 0 {
+		rate = 10 * 1024 * 1024
+	}
+	rate = (rate/1000 + 1) * 1000
+	return int32(rate)
+}


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

It's  an important feature to limit the download/upload speed for Dragonfly. More info about the advanced features about Dragonfly, please refer to [features](https://github.com/dragonflyoss/Dragonfly#features).

As you can see, dfget limits the speed with two parameters:
+ locallimit: rate limit about a single download task
+ totallimit: rate limit about the whole host
 
You can get more info about that [here](https://github.com/dragonflyoss/Dragonfly/blob/master/docs/cli_reference/dfget.md#options).

As for a download task, dfget will calculate the rate limit dynamically before download a piece from other peers **through the native uploader server**. Proceed as follows:
1. get locallimit
2. send a request to the **native uploader server** with: 
  + url: http://IP:Port/rate/{taskFileName}
  + header："rateLimit"=locallimit

As for a uploader server, the uploader will provide an API for parse rate limit. The behaviors of this handler are as follows:
1. Return the ratelimit obtained from the header when **totalLimit** less than or equals zero.
2. Calculate a new value based on all the download tasks and totalLimit based on the formula as follows:
  + Formula: `newRateLimit=(ratelimit*totalLimit+total-1)/total`

Where the `total` represents the sum of the rate limits of all download tasks of the native host.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

Added.

### Ⅳ. Describe how to verify it

Pass all unit tests with CI.

### Ⅴ. Special notes for reviews


