### PR TITLE
style: make log's output more clear and readable

### DIFF
--- a/dfget/core/downloader/p2p_downloader.go
+++ b/dfget/core/downloader/p2p_downloader.go
@@ -64,7 +64,8 @@ type P2PDownloader struct {
 	pieceSet map[string]bool
 	total    int64
 
-	rateLimiter *util.RateLimiter
+	rateLimiter  *util.RateLimiter
+	pullRateTime time.Time
 }
 
 func (p2p *P2PDownloader) init() {
@@ -87,6 +88,7 @@ func (p2p *P2PDownloader) init() {
 	p2p.pieceSet = make(map[string]bool)
 
 	p2p.rateLimiter = util.NewRateLimiter(int32(p2p.Cfg.LocalLimit), 2)
+	p2p.pullRateTime = time.Now().Add(-3 * time.Second)
 }
 
 // Run starts to download the file.
@@ -110,7 +112,7 @@ func (p2p *P2PDownloader) Run() error {
 		if !goNext {
 			continue
 		}
-		p2p.Cfg.ClientLogger.Infof("P2P download:%v", lastItem)
+		p2p.Cfg.ClientLogger.Infof("downloading piece:%v", lastItem)
 
 		curItem := *lastItem
 		curItem.Content = &bytes.Buffer{}
@@ -125,13 +127,13 @@ func (p2p *P2PDownloader) Run() error {
 				p2p.finishTask(response, clientWriter)
 				return nil
 			} else {
-				p2p.Cfg.ClientLogger.Warnf("Request piece result:%v", response)
+				p2p.Cfg.ClientLogger.Warnf("request piece result:%v", response)
 				if code == config.TaskCodeSourceError {
 					p2p.Cfg.BackSourceReason = config.BackSourceReasonSourceError
 				}
 			}
 		} else {
-			p2p.Cfg.ClientLogger.Errorf("P2P download fail: %v", err)
+			p2p.Cfg.ClientLogger.Errorf("download piece fail: %v", err)
 			if p2p.Cfg.BackSourceReason == 0 {
 				p2p.Cfg.BackSourceReason = config.BackSourceReasonDownloadError
 			}
@@ -175,10 +177,10 @@ func (p2p *P2PDownloader) pullPieceTask(item *Piece) (
 
 	for {
 		if res, err = p2p.API.PullPieceTask(item.SuperNode, req); err != nil {
-			p2p.Cfg.ClientLogger.Errorf("Pull piece task error: %v", err)
+			p2p.Cfg.ClientLogger.Errorf("pull piece task error: %v", err)
 		} else if res.Code == config.TaskCodeWait {
 			sleepTime := time.Duration(rand.Intn(1400)+600) * time.Millisecond
-			p2p.Cfg.ClientLogger.Infof("Pull piece task result:%s and sleep %.3fs",
+			p2p.Cfg.ClientLogger.Infof("pull piece task result:%s and sleep %.3fs",
 				res, sleepTime.Seconds())
 			time.Sleep(sleepTime)
 			continue
@@ -190,7 +192,7 @@ func (p2p *P2PDownloader) pullPieceTask(item *Piece) (
 		res.Code != config.TaskCodeFinish &&
 		res.Code != config.TaskCodeLimited &&
 		res.Code != config.Success) {
-		p2p.Cfg.ClientLogger.Errorf("Pull piece task fail:%v and will migrate", res)
+		p2p.Cfg.ClientLogger.Errorf("pull piece task fail:%v and will migrate", res)
 
 		var registerRes *regist.RegisterResult
 		if registerRes, err = p2p.Register.Register(p2p.Cfg.RV.PeerPort); err != nil {
@@ -209,8 +211,12 @@ func (p2p *P2PDownloader) pullPieceTask(item *Piece) (
 
 // getPullRate get download rate limit dynamically.
 func (p2p *P2PDownloader) getPullRate(data *types.PullPieceTaskResponseContinueData) {
-	var localRate int
+	if time.Since(p2p.pullRateTime).Seconds() < 3 {
+		return
+	}
+	p2p.pullRateTime = time.Now()
 
+	var localRate int
 	if p2p.Cfg.LocalLimit > 0 {
 		localRate = p2p.Cfg.LocalLimit
 	} else {
@@ -220,7 +226,6 @@ func (p2p *P2PDownloader) getPullRate(data *types.PullPieceTaskResponseContinueD
 	// Calculate the download speed limit
 	// that the current download task can be assigned
 	// by the uploader server.
-	// TODO: Reduce the frequency of requests.
 	url := fmt.Sprintf("http://%s:%d%s%s", p2p.Cfg.RV.LocalIP, p2p.Cfg.RV.PeerPort, config.LocalHTTPPathRate, p2p.taskFileName)
 	headers := make(map[string]string)
 	headers["rateLimit"] = strconv.Itoa(localRate)
@@ -270,7 +275,7 @@ func (p2p *P2PDownloader) getItem(latestItem *Piece) (bool, *Piece) {
 		if item.Range != "" {
 			v, ok := p2p.pieceSet[item.Range]
 			if !ok {
-				p2p.Cfg.ClientLogger.Warnf("PieceRange:%s is neither running nor success", item.Range)
+				p2p.Cfg.ClientLogger.Warnf("pieceRange:%s is neither running nor success", item.Range)
 				return false, latestItem
 			}
 			if !v && (item.Result == config.ResultSemiSuc ||
@@ -283,7 +288,7 @@ func (p2p *P2PDownloader) getItem(latestItem *Piece) (bool, *Piece) {
 		}
 		latestItem = item
 	} else {
-		p2p.Cfg.ClientLogger.Warnf("Get item timeout(2s) from queue.")
+		p2p.Cfg.ClientLogger.Warnf("get item timeout(2s) from queue.")
 		needMerge = false
 	}
 	if util.IsNil(latestItem) {
@@ -309,17 +314,18 @@ func (p2p *P2PDownloader) getItem(latestItem *Piece) (bool, *Piece) {
 func (p2p *P2PDownloader) processPiece(response *types.PullPieceTaskResponse,
 	item *Piece) {
 	var (
-		hasTask  = false
-		sucCount = 0
+		hasTask         = false
+		alreadyDownload []string
 	)
 	p2p.refresh(item)
 
 	data := response.ContinueData()
+	p2p.Cfg.ClientLogger.Debugf("pieces to be processed:%v", data)
 	for _, pieceTask := range data {
 		pieceRange := pieceTask.Range
 		v, ok := p2p.pieceSet[pieceRange]
 		if ok && v {
-			sucCount++
+			alreadyDownload = append(alreadyDownload, pieceRange)
 			p2p.queue.Put(NewPiece(p2p.taskID,
 				p2p.node,
 				pieceTask.Cid,
@@ -336,20 +342,21 @@ func (p2p *P2PDownloader) processPiece(response *types.PullPieceTaskResponse,
 		}
 	}
 	if !hasTask {
-		p2p.Cfg.ClientLogger.Warnf("Has not available pieceTask,maybe resource lack")
+		p2p.Cfg.ClientLogger.Warnf("has not available pieceTask, maybe resource lack")
 	}
-	if sucCount > 0 {
-		p2p.Cfg.ClientLogger.Warnf("Already suc item count:%d after a request super", sucCount)
+	if len(alreadyDownload) > 0 {
+		p2p.Cfg.ClientLogger.Warnf("already downloaded pieces:%v", alreadyDownload)
 	}
 }
 
 func (p2p *P2PDownloader) finishTask(response *types.PullPieceTaskResponse, clientWriter *ClientWriter) {
 	// wait client writer finished
-	p2p.Cfg.ClientLogger.Infof("Remaining writed piece count:%d", p2p.clientQueue.Len())
+	p2p.Cfg.ClientLogger.Infof("remaining piece to be written count:%d", p2p.clientQueue.Len())
 	p2p.clientQueue.Put(last)
-	waitStart := time.Now().Unix()
+	waitStart := time.Now()
 	clientWriter.Wait()
-	p2p.Cfg.ClientLogger.Infof("Wait client writer finish cost %d,main qu size:%d,client qu size:%d", time.Now().Unix()-waitStart, p2p.queue.Len(), p2p.clientQueue.Len())
+	p2p.Cfg.ClientLogger.Infof("wait client writer finish cost:%.3f,main qu size:%d,client qu size:%d",
+		time.Since(waitStart).Seconds(), p2p.queue.Len(), p2p.clientQueue.Len())
 
 	if p2p.Cfg.BackSourceReason > 0 {
 		return
@@ -361,9 +368,9 @@ func (p2p *P2PDownloader) finishTask(response *types.PullPieceTaskResponse, clie
 		src = p2p.Cfg.RV.TempTarget
 	} else {
 		if _, err := os.Stat(p2p.clientFilePath); err != nil {
-			p2p.Cfg.ClientLogger.Infof("Client file path:%s not found", p2p.clientFilePath)
+			p2p.Cfg.ClientLogger.Warnf("client file path:%s not found", p2p.clientFilePath)
 			if e := util.Link(p2p.serviceFilePath, p2p.clientFilePath); e != nil {
-				p2p.Cfg.ClientLogger.Warnln("Link failed, instead of use copy")
+				p2p.Cfg.ClientLogger.Warnln("hard link failed, instead of use copy")
 				util.CopyFile(p2p.serviceFilePath, p2p.clientFilePath)
 			}
 		}
@@ -374,7 +381,7 @@ func (p2p *P2PDownloader) finishTask(response *types.PullPieceTaskResponse, clie
 	if err := moveFile(src, p2p.targetFile, p2p.Cfg.Md5, p2p.Cfg.ClientLogger); err != nil {
 		return
 	}
-	p2p.Cfg.ClientLogger.Infof("Download successfully from dragonfly")
+	p2p.Cfg.ClientLogger.Infof("download successfully from dragonfly")
 }
 
 func (p2p *P2PDownloader) refresh(item *Piece) {

--- a/dfget/core/downloader/power_client.go
+++ b/dfget/core/downloader/power_client.go
@@ -56,7 +56,8 @@ func (pc *PowerClient) Run() (err error) {
 
 	defer func() {
 		if err != nil {
-			pc.cfg.ClientLogger.Errorf("failed to read piece cont from dst:%s ,error:%s", err, dstIP)
+			pc.cfg.ClientLogger.Errorf("failed to read piece cont from dst:%s:%d, error:%s",
+				dstIP, peerPort, err)
 		}
 	}()
 
@@ -90,12 +91,10 @@ func (pc *PowerClient) Run() (err error) {
 	pieceCont := bytes.NewBuffer(buf)
 
 	total, err := pieceCont.ReadFrom(limitReader)
-	pc.cfg.ClientLogger.Infof("get pieceCont total: %d", total)
 	if err != nil {
 		return err
 	}
 
-	// TODO handle read timeout
 	readFinish := time.Now()
 
 	// Verify md5 code

--- a/dfget/types/pull_piece_task_response.go
+++ b/dfget/types/pull_piece_task_response.go
@@ -73,6 +73,11 @@ type PullPieceTaskResponseFinishData struct {
 	FileLength int64  `json:"fileLength"`
 }
 
+func (data *PullPieceTaskResponseFinishData) String() string {
+	b, _ := json.Marshal(data)
+	return string(b)
+}
+
 // PullPieceTaskResponseContinueData is the data when successfully pulling piece task
 // and the task is continuing.
 type PullPieceTaskResponseContinueData struct {
@@ -85,4 +90,9 @@ type PullPieceTaskResponseContinueData struct {
 	PeerPort  int    `json:"peerPort"`
 	Path      string `json:"path"`
 	DownLink  int    `json:"downLink"`
+}
+
+func (data *PullPieceTaskResponseContinueData) String() string {
+	b, _ := json.Marshal(data)
+	return string(b)
 }

--- a/dfget/types/types_test.go
+++ b/dfget/types/types_test.go
@@ -19,6 +19,7 @@ package types
 import (
 	"math/rand"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -88,6 +89,8 @@ func (suite *TypesSuite) TestPullPieceTaskResponse_FinishData(c *check.C) {
 	res.Data = []byte("{\"fileLength\":1}")
 	c.Assert(res.FinishData(), check.NotNil)
 	c.Assert(res.FinishData().FileLength, check.Equals, int64(1))
+	c.Assert(strings.Index(res.FinishData().String(), "\"fileLength\":1") > 0,
+		check.Equals, true)
 }
 
 func (suite *TypesSuite) TestPullPieceTaskResponse_ContinueData(c *check.C) {
@@ -105,4 +108,6 @@ func (suite *TypesSuite) TestPullPieceTaskResponse_ContinueData(c *check.C) {
 	c.Assert(res.ContinueData(), check.NotNil)
 	c.Assert(len(res.ContinueData()), check.Equals, 1)
 	c.Assert(res.ContinueData()[0].PieceNum, check.Equals, 1)
+	c.Assert(strings.Index(res.ContinueData()[0].String(), "\"pieceNum\":1") > 0,
+		check.Equals, true)
 }

--- a/dfget/util/log.go
+++ b/dfget/util/log.go
@@ -120,7 +120,9 @@ func (f *DragonflyFormatter) Format(entry *log.Entry) ([]byte, error) {
 		timestampFormat = DefaultLogTimeFormat
 	}
 	f.appendValue(b, entry.Time.Format(timestampFormat), true)
-	f.appendValue(b, strings.ToUpper(entry.Level.String()), true)
+	f.appendValue(b,
+		fmt.Sprintf("%-4.4s", strings.ToUpper(entry.Level.String())),
+		true)
 	if !IsEmptyStr(f.Sign) {
 		fmt.Fprintf(b, "sign:%s ", f.Sign)
 	}

--- a/dfget/util/log_test.go
+++ b/dfget/util/log_test.go
@@ -38,9 +38,11 @@ func (suite *DFGetUtilSuite) TestCreateLogger(c *check.C) {
 
 	var checkLogs = func(level logrus.Level, msg string) {
 		line, _, _ := r.ReadLine()
-		tmpStr := strings.Split(strings.Trim(string(line), "\n"), " ")
+		tmpStr := strings.Fields(strings.Trim(string(line), "\n"))
 		c.Assert(len(tmpStr) >= 6, check.Equals, true)
-		c.Assert(tmpStr[2], check.Equals, strings.ToUpper(level.String()))
+		c.Assert(len(tmpStr[2]), check.Equals, 4)
+		c.Assert(strings.Index(strings.ToUpper(level.String()), tmpStr[2]),
+			check.Equals, 0)
 		c.Assert(tmpStr[3], check.Equals, "sign:x")
 		c.Assert(strings.Join(tmpStr[5:], " "), check.Equals, msg)
 	}

--- a/src/supernode/src/main/resources/logback.xml
+++ b/src/supernode/src/main/resources/logback.xml
@@ -5,6 +5,7 @@
     <property name="LOG_HOME" value="${LOG_HOME:-${supernode.baseHome:-/home/admin/supernode}/logs}"/>
     <property name="LOG_LEVEL" value="${LOG_LEVEL:-INFO}"/>
     <property name="LOG_APPENDER" value="${LOG_APPENDER:-STDOUT}"/>
+    <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%10.10t] %-30.30logger{29} - %msg%n"/>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">


### PR DESCRIPTION
Signed-off-by: lowzj <zj3142063@gmail.com>


### Ⅰ. Describe what this PR did

This pull request makes the log clearer and more readable.

**log of client**: only output first 4 chars of all log levels
* before
```
2019-01-29 17:23:57.693 WARNING sign:32351-1548753817.127 : has not available pieceTask,maybe resource lack
2019-01-29 17:23:57.695 INFO sign:32351-1548753817.127 : pull piece task result:{"code":602,"msg":"client sucCount:28,cdn status:RUNNING,cdn sucCount:28"} and sleep 1.313s
2019-01-29 17:23:58.019 ERROR sign:32351-1548753817.127 : download timeout(20.000s)
```
* after
```
2019-01-29 17:23:57.693 WARN sign:32351-1548753817.127 : has not available pieceTask,maybe resource lack
2019-01-29 17:23:57.695 INFO sign:32351-1548753817.127 : pull piece task result:{"code":602,"msg":"client sucCount:28,cdn status:RUNNING,cdn sucCount:28"} and sleep 1.313s
2019-01-29 17:23:58.019 ERRO sign:32351-1548753817.127 : download timeout(20.000s)
```

**log of supernode**: reduce prefix characters and align them
* before
```
2019-01-29 17:13:44.084  WARN 26295 --- [pool-1-thread-15] c.d.d.s.common.util.HttpClientUtil       : url:http://xxx isExpired error
2019-01-29 17:13:44.113  INFO 26295 --- [pool-1-thread-15] c.d.d.s.service.impl.CdnReporterImpl     : taskId:5e265e2a53408464fc40722408cbaf7c1c67e02a14ed34532f1c29e3f184eacc fileLength:522127477 status:SUCCESS from:local
2019-01-29 17:13:44.113  INFO 26295 --- [pool-1-thread-15] c.d.d.supernode.service.cdn.Downloader   : cache full hit for taskId:5e265e2a53408464fc40722408cbaf7c1c67e02a14ed34532f1c29e3f184eacc on local
```
* after
```
2019-01-29 17:23:40.109 WARN  [1-thread-1] c.d.d.s.c.util.HttpClientUtil  - url:http://xxx isExpired error
2019-01-29 17:23:40.145 INFO  [1-thread-1] c.d.d.s.s.cdn.Downloader       - taskId:5e265e2a53408464fc40722408cbaf7c1c67e02a14ed34532f1c29e3f184eacc fileUrl:http://ossproxy.aone.alibaba-inc.com/aone2/build-service/api/v2/ossproxy/download?ns=EnvCenter&bucketName=env-center-bucket&fileId=35853940-4d73-11e6-bb64-c7cf42337dc3&fileName=500.zip&md5Sign=ba52b67235859f76a8acaecdf18933b5 on downloader
2019-01-29 17:23:41.589 INFO  [6-thread-1] .d.s.c.u.NetConfigNotification - current rate limiter count is 2
2019-01-29 17:24:35.155 INFO  [  Thread-6] c.d.d.s.s.i.CdnReporterImpl    - taskId:5e265e2a53408464fc40722408cbaf7c1c67e02a14ed34532f1c29e3f184eacc fileLength:522127477 status:SUCCESS from:local
```


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


