### PR TITLE
refactor: directly config logrus' default Logger rather than create a new one

### DIFF
--- a/cmd/dfget/app/root_test.go
+++ b/cmd/dfget/app/root_test.go
@@ -85,7 +85,6 @@ func (suit *dfgetSuit) Test_initProperties() {
 	for _, v := range cases {
 		cfg = config.NewConfig()
 		buf.Reset()
-		cfg.ClientLogger = logrus.StandardLogger()
 		cfg.ConfigFiles = v.configs
 		localLimitStr := strconv.FormatInt(int64(v.expected.LocalLimit/1024), 10)
 		totalLimitStr := strconv.FormatInt(int64(v.expected.TotalLimit/1024), 10)

--- a/dfget/config/config.go
+++ b/dfget/config/config.go
@@ -34,7 +34,6 @@ import (
 	"github.com/dragonflyoss/Dragonfly/dfget/util"
 
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"gopkg.in/gcfg.v1"
 	"gopkg.in/warnings.v0"
 	"gopkg.in/yaml.v2"
@@ -223,12 +222,6 @@ type Config struct {
 
 	// The reason of backing to source.
 	BackSourceReason int `json:"-"`
-
-	// Client logger.
-	ClientLogger *logrus.Logger `json:"-"`
-
-	// Server logger, only created when Pattern equals 'p2p'.
-	ServerLogger *logrus.Logger `json:"-"`
 }
 
 func (cfg *Config) String() string {
@@ -263,10 +256,6 @@ func NewConfig() *Config {
 func AssertConfig(cfg *Config) (err error) {
 	if util.IsNil(cfg) {
 		return errors.Wrap(errType.ErrNotInitialized, "runtime config")
-	}
-
-	if util.IsNil(cfg.ClientLogger) {
-		return errors.Wrap(errType.ErrNotInitialized, "client log")
 	}
 
 	if err := checkURL(cfg); err != nil {

--- a/dfget/config/config_test.go
+++ b/dfget/config/config_test.go
@@ -100,7 +100,6 @@ func (suite *ConfigSuite) TestAssertConfig(c *check.C) {
 		output    string
 		checkFunc func(err error) bool
 	}{
-		{checkFunc: errors.IsNotInitialized},
 		{clog: clog, checkFunc: errors.IsInvalidValue},
 		{clog: clog, url: "http://a", checkFunc: errors.IsInvalidValue},
 		{clog: clog, url: "http://a.b.com", output: "/tmp/output", checkFunc: errors.IsNilError},
@@ -112,7 +111,6 @@ func (suite *ConfigSuite) TestAssertConfig(c *check.C) {
 	}
 
 	for _, v := range cases {
-		cfg.ClientLogger = v.clog
 		cfg.URL = v.url
 		cfg.Output = v.output
 		actual := f()

--- a/dfget/core/core_test.go
+++ b/dfget/core/core_test.go
@@ -32,6 +32,7 @@ import (
 	. "github.com/dragonflyoss/Dragonfly/dfget/core/helper"
 	"github.com/dragonflyoss/Dragonfly/dfget/core/regist"
 	"github.com/dragonflyoss/Dragonfly/dfget/util"
+
 	"github.com/go-check/check"
 	"github.com/valyala/fasthttp"
 )
@@ -150,14 +151,14 @@ func (s *CoreTestSuite) TestCheckConnectSupernode(c *check.C) {
 	go fasthttp.Serve(ln, func(ctx *fasthttp.RequestCtx) {})
 
 	buf := &bytes.Buffer{}
-	cfg := s.createConfig(buf)
+	s.createConfig(buf)
 
 	nodes := []string{host}
-	ip := checkConnectSupernode(nodes, cfg.ClientLogger)
+	ip := checkConnectSupernode(nodes)
 	c.Assert(ip, check.Equals, "127.0.0.1")
 
 	buf.Reset()
-	ip = checkConnectSupernode([]string{"127.0.0.2"}, cfg.ClientLogger)
+	ip = checkConnectSupernode([]string{"127.0.0.2"})
 	c.Assert(strings.Index(buf.String(), "Connect") > 0, check.Equals, true)
 	c.Assert(ip, check.Equals, "")
 }

--- a/dfget/core/downloader/back_downloader/back_downloader.go
+++ b/dfget/core/downloader/back_downloader/back_downloader.go
@@ -28,6 +28,8 @@ import (
 	"github.com/dragonflyoss/Dragonfly/dfget/core/downloader"
 	"github.com/dragonflyoss/Dragonfly/dfget/core/regist"
 	"github.com/dragonflyoss/Dragonfly/dfget/util"
+
+	"github.com/sirupsen/logrus"
 )
 
 // BackDownloader downloads the file from file resource.
@@ -75,7 +77,6 @@ func (bd *BackDownloader) Run() error {
 		err  error
 		f    *os.File
 	)
-	log := bd.cfg.ClientLogger
 
 	if bd.cfg.Notbs || bd.cfg.BackSourceReason == config.BackSourceReasonNoSpace {
 		bd.cfg.BackSourceReason += config.ForceNotBackSourceAddition
@@ -84,7 +85,7 @@ func (bd *BackDownloader) Run() error {
 	}
 
 	util.Printer.Printf("download from source")
-	log.Infof("start download %s from the source station", path.Base(bd.Target))
+	logrus.Infof("start download %s from the source station", path.Base(bd.Target))
 
 	defer bd.Cleanup()
 
@@ -108,7 +109,7 @@ func (bd *BackDownloader) Run() error {
 
 	realMd5 := reader.Md5()
 	if bd.Md5 == "" || bd.Md5 == realMd5 {
-		err = downloader.MoveFile(bd.tempFileName, bd.Target, "", bd.cfg.ClientLogger)
+		err = downloader.MoveFile(bd.tempFileName, bd.Target, "")
 	} else {
 		err = fmt.Errorf("md5 not match, expected:%s real:%s", bd.Md5, realMd5)
 	}

--- a/dfget/core/downloader/downloader.go
+++ b/dfget/core/downloader/downloader.go
@@ -84,19 +84,18 @@ func ConvertHeaders(headers []string) map[string]string {
 
 // MoveFile moves a file from src to dst and
 // checks if the MD5 code is expected before that.
-func MoveFile(src string, dst string, expectMd5 string, log *logrus.Logger) error {
+func MoveFile(src string, dst string, expectMd5 string) error {
 	start := time.Now()
 	if expectMd5 != "" {
 		realMd5 := util.Md5Sum(src)
-		log.Infof("compute raw md5:%s for file:%s cost:%.3fs", realMd5,
+		logrus.Infof("compute raw md5:%s for file:%s cost:%.3fs", realMd5,
 			src, time.Since(start).Seconds())
 		if realMd5 != expectMd5 {
 			return fmt.Errorf("Md5NotMatch, real:%s expect:%s", realMd5, expectMd5)
 		}
 	}
 	err := util.MoveFile(src, dst)
-
-	log.Infof("move src:%s to dst:%s result:%t cost:%.3f",
+	logrus.Infof("move src:%s to dst:%s result:%t cost:%.3f",
 		src, dst, err == nil, time.Since(start).Seconds())
 	return err
 }

--- a/dfget/core/downloader/downloader_test.go
+++ b/dfget/core/downloader/downloader_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/dragonflyoss/Dragonfly/dfget/core/helper"
 	"github.com/dragonflyoss/Dragonfly/dfget/util"
 	"github.com/go-check/check"
-	"github.com/sirupsen/logrus"
 )
 
 func Test(t *testing.T) {
@@ -77,24 +76,23 @@ func (s *DownloaderTestSuite) TestMoveFile(c *check.C) {
 	tmp, _ := ioutil.TempDir("/tmp", "dfget-TestMoveFile-")
 	defer os.RemoveAll(tmp)
 
-	log := &logrus.Logger{}
 	src := path.Join(tmp, "a")
 	dst := path.Join(tmp, "b")
 	md5str := helper.CreateTestFileWithMD5(src, "hello")
 
-	err := MoveFile(src, dst, "x", log)
+	err := MoveFile(src, dst, "x")
 	c.Assert(util.PathExist(src), check.Equals, true)
 	c.Assert(util.PathExist(dst), check.Equals, false)
 	c.Assert(err, check.NotNil)
 
-	err = MoveFile(src, dst, md5str, log)
+	err = MoveFile(src, dst, md5str)
 	c.Assert(util.PathExist(src), check.Equals, false)
 	c.Assert(util.PathExist(dst), check.Equals, true)
 	c.Assert(err, check.IsNil)
 	content, _ := ioutil.ReadFile(dst)
 	c.Assert(string(content), check.Equals, "hello")
 
-	err = MoveFile(src, dst, "", log)
+	err = MoveFile(src, dst, "")
 	c.Assert(err, check.NotNil)
 }
 

--- a/dfget/core/downloader/p2p_downloader/client_writer.go
+++ b/dfget/core/downloader/p2p_downloader/client_writer.go
@@ -27,6 +27,8 @@ import (
 	"github.com/dragonflyoss/Dragonfly/dfget/core/helper"
 	"github.com/dragonflyoss/Dragonfly/dfget/types"
 	"github.com/dragonflyoss/Dragonfly/dfget/util"
+
+	"github.com/sirupsen/logrus"
 )
 
 // ClientWriter writes a file for uploading and a target file.
@@ -77,7 +79,7 @@ func (cw *ClientWriter) init() (err error) {
 	cw.p2pPattern = helper.IsP2P(cw.cfg.Pattern)
 	if cw.p2pPattern {
 		if e := util.Link(cw.cfg.RV.TempTarget, cw.clientFilePath); e != nil {
-			cw.cfg.ClientLogger.Warn(e)
+			logrus.Warn(e)
 			cw.acrossWrite = true
 		}
 
@@ -128,7 +130,7 @@ func (cw *ClientWriter) Run() {
 			continue
 		}
 		if err := cw.write(piece, time.Now()); err != nil {
-			cw.cfg.ClientLogger.Errorf("write item:%s error:%v", piece, err)
+			logrus.Errorf("write item:%s error:%v", piece, err)
 			cw.cfg.BackSourceReason = config.BackSourceReasonWriteError
 			cw.result = false
 		}
@@ -182,7 +184,7 @@ func (cw *ClientWriter) sendSuccessPiece(piece *Piece, cost time.Duration) {
 		PieceRange: piece.Range,
 	})
 	if cost.Seconds() > 2.0 {
-		cw.cfg.ClientLogger.Infof(
+		logrus.Infof(
 			"async writer and report suc from dst:%s... cost:%.3f for range:%s",
 			piece.DstCid[:25], cost.Seconds(), piece.Range)
 	}

--- a/dfget/core/downloader/p2p_downloader/power_client.go
+++ b/dfget/core/downloader/p2p_downloader/power_client.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dragonflyoss/Dragonfly/dfget/errors"
 	"github.com/dragonflyoss/Dragonfly/dfget/types"
 	"github.com/dragonflyoss/Dragonfly/dfget/util"
+
 	"github.com/sirupsen/logrus"
 )
 
@@ -54,12 +55,12 @@ func (pc *PowerClient) Run() error {
 	content, err := pc.downloadPiece()
 
 	timeDuring := time.Since(startTime).Seconds()
-	pc.log().Debugf("client range:%s cost:%.3f from peer:%s:%d, readCost:%.3f, length:%d",
+	logrus.Debugf("client range:%s cost:%.3f from peer:%s:%d, readCost:%.3f, length:%d",
 		pc.pieceTask.Range, timeDuring, pc.pieceTask.PeerIP, pc.pieceTask.PeerPort,
 		pc.readCost.Seconds(), pc.total)
 
 	if err != nil {
-		pc.log().Errorf("read piece cont error:%v from dst:%s:%d",
+		logrus.Errorf("read piece cont error:%v from dst:%s:%d",
 			err, pc.pieceTask.PeerIP, pc.pieceTask.PeerPort)
 		pc.queue.Put(pc.failPiece())
 		return err
@@ -114,7 +115,7 @@ func (pc *PowerClient) downloadPiece() (content *bytes.Buffer, e error) {
 	}
 
 	if timeDuring := time.Since(startTime).Seconds(); timeDuring > 2.0 {
-		pc.log().Warnf("client range:%s cost:%.3f from peer:%s, readCost:%.3f, length:%d",
+		logrus.Warnf("client range:%s cost:%.3f from peer:%s, readCost:%.3f, length:%d",
 			pc.pieceTask.Range, timeDuring, dstIP, pc.readCost.Seconds(), pc.total)
 	}
 	return content, nil
@@ -152,8 +153,4 @@ func (pc *PowerClient) readBody(body io.ReadCloser) string {
 		return ""
 	}
 	return buf.String()
-}
-
-func (pc *PowerClient) log() *logrus.Logger {
-	return pc.cfg.ClientLogger
 }

--- a/dfget/core/downloader/p2p_downloader/target_writer.go
+++ b/dfget/core/downloader/p2p_downloader/target_writer.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/dragonflyoss/Dragonfly/dfget/config"
 	"github.com/dragonflyoss/Dragonfly/dfget/util"
+
+	"github.com/sirupsen/logrus"
 )
 
 // TargetWriter writes downloading file to disk.
@@ -87,7 +89,7 @@ func (tw *TargetWriter) Run() {
 			continue
 		}
 		if err := tw.write(piece); err != nil {
-			tw.cfg.ClientLogger.Errorf("write item:%s error:%v", piece, err)
+			logrus.Errorf("write item:%s error:%v", piece, err)
 			tw.cfg.BackSourceReason = config.BackSourceReasonWriteError
 			tw.result = false
 		}

--- a/dfget/core/helper/test_helper.go
+++ b/dfget/core/helper/test_helper.go
@@ -41,8 +41,6 @@ func CreateConfig(writer io.Writer, workHome string) *config.Config {
 	cfg.RV.SystemDataDir = path.Join(cfg.WorkHome, "data")
 
 	logrus.StandardLogger().Out = writer
-	cfg.ClientLogger = logrus.StandardLogger()
-	cfg.ServerLogger = logrus.StandardLogger()
 	return cfg
 }
 

--- a/dfget/core/uploader/uploader_util.go
+++ b/dfget/core/uploader/uploader_util.go
@@ -31,6 +31,8 @@ import (
 	"github.com/dragonflyoss/Dragonfly/dfget/core/helper"
 	"github.com/dragonflyoss/Dragonfly/dfget/errors"
 	"github.com/dragonflyoss/Dragonfly/version"
+
+	"github.com/sirupsen/logrus"
 )
 
 // uploader helper
@@ -150,7 +152,7 @@ func (ps *peerServer) uploadPiece(f *os.File, w http.ResponseWriter, up *uploadP
 		}
 
 		if num == 0 {
-			ps.cfg.ServerLogger.Warnf("empty range:%s-%s of file:%s",
+			logrus.Warnf("empty range:%s-%s of file:%s",
 				up.start, up.end, f.Name())
 			break
 		}


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

In the component of dfget, the Logger is regarded one field of the configuration, and it will be transferred to other places where logger recording is needed.

Since when dfget process is started to the status of its exit, the log configuration will not change, then I think we can directly use the default `logrus.Logger` in pkg `logrus`. And we only need to configure the default logger's LogLevel, Formatter and Output via:

* logrus.SetOutput()
* logrus.SetLevel()
* logrus.SetFormatter()


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
no, just refactoring

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
no 


### Ⅳ. Describe how to verify it
no

### Ⅴ. Special notes for reviews
none

