### PR TITLE
test: add mock test for api client and preheat API mock test

### DIFF
--- a/client/client_mock_test.go
+++ b/client/client_mock_test.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/dragonflyoss/Dragonfly/apis/types"
+)
+
+type transportFunc func(*http.Request) (*http.Response, error)
+
+func (transFunc transportFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return transFunc(req)
+}
+
+func newMockClient(handler func(*http.Request) (*http.Response, error)) *http.Client {
+	return &http.Client{
+		Transport: transportFunc(handler),
+	}
+}
+
+func errorMockResponse(statusCode int, message string) func(req *http.Request) (*http.Response, error) {
+	return func(req *http.Request) (*http.Response, error) {
+		header := http.Header{}
+		header.Set("Content-Type", "application/json")
+
+		body, err := json.Marshal(&types.Error{
+			Message: message,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		return &http.Response{
+			StatusCode: statusCode,
+			Body:       ioutil.NopCloser(bytes.NewReader(body)),
+			Header:     header,
+		}, nil
+	}
+}

--- a/client/preheat_info_test.go
+++ b/client/preheat_info_test.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dragonflyoss/Dragonfly/apis/types"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPreheatInfoError(t *testing.T) {
+	serverErr := "Server error"
+	client := &APIClient{
+		HTTPCli: newMockClient(errorMockResponse(http.StatusInternalServerError, serverErr)),
+	}
+
+	preheatTaskID := "asdfghjkl345678"
+	_, err := client.PreheatInfo(context.Background(), preheatTaskID)
+	if err == nil {
+		t.Fatalf("expected a %s, got no error", serverErr)
+	}
+	if !strings.Contains(err.Error(), serverErr) {
+		t.Fatalf("expected an error contains %s, got %v", serverErr, err)
+	}
+}
+
+func TestPreheatInfo(t *testing.T) {
+	id := "1234567890"
+	startTime := strfmt.DateTime(time.Now())
+	finishTime := strfmt.DateTime(time.Now().Add(time.Duration(time.Minute)))
+	status := "SUCCESS"
+
+	expectedURL := fmt.Sprintf("/preheats/%s", id)
+
+	httpClient := newMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
+		info := types.PreheatInfo{
+			ID:         id,
+			StartTime:  startTime,
+			FinishTime: finishTime,
+			Status:     "SUCCESS",
+		}
+		b, err := json.Marshal(info)
+		if err != nil {
+			return nil, err
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(b))),
+		}, nil
+	})
+
+	client := &APIClient{
+		HTTPCli: httpClient,
+	}
+
+	info, err := client.PreheatInfo(context.Background(), id)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	assert.Equal(t, info.ID, id)
+	assert.Equal(t, info.StartTime.String(), startTime.String())
+	assert.Equal(t, info.FinishTime.String(), finishTime.String())
+	assert.Equal(t, info.Status, status)
+}

--- a/hack/env.sh
+++ b/hack/env.sh
@@ -15,10 +15,8 @@
 
 export INSTALL_HOME=/opt/dragonfly
 export INSTALL_CLIENT_PATH=df-client
-export GO_SOURCE_DIRECTORIES=( \
-    "dfdaemon" \
-    "dfget" \
-    "version" \
+export GO_SOURCE_EXCLUDES=( \
+    "test" \
 )
 
 GOOS=$(go env GOOS)

--- a/hack/unit-test.sh
+++ b/hack/unit-test.sh
@@ -9,11 +9,13 @@ unit_test() {
     cd ../ || return
     go test -i ./...
 
+    # folder /test contains test cases for integration test.
+    # then we exclude them in unit test.
     cmd="go list ./... | grep 'github.com/dragonflyoss/Dragonfly/'"
-    sources="${GO_SOURCE_DIRECTORIES[*]}"
-    sources="${sources// /|}"
+    excludes="${GO_SOURCE_EXCLUDES[*]}"
+    excludes="${excludes// /|}"
     retCode=0
-    test -n "${sources}" && cmd+=" | grep -E '${sources}'"
+    test -n "${excludes}" && cmd+=" | grep -vE '${excludes}'"
 
     for d in $(eval "${cmd}")
     do


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Unit test for API client is very essential for dragonfly. We should guarantee the quality of golang SDK.

This PR adds : 
* mock test for api client
* preheat API mock test

And Dragonfly community encourages everyone to finish the golang SDK of dragonfly's supernode's API and finish the mock test for client as well.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
This fixes one part of https://github.com/dragonflyoss/Dragonfly/issues/366.


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
added


### Ⅳ. Describe how to verify it
```
Running tool: /usr/local/go/bin/go test -timeout 30s github.com/dragonflyoss/Dragonfly/client -run ^(TestSystemInfoError)$

ok  	github.com/dragonflyoss/Dragonfly/client	0.103s
Success: Tests passed.
```

and 

```
Running tool: /usr/local/go/bin/go test -timeout 30s github.com/dragonflyoss/Dragonfly/client -run ^(TestPreheatInfo)$

ok  	github.com/dragonflyoss/Dragonfly/client	0.104s
Success: Tests passed.
```

### Ⅴ. Special notes for reviews
none

