### PR TITLE
fix: optimize the judgment of local cache expiration

### DIFF
--- a/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/common/util/HttpClientUtil.java
+++ b/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/common/util/HttpClientUtil.java
@@ -27,7 +27,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
@@ -85,7 +84,7 @@ public class HttpClientUtil {
                 fillHeaders(conn, headers);
                 conn.setUseCaches(false);
                 conn.setConnectTimeout(2000);
-                conn.setReadTimeout(1000);
+                conn.setReadTimeout(2000);
                 if (lastModified > 0) {
                     conn.setIfModifiedSince(lastModified);
                 }
@@ -106,7 +105,10 @@ public class HttpClientUtil {
                 }
                 break;
             } catch (Exception e) {
-                logger.warn("url:{} isExpired error", fileUrl, e);
+                logger.warn("url:{} isExpired error:%s", fileUrl, e.getMessage(), e);
+                if (times == 0) {
+                    return false;
+                }
             } finally {
                 closeConn(conn);
                 conn = null;


### PR DESCRIPTION
Signed-off-by: lowzj <zj3142063@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

* increase read timeout to 2 seconds
* not expire if get response from remote server timeout


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


