### PR TITLE
feature: add ping impelmentation in sdk and add mock test

### DIFF
--- a/client/ping.go
+++ b/client/ping.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"context"
+	"io/ioutil"
+)
+
+// Ping sends a _ping request to supernode to see if it's working.
+func (client *APIClient) Ping(ctx context.Context) (string, error) {
+	resp, err := client.get(ctx, "/_ping", nil, nil)
+	if err != nil {
+		return "", err
+	}
+
+	defer resp.Body.Close()
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(data), nil
+}

--- a/client/ping_test.go
+++ b/client/ping_test.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package client
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestPingError(t *testing.T) {
+	client := &APIClient{
+		HTTPCli: newMockClient(errorMockResponse(http.StatusInternalServerError, "Server error")),
+	}
+	_, err := client.Ping(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "Server error") {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestPing(t *testing.T) {
+	expectedURL := "/_ping"
+
+	httpClient := newMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte("OK"))),
+		}, nil
+	})
+
+	client := &APIClient{
+		HTTPCli: httpClient,
+	}
+
+	if resp, err := client.Ping(context.Background()); err != nil {
+		t.Fatal(err)
+	} else if resp != "OK" {
+		t.Fatalf("expect to get response body OK, got %s", resp)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

add ping impelmentation in sdk and add mock test


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
this fixes one part of https://github.com/dragonflyoss/Dragonfly/issues/366


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
added mock test


### Ⅳ. Describe how to verify it
```
Running tool: /usr/local/go/bin/go test -timeout 30s github.com/dragonflyoss/Dragonfly/client -run ^(TestPing)$

ok  	github.com/dragonflyoss/Dragonfly/client	0.063s
Success: Tests passed.
```

### Ⅴ. Special notes for reviews
none

