### PR TITLE
feature: report peer server down when it passively exits

### DIFF
--- a/dfget/core/api/uploader_api.go
+++ b/dfget/core/api/uploader_api.go
@@ -28,7 +28,7 @@ import (
 
 // UploaderAPI defines the communication methods between dfget and uploader.
 type UploaderAPI interface {
-	// ParseRate sends a request to uploader to calculate the ratelimit dynamically
+	// ParseRate sends a request to uploader to calculate the rateLimit dynamically
 	// for the speed limit of the whole host machine.
 	ParseRate(ip string, port int, req *ParseRateRequest) (string, error)
 

--- a/dfget/core/helper/test_helper.go
+++ b/dfget/core/helper/test_helper.go
@@ -17,9 +17,9 @@
 package helper
 
 import (
-	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -33,7 +33,7 @@ import (
 // CreateConfig create a temporary config
 func CreateConfig(writer io.Writer, workHome string) *config.Config {
 	if writer == nil {
-		writer = &bytes.Buffer{}
+		writer = ioutil.Discard
 	}
 	cfg := config.NewConfig()
 	cfg.WorkHome = workHome

--- a/dfget/core/uploader/peer_server.go
+++ b/dfget/core/uploader/peer_server.go
@@ -1,0 +1,476 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uploader
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dragonflyoss/Dragonfly/dfget/config"
+	"github.com/dragonflyoss/Dragonfly/dfget/core/api"
+	"github.com/dragonflyoss/Dragonfly/dfget/core/helper"
+	"github.com/dragonflyoss/Dragonfly/dfget/errors"
+	"github.com/dragonflyoss/Dragonfly/dfget/util"
+	"github.com/dragonflyoss/Dragonfly/version"
+
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+)
+
+// newPeerServer return a new P2PServer.
+func newPeerServer(cfg *config.Config, port int) *peerServer {
+	s := &peerServer{
+		cfg:      cfg,
+		finished: make(chan struct{}),
+		host:     cfg.RV.LocalIP,
+		port:     port,
+		api:      api.NewSupernodeAPI(),
+	}
+
+	r := s.initRouter()
+	s.Server = &http.Server{
+		Addr:    net.JoinHostPort(s.host, strconv.Itoa(port)),
+		Handler: r,
+	}
+
+	return s
+}
+
+// ----------------------------------------------------------------------------
+// peerServer structure
+
+// peerServer offer file-block to other clients
+type peerServer struct {
+	cfg *config.Config
+
+	// finished indicates whether the peer server is shutdown
+	finished chan struct{}
+
+	// server related fields
+	host string
+	port int
+	*http.Server
+
+	api         api.SupernodeAPI
+	rateLimiter *util.RateLimiter
+
+	// totalLimitRate is the total network bandwidth shared by tasks on the same host
+	totalLimitRate int
+
+	// syncTaskMap stores the meta info of tasks on the host
+	syncTaskMap sync.Map
+}
+
+// taskConfig refers to some info about peer task.
+type taskConfig struct {
+	taskID    string
+	rateLimit int
+	cid       string
+	dataDir   string
+	superNode string
+	finished  bool
+}
+
+// uploadParam refers to all params needed in the handler of upload.
+type uploadParam struct {
+	padSize int64
+	start   int64
+	length  int64
+
+	pieceSize int64
+	pieceNum  int64
+}
+
+// ----------------------------------------------------------------------------
+// init method of peerServer
+
+func (ps *peerServer) initRouter() *mux.Router {
+	r := mux.NewRouter()
+	r.HandleFunc(config.PeerHTTPPathPrefix+"{commonFile:.*}", ps.uploadHandler).Methods("GET")
+	r.HandleFunc(config.LocalHTTPPathRate+"{commonFile:.*}", ps.parseRateHandler).Methods("GET")
+	r.HandleFunc(config.LocalHTTPPathCheck+"{commonFile:.*}", ps.checkHandler).Methods("GET")
+	r.HandleFunc(config.LocalHTTPPathClient+"finish", ps.oneFinishHandler).Methods("GET")
+	r.HandleFunc(config.LocalHTTPPing, ps.pingHandler).Methods("GET")
+
+	return r
+}
+
+// ----------------------------------------------------------------------------
+// peerServer handlers
+
+// uploadHandler use to upload a task file when other peers download from it.
+func (ps *peerServer) uploadHandler(w http.ResponseWriter, r *http.Request) {
+	aliveQueue.Put(true)
+
+	var (
+		up   *uploadParam
+		f    *os.File
+		size int64
+		err  error
+	)
+
+	taskFileName := mux.Vars(r)["commonFile"]
+	rangeStr := r.Header.Get(config.StrRange)
+
+	logrus.Debugf("upload file:%s to %s, req:%v", taskFileName, r.RemoteAddr, jsonStr(r.Header))
+
+	// Step1: parse param
+	if up, err = parseParams(rangeStr, r.Header.Get(config.StrPieceNum),
+		r.Header.Get(config.StrPieceSize)); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		logrus.Warnf("invalid param file:%s req:%v, %v", taskFileName, r.Header, err)
+		return
+	}
+
+	// Step2: get task file
+	if f, size, err = ps.getTaskFile(taskFileName); err != nil {
+		rangeErrorResponse(w, err)
+		logrus.Errorf("failed to open file:%s, %v", taskFileName, err)
+		return
+	}
+	defer f.Close()
+
+	// Step3: amend range with piece meta data
+	if err = amendRange(size, true, up); err != nil {
+		rangeErrorResponse(w, err)
+		logrus.Errorf("failed to amend range of file %s: %v", taskFileName, err)
+		return
+	}
+
+	// Step4: send piece wrapped by meta data
+	if err := ps.uploadPiece(f, w, up); err != nil {
+		logrus.Errorf("failed to send range(%s) of file(%s): %v", rangeStr, taskFileName, err)
+	}
+}
+
+func (ps *peerServer) parseRateHandler(w http.ResponseWriter, r *http.Request) {
+	aliveQueue.Put(true)
+
+	// get params from request
+	taskFileName := mux.Vars(r)["commonFile"]
+	rateLimit := r.Header.Get(config.StrRateLimit)
+	clientRate, err := strconv.Atoi(rateLimit)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, err.Error())
+		logrus.Errorf("failed to convert rateLimit %v, %v", rateLimit, err)
+		return
+	}
+	sendSuccess(w)
+
+	// update the rateLimit of commonFile
+	if v, ok := ps.syncTaskMap.Load(taskFileName); ok {
+		param := v.(*taskConfig)
+		param.rateLimit = clientRate
+	}
+
+	// no need to calculate rate when totalLimitRate less than or equals zero.
+	if ps.totalLimitRate <= 0 {
+		fmt.Fprintf(w, rateLimit)
+		return
+	}
+
+	clientRate = ps.calculateRateLimit(clientRate)
+
+	fmt.Fprintf(w, strconv.Itoa(clientRate))
+}
+
+// checkHandler use to check the server status.
+// TODO: Disassemble this function for too many things done.
+func (ps *peerServer) checkHandler(w http.ResponseWriter, r *http.Request) {
+	aliveQueue.Put(true)
+	sendSuccess(w)
+
+	// handle totalLimit
+	totalLimit, err := strconv.Atoi(r.Header.Get(config.StrTotalLimit))
+	if err == nil && totalLimit > 0 {
+		if ps.rateLimiter == nil {
+			ps.rateLimiter = util.NewRateLimiter(int32(totalLimit), 2)
+		} else {
+			ps.rateLimiter.SetRate(util.TransRate(totalLimit))
+		}
+		ps.totalLimitRate = totalLimit
+		logrus.Infof("update total limit to %d", totalLimit)
+	}
+
+	// get parameters
+	taskFileName := mux.Vars(r)["commonFile"]
+	dataDir := r.Header.Get(config.StrDataDir)
+
+	param := &taskConfig{
+		dataDir: dataDir,
+	}
+	ps.syncTaskMap.Store(taskFileName, param)
+	fmt.Fprintf(w, "%s@%s", taskFileName, version.DFGetVersion)
+}
+
+// oneFinishHandler use to update the status of peer task.
+func (ps *peerServer) oneFinishHandler(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		sendHeader(w, http.StatusBadRequest)
+		fmt.Fprintf(w, err.Error())
+		return
+	}
+
+	taskFileName := r.FormValue(config.StrTaskFileName)
+	taskID := r.FormValue(config.StrTaskID)
+	cid := r.FormValue(config.StrClientID)
+	superNode := r.FormValue(config.StrSuperNode)
+	if v, ok := ps.syncTaskMap.Load(taskFileName); ok {
+		task := v.(*taskConfig)
+		task.taskID = taskID
+		task.cid = cid
+		task.superNode = superNode
+		task.finished = true
+	}
+	sendSuccess(w)
+	fmt.Fprintf(w, "success")
+}
+
+func (ps *peerServer) pingHandler(w http.ResponseWriter, r *http.Request) {
+	sendSuccess(w)
+	fmt.Fprintf(w, "success")
+}
+
+// ----------------------------------------------------------------------------
+// handler process
+
+// getTaskFile find the file2000 and return the File object.
+func (ps *peerServer) getTaskFile(taskFileName string) (*os.File, int64, error) {
+	errSize := int64(-1)
+
+	v, ok := ps.syncTaskMap.Load(taskFileName)
+	if !ok {
+		return nil, errSize, fmt.Errorf("failed to get taskPath: %s", taskFileName)
+	}
+	tc, ok := v.(*taskConfig)
+	if !ok {
+		return nil, errSize, fmt.Errorf("failed to assert: %s", taskFileName)
+	}
+
+	taskPath := helper.GetServiceFile(taskFileName, tc.dataDir)
+
+	fileInfo, err := os.Stat(taskPath)
+	if err != nil {
+		return nil, errSize, err
+	}
+
+	taskFile, err := os.Open(taskPath)
+	if err != nil {
+		return nil, errSize, err
+	}
+	return taskFile, fileInfo.Size(), nil
+}
+
+func amendRange(size int64, needPad bool, up *uploadParam) error {
+	up.padSize = 0
+	if needPad {
+		up.padSize = config.PieceMetaSize
+		up.start -= up.pieceNum * up.padSize
+	}
+
+	// we must send an whole piece with both piece head and tail
+	if up.length < up.padSize || up.start < 0 {
+		return errors.ErrRangeNotSatisfiable
+	}
+
+	if up.start >= size && !needPad {
+		return errors.ErrRangeNotSatisfiable
+	}
+
+	if up.start+up.length-up.padSize > size {
+		up.length = size - up.start + up.padSize
+		if size == 0 {
+			up.length = up.padSize
+		}
+	}
+
+	return nil
+}
+
+// parseParams validates the parameter range and parses it
+func parseParams(rangeVal, pieceNumStr, pieceSizeStr string) (*uploadParam, error) {
+	var (
+		err error
+		up  = &uploadParam{}
+	)
+
+	if up.pieceNum, err = strconv.ParseInt(pieceNumStr, 10, 64); err != nil {
+		return nil, err
+	}
+
+	if up.pieceSize, err = strconv.ParseInt(pieceSizeStr, 10, 64); err != nil {
+		return nil, err
+	}
+
+	if strings.Count(rangeVal, "=") != 1 {
+		return nil, fmt.Errorf("invaild range: %s", rangeVal)
+	}
+	rangeStr := strings.Split(rangeVal, "=")[1]
+
+	if strings.Count(rangeStr, "-") != 1 {
+		return nil, fmt.Errorf("invaild range: %s", rangeStr)
+	}
+	rangeArr := strings.Split(rangeStr, "-")
+	if up.start, err = strconv.ParseInt(rangeArr[0], 10, 64); err != nil {
+		return nil, err
+	}
+
+	var end int64
+	if end, err = strconv.ParseInt(rangeArr[1], 10, 64); err != nil {
+		return nil, err
+	}
+
+	if end <= up.start {
+		return nil, fmt.Errorf("invalid range: %s", rangeStr)
+	}
+	up.length = end - up.start + 1
+	return up, nil
+}
+
+// uploadPiece send a piece of the file to the remote peer.
+func (ps *peerServer) uploadPiece(f *os.File, w http.ResponseWriter, up *uploadParam) (e error) {
+	w.Header().Set(config.StrContentLength, strconv.FormatInt(up.length, 10))
+	sendHeader(w, http.StatusPartialContent)
+
+	readLen := up.length - up.padSize
+	buf := make([]byte, 256*1024)
+
+	if up.padSize > 0 {
+		binary.BigEndian.PutUint32(buf, uint32((readLen)|(up.pieceSize)<<4))
+		w.Write(buf[:config.PieceHeadSize])
+		defer w.Write([]byte{config.PieceTailChar})
+	}
+
+	f.Seek(up.start, 0)
+	r := io.LimitReader(f, readLen)
+	if ps.rateLimiter != nil {
+		lr := util.NewLimitReaderWithLimiter(ps.rateLimiter, r, false)
+		_, e = io.CopyBuffer(w, lr, buf)
+	} else {
+		_, e = io.CopyBuffer(w, r, buf)
+	}
+
+	return
+}
+
+func (ps *peerServer) calculateRateLimit(clientRate int) int {
+	total := 0
+
+	// define a function that Range will call it sequentially
+	// for each key and value present in the map
+	f := func(key, value interface{}) bool {
+		if task, ok := value.(*taskConfig); ok {
+			total += task.rateLimit
+		}
+		return true
+	}
+	ps.syncTaskMap.Range(f)
+
+	// calculate the rate limit again according to totalLimit
+	if total > ps.totalLimitRate {
+		return (clientRate*ps.totalLimitRate + total - 1) / total
+	}
+	return clientRate
+}
+
+// ----------------------------------------------------------------------------
+// methods of peerServer
+
+func (ps *peerServer) shutdown() {
+	// tell supernode this peer node is down and delete related files.
+	p2p.syncTaskMap.Range(func(key, value interface{}) bool {
+		task, ok := value.(*taskConfig)
+		if ok {
+			p2p.api.ServiceDown(task.superNode, task.taskID, task.cid)
+			serviceFile := helper.GetServiceFile(key.(string), task.dataDir)
+			os.Remove(serviceFile)
+			logrus.Infof("shutdown, remove task id:%s file:%s",
+				task.taskID, serviceFile)
+		}
+		return true
+	})
+
+	c, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Minute))
+	ps.Shutdown(c)
+	cancel()
+	updateServicePortInMeta(ps.cfg.RV.MetaPath, 0)
+	logrus.Info("peer server is shutdown.")
+	close(ps.finished)
+}
+
+func (ps *peerServer) deleteExpiredFile(path string, info os.FileInfo,
+	expireTime time.Duration) bool {
+	taskName := helper.GetTaskName(info.Name())
+	if v, ok := ps.syncTaskMap.Load(taskName); ok {
+		task, ok := v.(*taskConfig)
+		if ok && !task.finished {
+			return false
+		}
+		if time.Now().Sub(info.ModTime()) > expireTime {
+			if ok {
+				ps.api.ServiceDown(task.superNode, task.taskID, task.cid)
+			}
+			os.Remove(path)
+			ps.syncTaskMap.Delete(taskName)
+			return true
+		}
+	} else {
+		os.Remove(path)
+		return true
+	}
+	return false
+}
+
+// ----------------------------------------------------------------------------
+// helper functions
+
+func sendSuccess(w http.ResponseWriter) {
+	sendHeader(w, http.StatusOK)
+}
+
+func sendHeader(w http.ResponseWriter, code int) {
+	w.Header().Set(config.StrContentType, ctype)
+	w.WriteHeader(code)
+}
+
+func rangeErrorResponse(w http.ResponseWriter, err error) {
+	if errors.IsRangeNotSatisfiable(err) {
+		http.Error(w, config.RangeNotSatisfiableDesc, http.StatusRequestedRangeNotSatisfiable)
+	} else if os.IsPermission(err) {
+		http.Error(w, err.Error(), http.StatusForbidden)
+	} else if os.IsNotExist(err) {
+		http.Error(w, err.Error(), http.StatusNotFound)
+	} else {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func jsonStr(v interface{}) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}

--- a/dfget/core/uploader/peer_server_test.go
+++ b/dfget/core/uploader/peer_server_test.go
@@ -1,0 +1,381 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uploader
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+
+	"github.com/dragonflyoss/Dragonfly/dfget/config"
+	"github.com/dragonflyoss/Dragonfly/dfget/core/helper"
+	"github.com/dragonflyoss/Dragonfly/dfget/errors"
+	"github.com/go-check/check"
+)
+
+func init() {
+	check.Suite(&PeerServerTestSuite{})
+}
+
+var (
+	commonFile        = "commonFile"
+	commonFileContent = "hello File"
+
+	file2000        = "file2000"
+	file2000Content = helper.CreateRandomString(2000)
+
+	emptyFile = "emptyFile"
+)
+
+type PeerServerTestSuite struct {
+	workHome    string
+	servicePath string
+}
+
+func (s *PeerServerTestSuite) SetUpSuite(c *check.C) {
+	s.workHome, _ = ioutil.TempDir("/tmp", "dfget-PeerServerTestSuite-")
+	newTestPeerServer(s.workHome)
+	initHelper(commonFile, s.workHome, commonFileContent)
+	initHelper(file2000, s.workHome, file2000Content)
+	initHelper(emptyFile, s.workHome, "")
+}
+
+func (s *PeerServerTestSuite) TearDownSuite(c *check.C) {
+	if s.workHome != "" {
+		if err := os.RemoveAll(s.workHome); err != nil {
+			fmt.Printf("remove path:%s error", s.workHome)
+		}
+	}
+}
+
+func (s *PeerServerTestSuite) TestGetTaskFile(c *check.C) {
+	// normal test
+	f, _, err := p2p.getTaskFile(commonFile)
+	defer f.Close()
+	// check get file correctly
+	c.Assert(err, check.IsNil)
+	c.Assert(f, check.NotNil)
+	// check read file correctly
+	result, err := ioutil.ReadAll(f)
+	c.Assert(err, check.IsNil)
+	c.Assert(string(result), check.Equals, commonFileContent)
+}
+
+func (s *PeerServerTestSuite) TestUploadPiece(c *check.C) {
+	f, size, _ := p2p.getTaskFile(commonFile)
+	defer f.Close()
+
+	var up = func(start, length int64, pad bool) *uploadParam {
+		up := &uploadParam{
+			start:     start,
+			length:    length,
+			pieceNum:  0,
+			pieceSize: defaultPieceSize,
+		}
+		amendRange(size, pad, up)
+		return up
+	}
+
+	var cases = []struct {
+		start    int64
+		end      int64
+		pad      bool
+		expected string
+	}{
+		// normal test when start offset equals zero
+		{0, 10, false, commonFileContent},
+		// normal test when start offset not equals zero
+		{1, 5, false, commonFileContent[1:6]},
+		// range length more than file data test
+		{0, 20, false, commonFileContent},
+		// range length less than file data test
+		{0, 5, false, commonFileContent[:6]},
+		// with piece meta data
+		{0, 5, true, commonFileContent[:1]},
+		{0, 4, true, ""},
+		{0, 15, true, commonFileContent},
+	}
+
+	for _, v := range cases {
+		rr := httptest.NewRecorder()
+		p := up(v.start, v.end-v.start+1, v.pad)
+		err := p2p.uploadPiece(f, rr, p)
+		c.Check(err, check.IsNil)
+		cmt := check.Commentf("content:'%s' start:%d end:%d pad:%v",
+			commonFileContent, v.start, v.end, v.pad)
+		if v.pad {
+			c.Check(rr.Body.String(), check.DeepEquals,
+				pieceContent(p.pieceSize, v.expected), cmt)
+		} else {
+			c.Check(rr.Body.String(), check.Equals, v.expected, cmt)
+		}
+	}
+}
+
+func (s *PeerServerTestSuite) TestAmendRange(c *check.C) {
+	var p = func() *uploadParamBuilder {
+		return &uploadParamBuilder{
+			up: uploadParam{
+				padSize:  config.PieceMetaSize,
+				start:    0,
+				length:   5,
+				pieceNum: 0,
+			},
+		}
+	}
+	var f = func() *uploadParamBuilder { return p().padSize(0) }
+
+	var cases = []struct {
+		size        int64
+		needPad     bool
+		up          *uploadParam
+		expected    *uploadParam
+		expectedErr bool
+	}{
+		{
+			size:     10,
+			up:       p().build(),
+			expected: f().build(),
+		},
+		{
+			size:     10,
+			up:       p().length(11).build(),
+			expected: f().length(10).build(),
+		},
+		{
+			size:        10,
+			up:          p().length(-1).build(),
+			expectedErr: true,
+		},
+		{
+			size:        10,
+			up:          p().start(-1).build(),
+			expectedErr: true,
+		},
+
+		{
+			size:     10,
+			needPad:  true,
+			up:       p().build(),
+			expected: p().build(),
+		},
+		{
+			size:     10,
+			needPad:  true,
+			up:       p().start(5).pieceNum(1).build(),
+			expected: p().pieceNum(1).build(),
+		},
+		{
+			size:        10,
+			needPad:     true,
+			up:          p().pieceNum(1).build(),
+			expectedErr: true,
+		},
+		{
+			size:     0,
+			needPad:  true,
+			up:       p().build(),
+			expected: p().build(),
+		},
+	}
+
+	for _, v := range cases {
+		err := amendRange(v.size, v.needPad, v.up)
+		if v.expectedErr {
+			c.Assert(err, check.Equals, errors.ErrRangeNotSatisfiable)
+		} else {
+			c.Assert(err, check.IsNil)
+			c.Assert(v.up, check.DeepEquals, v.expected)
+		}
+	}
+}
+
+func (s *PeerServerTestSuite) TestParseParams(c *check.C) {
+	uh := defaultUploadHeader
+
+	tests := []struct {
+		name    string
+		header  uploadHeader
+		want    *uploadParam
+		wantErr bool
+	}{
+		{
+			name:   "normalTest",
+			header: uh.newRange("0-65575"),
+			want: &uploadParam{
+				start:     0,
+				length:    65576,
+				pieceSize: defaultPieceSize,
+			},
+			wantErr: false,
+		},
+		{
+			name:    "MultiDashesTest",
+			header:  uh.newRange("0-65-575"),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "NotIntTest",
+			header:  uh.newRange("0-hello"),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "EndLessStartTest",
+			header:  uh.newRange("65575-0"),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "NegativeStartTest",
+			header:  uh.newRange("-1-8"),
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		h := tt.header
+		got, err := parseParams(h.rangeStr, h.num, h.size)
+		if tt.wantErr {
+			c.Check(err, check.NotNil)
+		} else {
+			c.Check(err, check.IsNil)
+		}
+		c.Check(got, check.DeepEquals, tt.want,
+			check.Commentf("%s:%v", tt.name, tt.header))
+	}
+}
+
+// ----------------------------------------------------------------------------
+// test peerServer handlers
+
+func (s *PeerServerTestSuite) TestUploadHandler(c *check.C) {
+	headers := make(map[string]string)
+	headers[config.StrPieceSize] = defaultPieceSizeStr
+	headers[config.StrPieceNum] = "0"
+
+	// normal test
+	headers["range"] = "bytes=0-1999"
+	if rr, err := s.testHandlerHelper(&HandlerHelper{
+		method:  http.MethodGet,
+		url:     config.PeerHTTPPathPrefix + file2000,
+		headers: headers,
+	}); err == nil {
+		c.Check(rr.Code, check.Equals, http.StatusPartialContent)
+		c.Check(rr.Body.String(), check.Equals, pc(file2000Content[:1995]))
+
+		// TODO: limit read check
+	}
+
+	// RangeNotSatisfiable
+	headers["range"] = "bytes=0-1"
+	if rr, err := s.testHandlerHelper(&HandlerHelper{
+		method:  http.MethodGet,
+		url:     config.PeerHTTPPathPrefix + emptyFile,
+		headers: headers,
+	}); err == nil {
+		c.Check(rr.Code, check.Equals, http.StatusRequestedRangeNotSatisfiable)
+	}
+
+	// not found test
+	if rr, err := s.testHandlerHelper(&HandlerHelper{
+		method:  http.MethodGet,
+		url:     config.PeerHTTPPathPrefix + "foo",
+		body:    nil,
+		headers: headers,
+	}); err == nil {
+		c.Check(rr.Code, check.Equals, http.StatusInternalServerError)
+	}
+
+	// bad request test
+	headers["range"] = "bytes=0-x"
+	if rr, err := s.testHandlerHelper(&HandlerHelper{
+		method:  http.MethodGet,
+		url:     config.PeerHTTPPathPrefix + file2000,
+		headers: headers,
+	}); err == nil {
+		c.Check(rr.Code, check.Equals, http.StatusBadRequest)
+	}
+}
+
+func (s *PeerServerTestSuite) TestParseRateHandler(c *check.C) {
+	headers := make(map[string]string)
+
+	// normal test
+	testRateLimit := 1000
+	headers["rateLimit"] = strconv.Itoa(testRateLimit)
+	if rr, err := s.testHandlerHelper(&HandlerHelper{
+		method:  http.MethodGet,
+		url:     config.LocalHTTPPathRate + file2000,
+		headers: headers,
+	}); err == nil {
+		c.Check(rr.Code, check.Equals, http.StatusOK)
+		limit := p2p.calculateRateLimit(testRateLimit)
+		c.Check(rr.Body.String(), check.Equals, strconv.Itoa(limit))
+	}
+
+	// totalLimitRate zero test
+	p2p.totalLimitRate = 0
+	if rr, err := s.testHandlerHelper(&HandlerHelper{
+		method:  http.MethodGet,
+		url:     config.LocalHTTPPathRate + file2000,
+		headers: headers,
+	}); err == nil {
+		c.Check(rr.Code, check.Equals, http.StatusOK)
+		c.Check(rr.Body.String(), check.Equals, strconv.Itoa(testRateLimit))
+	}
+	p2p.totalLimitRate = 1000
+
+	// wrong rateLimit test
+	headers["rateLimit"] = "foo"
+	if rr, err := s.testHandlerHelper(&HandlerHelper{
+		method:  http.MethodGet,
+		url:     config.LocalHTTPPathRate + file2000,
+		headers: headers,
+	}); err == nil {
+		c.Check(rr.Code, check.Equals, http.StatusBadRequest)
+	}
+}
+
+func (s *PeerServerTestSuite) testHandlerHelper(hh *HandlerHelper) (*httptest.ResponseRecorder, error) {
+	// Create a request to pass to our handler. We don't have any query parameters for now, so we'll
+	// pass 'nil' as the third parameter.
+	req, err := http.NewRequest(hh.method, hh.url, hh.body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set request headers.
+	for k, v := range hh.headers {
+		req.Header.Set(k, v)
+	}
+
+	// We create a ResponseRecorder
+	// (which satisfies http.ResponseWriter) to record the response.
+	rr := httptest.NewRecorder()
+
+	// Init a router.
+	r := p2p.initRouter()
+	r.ServeHTTP(rr, req)
+
+	return rr, nil
+}

--- a/dfget/core/uploader/uploader_test.go
+++ b/dfget/core/uploader/uploader_test.go
@@ -17,188 +17,52 @@
 package uploader
 
 import (
-	"bytes"
 	"fmt"
-	"io"
-	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
-	"os"
-	"strconv"
-
-	"github.com/dragonflyoss/Dragonfly/dfget/config"
-	"github.com/dragonflyoss/Dragonfly/dfget/core/helper"
-	"github.com/dragonflyoss/Dragonfly/dfget/util"
+	"testing"
+	"time"
 
 	"github.com/go-check/check"
 )
 
-var (
-	taskFile         = "taskfile"
-	emptyFile        = "emptyfile"
-	fileContent      = helper.CreateRandomString(2000)
-	defaultRateLimit = 1000
-)
-
-type HandlerHelper struct {
-	method  string
-	url     string
-	body    io.Reader
-	headers map[string]string
-}
-
-type UploaderTestSuite struct {
-	workHome string
+func Test(t *testing.T) {
+	check.TestingT(t)
 }
 
 func init() {
 	check.Suite(&UploaderTestSuite{})
 }
 
-func (u *UploaderTestSuite) SetUpSuite(c *check.C) {
-	u.workHome, _ = ioutil.TempDir("/tmp", "dfget-UploadTestSuite-")
-	newTestPeerServer(u.workHome)
-
-	initHelper(taskFile, u.workHome, fileContent)
-	initHelper(emptyFile, u.workHome, "")
+type UploaderTestSuite struct {
 }
 
-func (u *UploaderTestSuite) TearDownSuite(c *check.C) {
-	if u.workHome != "" {
-		if err := os.RemoveAll(u.workHome); err != nil {
-			fmt.Printf("remove path:%s error", u.workHome)
-		}
-	}
+func (s *UploaderTestSuite) TestIsRunning(c *check.C) {
+	p2p = nil
+	c.Assert(isRunning(), check.Equals, false)
+
+	p2p = &peerServer{finished: make(chan struct{})}
+	c.Assert(isRunning(), check.Equals, true)
+	close(p2p.finished)
+	c.Assert(isRunning(), check.Equals, false)
 	p2p = nil
 }
 
-func (u *UploaderTestSuite) TestUploadHandler(c *check.C) {
-	headers := make(map[string]string)
-	headers[config.StrPieceSize] = defaultPieceSizeStr
-	headers[config.StrPieceNum] = "0"
+func (s *UploaderTestSuite) TestWaitForShutdown(c *check.C) {
+	res := make(chan error)
 
-	// normal test
-	headers["range"] = "bytes=0-1999"
-	if rr, err := u.testHandlerHelper(&HandlerHelper{
-		method:  http.MethodGet,
-		url:     config.PeerHTTPPathPrefix + taskFile,
-		headers: headers,
-	}); err == nil {
-		c.Check(rr.Code, check.Equals, http.StatusPartialContent)
-		c.Check(rr.Body.String(), check.Equals, pc(fileContent[:1995]))
+	p2p = nil
+	e := waitForStartup(res)
+	c.Assert(e, check.NotNil)
 
-		// TODO: limit read check
-	}
+	p2p = &peerServer{finished: make(chan struct{})}
+	e = waitForStartup(res)
+	c.Assert(e, check.NotNil)
 
-	// RangeNotSatisfiable
-	headers["range"] = "bytes=0-1"
-	if rr, err := u.testHandlerHelper(&HandlerHelper{
-		method:  http.MethodGet,
-		url:     config.PeerHTTPPathPrefix + emptyFile,
-		headers: headers,
-	}); err == nil {
-		c.Check(rr.Code, check.Equals, http.StatusRequestedRangeNotSatisfiable)
-	}
+	time.AfterFunc(50*time.Millisecond, func() { res <- nil })
+	e = waitForStartup(res)
+	c.Assert(e, check.IsNil)
 
-	// not found test
-	if rr, err := u.testHandlerHelper(&HandlerHelper{
-		method:  http.MethodGet,
-		url:     config.PeerHTTPPathPrefix + "foo",
-		body:    nil,
-		headers: headers,
-	}); err == nil {
-		c.Check(rr.Code, check.Equals, http.StatusInternalServerError)
-	}
-
-	// bad request test
-	headers["range"] = "bytes=0-x"
-	if rr, err := u.testHandlerHelper(&HandlerHelper{
-		method:  http.MethodGet,
-		url:     config.PeerHTTPPathPrefix + taskFile,
-		headers: headers,
-	}); err == nil {
-		c.Check(rr.Code, check.Equals, http.StatusBadRequest)
-	}
-}
-
-func (u *UploaderTestSuite) TestParseRateHandler(c *check.C) {
-	headers := make(map[string]string)
-
-	// normal test
-	testRateLimit := 1000
-	total := testRateLimit + defaultRateLimit
-	headers["rateLimit"] = strconv.Itoa(testRateLimit)
-	if rr, err := u.testHandlerHelper(&HandlerHelper{
-		method:  http.MethodGet,
-		url:     config.LocalHTTPPathRate + taskFile,
-		headers: headers,
-	}); err == nil {
-		c.Check(rr.Code, check.Equals, http.StatusOK)
-		limit := (testRateLimit*p2p.totalLimitRate + total - 1) / total
-		c.Check(rr.Body.String(), check.Equals, strconv.Itoa(limit))
-	}
-
-	// totalLimitRate zero test
-	p2p.totalLimitRate = 0
-	if rr, err := u.testHandlerHelper(&HandlerHelper{
-		method:  http.MethodGet,
-		url:     config.LocalHTTPPathRate + taskFile,
-		headers: headers,
-	}); err == nil {
-		c.Check(rr.Code, check.Equals, http.StatusOK)
-		c.Check(rr.Body.String(), check.Equals, strconv.Itoa(testRateLimit))
-	}
-	p2p.totalLimitRate = 1000
-
-	// wrong rateLimit test
-	headers["rateLimit"] = "foo"
-	if rr, err := u.testHandlerHelper(&HandlerHelper{
-		method:  http.MethodGet,
-		url:     config.LocalHTTPPathRate + taskFile,
-		headers: headers,
-	}); err == nil {
-		c.Check(rr.Code, check.Equals, http.StatusBadRequest)
-	}
-}
-
-func (u *UploaderTestSuite) testHandlerHelper(hh *HandlerHelper) (*httptest.ResponseRecorder, error) {
-	// Create a request to pass to our handler. We don't have any query parameters for now, so we'll
-	// pass 'nil' as the third parameter.
-	req, err := http.NewRequest(hh.method, hh.url, hh.body)
-	if err != nil {
-		return nil, err
-	}
-
-	// Set request headers.
-	for k, v := range hh.headers {
-		req.Header.Set(k, v)
-	}
-
-	// We create a ResponseRecorder
-	// (which satisfies http.ResponseWriter) to record the response.
-	rr := httptest.NewRecorder()
-
-	// Init a router.
-	r := p2p.initRouter()
-	r.ServeHTTP(rr, req)
-
-	return rr, nil
-}
-
-// newTestPeerServer init the peer server for testing.
-func newTestPeerServer(workHome string) {
-	buf := &bytes.Buffer{}
-	cfg := helper.CreateConfig(buf, workHome)
-	p2p = newPeerServer(cfg, 0)
-	p2p.totalLimitRate = 1000
-	p2p.rateLimiter = util.NewRateLimiter(int32(defaultRateLimit), 2)
-}
-
-// initHelper create a temporary file and store it in the syncTaskMap.
-func initHelper(fileName, workHome, content string) {
-	helper.CreateTestFile(helper.GetServiceFile(fileName, workHome), content)
-	p2p.syncTaskMap.Store(fileName, &taskConfig{
-		dataDir:   workHome,
-		rateLimit: defaultRateLimit,
-	})
+	time.AfterFunc(50*time.Millisecond, func() { res <- fmt.Errorf("test") })
+	e = waitForStartup(res)
+	c.Assert(e, check.NotNil)
+	c.Assert(e.Error(), check.Equals, "test")
 }

--- a/dfget/core/uploader/uploader_util.go
+++ b/dfget/core/uploader/uploader_util.go
@@ -17,165 +17,15 @@
 package uploader
 
 import (
-	"encoding/binary"
-	"fmt"
-	"io"
-	"net/http"
-	"os"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/dragonflyoss/Dragonfly/dfget/config"
 	"github.com/dragonflyoss/Dragonfly/dfget/core/api"
-	"github.com/dragonflyoss/Dragonfly/dfget/core/helper"
-	"github.com/dragonflyoss/Dragonfly/dfget/errors"
 	"github.com/dragonflyoss/Dragonfly/version"
-
-	"github.com/sirupsen/logrus"
 )
 
 // uploader helper
-
-// getTaskFile find the taskFile and return the File object.
-func (ps *peerServer) getTaskFile(taskFileName string) (*os.File, int64, error) {
-	errSize := int64(-1)
-
-	v, ok := ps.syncTaskMap.Load(taskFileName)
-	if !ok {
-		return nil, errSize, fmt.Errorf("failed to get taskPath: %s", taskFileName)
-	}
-	tc, ok := v.(*taskConfig)
-	if !ok {
-		return nil, errSize, fmt.Errorf("failed to assert: %s", taskFileName)
-	}
-
-	taskPath := helper.GetServiceFile(taskFileName, tc.dataDir)
-
-	fileInfo, err := os.Stat(taskPath)
-	if err != nil {
-		return nil, errSize, err
-	}
-
-	taskFile, err := os.Open(taskPath)
-	if err != nil {
-		return nil, errSize, err
-	}
-	return taskFile, fileInfo.Size(), nil
-}
-
-func amendRange(size int64, needPad bool, up *uploadParam) error {
-	if needPad {
-		up.padSize = config.PieceMetaSize
-		// we must send an whole piece with both piece head and tail
-		if up.length < up.padSize {
-			return errors.ErrRangeNotSatisfiable
-		}
-		up.start -= up.pieceNum * up.padSize
-		up.end = up.start + (up.length - up.padSize) - 1
-	}
-
-	if up.start >= size && !needPad {
-		return errors.ErrRangeNotSatisfiable
-	}
-
-	if up.end >= size {
-		up.end = size - 1
-		up.length = size - up.start + up.padSize
-		if size == 0 {
-			up.length = up.padSize
-		}
-	}
-
-	return nil
-}
-
-// parseParams validates the parameter range and parses it
-func parseParams(rangeVal, pieceNumStr, pieceSizeStr string) (*uploadParam, error) {
-	var (
-		err error
-		up  = &uploadParam{}
-	)
-
-	if up.pieceNum, err = strconv.ParseInt(pieceNumStr, 10, 64); err != nil {
-		return nil, err
-	}
-
-	if up.pieceSize, err = strconv.ParseInt(pieceSizeStr, 10, 64); err != nil {
-		return nil, err
-	}
-
-	if strings.Count(rangeVal, "=") != 1 {
-		return nil, fmt.Errorf("invaild range: %s", rangeVal)
-	}
-	rangeStr := strings.Split(rangeVal, "=")[1]
-
-	if strings.Count(rangeStr, "-") != 1 {
-		return nil, fmt.Errorf("invaild range: %s", rangeStr)
-	}
-	rangeArr := strings.Split(rangeStr, "-")
-	if up.start, err = strconv.ParseInt(rangeArr[0], 10, 64); err != nil {
-		return nil, err
-	}
-	if up.end, err = strconv.ParseInt(rangeArr[1], 10, 64); err != nil {
-		return nil, err
-	}
-
-	if up.end <= up.start {
-		return nil, fmt.Errorf("invalid range: %s", rangeStr)
-	}
-	up.length = up.end - up.start + 1
-	return up, nil
-}
-
-// uploadPiece send a piece of the file to the remote peer.
-func (ps *peerServer) uploadPiece(f *os.File, w http.ResponseWriter, up *uploadParam) error {
-	w.Header().Set(config.StrContentLength, strconv.FormatInt(up.length, 10))
-	sendHeader(w, http.StatusPartialContent)
-
-	f.Seek(up.start, 0)
-
-	remain := up.length - up.padSize
-	buf := make([]byte, 256*1024)
-
-	if up.padSize > 0 {
-		binary.BigEndian.PutUint32(buf, uint32((remain)|(up.pieceSize)<<4))
-		w.Write(buf[:config.PieceHeadSize])
-		defer w.Write([]byte{config.PieceTailChar})
-	}
-
-	for remain > 0 {
-		// read len(buf) of data
-		num, err := f.Read(buf)
-		if err != nil && err != io.EOF {
-			return err
-		}
-
-		if num == 0 {
-			logrus.Warnf("empty range:%s-%s of file:%s",
-				up.start, up.end, f.Name())
-			break
-		}
-
-		length := int64(num)
-		if length > remain {
-			length = remain
-		}
-
-		if ps.rateLimiter != nil {
-			ps.rateLimiter.AcquireBlocking(int32(length))
-		}
-
-		w.Write(buf[:length])
-		remain -= length
-
-		if num < len(buf) {
-			break
-		}
-	}
-
-	return nil
-}
 
 // LaunchPeerServer helper
 
@@ -192,8 +42,7 @@ func FinishTask(ip string, port int, taskFileName, cid, taskID, node string) err
 }
 
 // checkServer check if the server is available。
-func checkServer(ip string, port int, dataDir, taskFileName string, totalLimit int,
-	timeout time.Duration) (string, error) {
+func checkServer(ip string, port int, dataDir, taskFileName string, totalLimit int) (string, error) {
 
 	// prepare the request body
 	req := &api.CheckServerRequest{
@@ -228,4 +77,13 @@ func getPortFromMeta(metaPath string) int {
 		return 0
 	}
 	return meta.ServicePort
+}
+
+func updateServicePortInMeta(metaPath string, port int) {
+	meta := config.NewMetaData(metaPath)
+	meta.Load()
+	if meta.ServicePort != port {
+		meta.ServicePort = port
+		meta.Persist()
+	}
 }

--- a/dfget/core/uploader/uploader_util_test.go
+++ b/dfget/core/uploader/uploader_util_test.go
@@ -22,11 +22,8 @@ import (
 	"math/rand"
 	"net"
 	"net/http"
-	"net/http/httptest"
 	"os"
 	"path"
-	"testing"
-	"time"
 
 	"github.com/dragonflyoss/Dragonfly/dfget/config"
 	"github.com/dragonflyoss/Dragonfly/version"
@@ -35,214 +32,84 @@ import (
 	"github.com/gorilla/mux"
 )
 
-var (
-	taskFileName    = "testFile"
-	tempFileContent = "hello File"
-)
-
-func Test(t *testing.T) {
-	check.TestingT(t)
-}
-
-type UploadUtilTestSuite struct {
-	dataDir     string
-	servicePath string
-	host        string
-	ip          string
-	port        int
-	ln          net.Listener
-}
-
 func init() {
-	check.Suite(&UploadUtilTestSuite{})
+	check.Suite(&UploaderUtilTestSuite{})
 }
 
-func (s *UploadUtilTestSuite) SetUpSuite(c *check.C) {
-	s.dataDir, _ = ioutil.TempDir("/tmp", "dfget-UploadUtilTestSuite-")
-	newTestPeerServer(s.dataDir)
-	initHelper(taskFileName, s.dataDir, tempFileContent)
+type UploaderUtilTestSuite struct {
+	workHome string
+	host     string
+	ip       string
+	port     int
+	ln       net.Listener
+}
 
+func (s *UploaderUtilTestSuite) SetUpSuite(c *check.C) {
+	s.workHome, _ = ioutil.TempDir("/tmp", "dfget-UploaderUtilTestSuite-")
 	s.startTestServer()
 }
 
-func (s *UploadUtilTestSuite) TearDownSuite(c *check.C) {
+func (s *UploaderUtilTestSuite) TearDownSuite(c *check.C) {
 	s.ln.Close()
-
-	if s.dataDir != "" {
-		if err := os.RemoveAll(s.dataDir); err != nil {
-			fmt.Printf("remove path:%s error", s.dataDir)
+	if s.workHome != "" {
+		if err := os.RemoveAll(s.workHome); err != nil {
+			fmt.Printf("remove path:%s error", s.workHome)
 		}
 	}
 }
 
-func (s *UploadUtilTestSuite) TestGetTaskFile(c *check.C) {
-	// normal test
-	f, _, err := p2p.getTaskFile(taskFileName)
-	defer f.Close()
-	// check get file correctly
-	c.Assert(err, check.IsNil)
-	c.Assert(f, check.NotNil)
-	// check read file correctly
-	result, err := ioutil.ReadAll(f)
-	c.Assert(err, check.IsNil)
-	c.Assert(string(result), check.Equals, tempFileContent)
+func (s *UploaderUtilTestSuite) TestGeneratePort(c *check.C) {
+	port := generatePort(0)
+	c.Assert(port >= config.ServerPortLowerLimit, check.Equals, true)
+	c.Assert(port <= config.ServerPortUpperLimit, check.Equals, true)
 }
 
-func (s *UploadUtilTestSuite) TestUploadPiece(c *check.C) {
-	f, size, _ := p2p.getTaskFile(taskFileName)
-	defer f.Close()
+func (s *UploaderUtilTestSuite) TestGetPort(c *check.C) {
+	metaPath := path.Join(s.workHome, "meta")
+	port := getPortFromMeta(metaPath)
+	c.Assert(port, check.Equals, 0)
 
-	var up = func(start, end int64, pad bool) *uploadParam {
-		up := &uploadParam{
-			start:     start,
-			end:       end,
-			length:    end - start + 1,
-			pieceNum:  0,
-			pieceSize: defaultPieceSize,
-		}
-		amendRange(size, pad, up)
-		return up
-	}
-
-	var cases = []struct {
-		start    int64
-		end      int64
-		pad      bool
-		expected string
-	}{
-		// normal test when start offset equals zero
-		{0, 10, false, tempFileContent},
-		// normal test when start offset not equals zero
-		{1, 5, false, tempFileContent[1:6]},
-		// range length more than file data test
-		{0, 20, false, tempFileContent},
-		// range length less than file data test
-		{0, 5, false, tempFileContent[:6]},
-		// with piece meta data
-		{0, 5, true, tempFileContent[:1]},
-		{0, 4, true, ""},
-		{0, 15, true, tempFileContent},
-	}
-
-	for _, v := range cases {
-		rr := httptest.NewRecorder()
-		p := up(v.start, v.end, v.pad)
-		err := p2p.uploadPiece(f, rr, p)
-		c.Check(err, check.IsNil)
-		cmt := check.Commentf("content:'%s' start:%d end:%d pad:%v",
-			tempFileContent, v.start, v.end, v.pad)
-		if v.pad {
-			c.Check(rr.Body.String(), check.DeepEquals,
-				pieceContent(p.pieceSize, v.expected), cmt)
-		} else {
-			c.Check(rr.Body.String(), check.Equals, v.expected, cmt)
-		}
-	}
-}
-
-func (s *UploadUtilTestSuite) TestAmendRange(c *check.C) {
-
-}
-
-func (s *UploadUtilTestSuite) TestCheckServer(c *check.C) {
-	// normal test
-	result, err := checkServer(s.ip, s.port, s.dataDir, taskFileName, 0, 10*time.Millisecond)
-	c.Check(err, check.IsNil)
-	c.Check(result, check.Equals, taskFileName)
-
-	// timeout equals zero test
-	result, err = checkServer(s.ip, s.port, s.dataDir, taskFileName, 0, 0)
-	c.Check(err, check.IsNil)
-	c.Check(result, check.Equals, taskFileName)
-
-	// error url test
-	result, err = checkServer(s.ip+"1", s.port, s.dataDir, taskFileName, 0, 0)
-	c.Check(err, check.NotNil)
-	c.Check(result, check.Equals, "")
-}
-
-func (s *UploadUtilTestSuite) TestParseParams(c *check.C) {
-	uh := defaultUploadHeader
-
-	tests := []struct {
-		name    string
-		header  uploadHeader
-		want    *uploadParam
-		wantErr bool
-	}{
-		{
-			name:   "normalTest",
-			header: uh.newRange("0-65575"),
-			want: &uploadParam{
-				start:     0,
-				end:       65575,
-				length:    65576,
-				pieceSize: defaultPieceSize,
-			},
-			wantErr: false,
-		},
-		{
-			name:    "MultiDashesTest",
-			header:  uh.newRange("0-65-575"),
-			want:    nil,
-			wantErr: true,
-		},
-		{
-			name:    "NotIntTest",
-			header:  uh.newRange("0-hello"),
-			want:    nil,
-			wantErr: true,
-		},
-		{
-			name:    "EndLessStartTest",
-			header:  uh.newRange("65575-0"),
-			want:    nil,
-			wantErr: true,
-		},
-		{
-			name:    "NegativeStartTest",
-			header:  uh.newRange("-1-8"),
-			want:    nil,
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		h := tt.header
-		got, err := parseParams(h.rangeStr, h.num, h.size)
-		if tt.wantErr {
-			c.Check(err, check.NotNil)
-		} else {
-			c.Check(err, check.IsNil)
-		}
-		c.Check(got, check.DeepEquals, tt.want,
-			check.Commentf("%s:%v", tt.name, tt.header))
-	}
-}
-
-func (s *UploadUtilTestSuite) TestGetPort(c *check.C) {
 	servicePort := 8080
-	metaPath := path.Join(s.dataDir, "meta")
 	meta := config.NewMetaData(metaPath)
 	meta.ServicePort = servicePort
 	err := meta.Persist()
 	c.Check(err, check.IsNil)
 
-	port := getPortFromMeta(metaPath)
-	c.Check(port, check.Equals, servicePort)
+	port = getPortFromMeta(metaPath)
+	c.Assert(port, check.Equals, servicePort)
 }
 
-func (s *UploadUtilTestSuite) startTestServer() {
+func (s *UploaderUtilTestSuite) TestCheckServer(c *check.C) {
+	// normal test
+	result, err := checkServer(s.ip, s.port, s.workHome, commonFile, 0)
+	c.Check(err, check.IsNil)
+	c.Check(result, check.Equals, commonFile)
+
+	// error url test
+	result, err = checkServer(s.ip+"1", s.port, s.workHome, commonFile, 0)
+	c.Check(err, check.NotNil)
+	c.Check(result, check.Equals, "")
+}
+
+func (s *UploaderUtilTestSuite) TestUpdateServicePortInMeta(c *check.C) {
+	expectedPort := 80
+	metaPath := path.Join(s.workHome, "meta")
+	updateServicePortInMeta(metaPath, expectedPort)
+	port := getPortFromMeta(metaPath)
+	c.Assert(port, check.Equals, expectedPort)
+}
+
+func (s *UploaderUtilTestSuite) startTestServer() {
 	// run a server
 	s.ip = "127.0.0.1"
 	s.port = rand.Intn(1000) + 63000
 	s.host = fmt.Sprintf("%s:%d", s.ip, s.port)
 	s.ln, _ = net.Listen("tcp", s.host)
 	checkHandler := func(w http.ResponseWriter, r *http.Request) {
-		fileName := mux.Vars(r)["taskFileName"]
+		fileName := mux.Vars(r)["commonFile"]
 		fmt.Fprintf(w, "%s@%s", fileName, version.DFGetVersion)
 	}
 	r := mux.NewRouter()
-	r.HandleFunc(config.LocalHTTPPathCheck+"{taskFileName:.*}", checkHandler).Methods("GET")
+	r.HandleFunc(config.LocalHTTPPathCheck+"{commonFile:.*}", checkHandler).Methods("GET")
 	go http.Serve(s.ln, r)
 }

--- a/dfget/util/limit_reader.go
+++ b/dfget/util/limit_reader.go
@@ -31,7 +31,7 @@ func NewLimitReader(src io.Reader, rate int, calculateMd5 bool) *LimitReader {
 	return NewLimitReaderWithLimiter(limiter, src, calculateMd5)
 }
 
-// NewLimitReaderWithLimiter create LimitReader with a ratelimiter.
+// NewLimitReaderWithLimiter create LimitReader with a rateLimiter.
 // src: reader
 // rate: bytes/second
 func NewLimitReaderWithLimiter(rateLimiter *RateLimiter, src io.Reader, calculateMd5 bool) *LimitReader {


### PR DESCRIPTION
Signed-off-by: lowzj <zj3142063@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
When peer server passively exists, such as killed by people or other processes, it doesn't tell supernode that it has been down. So `supernode` will also schedules the down peer to other `dfget` who is downloading the same file. This will cause that downloading `dfget` failed to download from the down peer and retries to other peers serval times.

Here is some logs:
```
2019-02-03 13:57:52.228 DEBU sign:4456-1549173472.085 : pieces to be processed:[{"range":"0-4194303","pieceNum":0,"pieceSize":4194304,"pieceMd5":"6f4783b83c95b697da36ff912a6fa7bf:25681","cid":"127.0.0.1-3895-1549172876.386","peerIp":"127.0.0.1","peerPort":1234,"path":"/peer/file/b.test-3895-1549172876.386","downLink":20480}]
2019-02-03 13:57:52.229 DEBU sign:4456-1549173472.085 : client range:0-4194303 cost:0.000 from peer:127.0.0.1:1234, readCost:0.000, length:0
2019-02-03 13:57:52.229 ERRO sign:4456-1549173472.085 : read piece cont error:Get http://127.0.0.1:1234/peer/file/b.test-3895-1549172876.386: dial tcp 127.0.0.1:1234: connect: connection refused from dst:127.0.0.1:1234
2019-02-03 13:57:52.229 INFO sign:4456-1549173472.085 : downloading piece:{"taskID":"b4b0f175f7aef583ff6ff8da6b00024d7772b165caa66ff8ef3a9dce6701b690","superNode":"127.0.0.1","dstCid":"127.0.0.1-3895-1549172876.386","range":"0-4194303","result":500,"status":701,"pieceSize":0,"pieceNum":0}
2019-02-03 13:57:52.231 DEBU sign:4456-1549173472.085 : pieces to be processed:[{"range":"0-4194303","pieceNum":0,"pieceSize":4194304,"pieceMd5":"6f4783b83c95b697da36ff912a6fa7bf:25681","cid":"127.0.0.1-4051-1549172942.332","peerIp":"127.0.0.1","peerPort":1234,"path":"/peer/file/b.test-4051-1549172942.332","downLink":20480}]
2019-02-03 13:57:52.231 DEBU sign:4456-1549173472.085 : client range:0-4194303 cost:0.000 from peer:127.0.0.1:1234, readCost:0.000, length:0
2019-02-03 13:57:52.231 ERRO sign:4456-1549173472.085 : read piece cont error:Get http://127.0.0.1:1234/peer/file/b.test-4051-1549172942.332: dial tcp 127.0.0.1:1234: connect: connection refused from dst:127.0.0.1:1234
2019-02-03 13:57:52.231 INFO sign:4456-1549173472.085 : downloading piece:{"taskID":"b4b0f175f7aef583ff6ff8da6b00024d7772b165caa66ff8ef3a9dce6701b690","superNode":"127.0.0.1","dstCid":"127.0.0.1-4051-1549172942.332","range":"0-4194303","result":500,"status":701,"pieceSize":0,"pieceNum":0}
2019-02-03 13:57:52.234 DEBU sign:4456-1549173472.085 : pieces to be processed:[{"range":"0-4194303","pieceNum":0,"pieceSize":4194304,"pieceMd5":"6f4783b83c95b697da36ff912a6fa7bf:25681","cid":"127.0.0.1-4060-1549172943.094","peerIp":"127.0.0.1","peerPort":1234,"path":"/peer/file/b.test-4060-1549172943.094","downLink":20480}]
2019-02-03 13:57:52.234 DEBU sign:4456-1549173472.085 : client range:0-4194303 cost:0.000 from peer:127.0.0.1:1234, readCost:0.000, length:0
2019-02-03 13:57:52.234 ERRO sign:4456-1549173472.085 : read piece cont error:Get http://127.0.0.1:1234/peer/file/b.test-4060-1549172943.094: dial tcp 127.0.0.1:1234: connect: connection refused from dst:127.0.0.1:1234
2019-02-03 13:57:52.234 INFO sign:4456-1549173472.085 : downloading piece:{"taskID":"b4b0f175f7aef583ff6ff8da6b00024d7772b165caa66ff8ef3a9dce6701b690","superNode":"127.0.0.1","dstCid":"127.0.0.1-4060-1549172943.094","range":"0-4194303","result":500,"status":701,"pieceSize":0,"pieceNum":0}
2019-02-03 13:57:52.236 DEBU sign:4456-1549173472.085 : pieces to be processed:[{"range":"0-4194303","pieceNum":0,"pieceSize":4194304,"pieceMd5":"6f4783b83c95b697da36ff912a6fa7bf:25681","cid":"127.0.0.1-4069-1549172943.886","peerIp":"127.0.0.1","peerPort":1234,"path":"/peer/file/b.test-4069-1549172943.886","downLink":20480}]
2019-02-03 13:57:52.237 DEBU sign:4456-1549173472.085 : client range:0-4194303 cost:0.000 from peer:127.0.0.1:1234, readCost:0.000, length:0
2019-02-03 13:57:52.237 ERRO sign:4456-1549173472.085 : read piece cont error:Get http://127.0.0.1:1234/peer/file/b.test-4069-1549172943.886: dial tcp 127.0.0.1:1234: connect: connection refused from dst:127.0.0.1:1234
2019-02-03 13:57:52.237 INFO sign:4456-1549173472.085 : downloading piece:{"taskID":"b4b0f175f7aef583ff6ff8da6b00024d7772b165caa66ff8ef3a9dce6701b690","superNode":"127.0.0.1","dstCid":"127.0.0.1-4069-1549172943.886","range":"0-4194303","result":500,"status":701,"pieceSize":0,"pieceNum":0}
2019-02-03 13:57:52.239 DEBU sign:4456-1549173472.085 : pieces to be processed:[{"range":"0-4194303","pieceNum":0,"pieceSize":4194304,"pieceMd5":"6f4783b83c95b697da36ff912a6fa7bf:25681","cid":"127.0.0.1-4033-1549172940.356","peerIp":"127.0.0.1","peerPort":1234,"path":"/peer/file/b.test-4033-1549172940.356","downLink":20480}]
2019-02-03 13:57:52.239 DEBU sign:4456-1549173472.085 : client range:0-4194303 cost:0.000 from peer:127.0.0.1:1234, readCost:0.000, length:0
2019-02-03 13:57:52.239 ERRO sign:4456-1549173472.085 : read piece cont error:Get http://127.0.0.1:1234/peer/file/b.test-4033-1549172940.356: dial tcp 127.0.0.1:1234: connect: connection refused from dst:127.0.0.1:1234
2019-02-03 13:57:52.239 INFO sign:4456-1549173472.085 : downloading piece:{"taskID":"b4b0f175f7aef583ff6ff8da6b00024d7772b165caa66ff8ef3a9dce6701b690","superNode":"127.0.0.1","dstCid":"127.0.0.1-4033-1549172940.356","range":"0-4194303","result":500,"status":701,"pieceSize":0,"pieceNum":0}
2019-02-03 13:57:52.242 DEBU sign:4456-1549173472.085 : pieces to be processed:[{"range":"0-4194303","pieceNum":0,"pieceSize":4194304,"pieceMd5":"6f4783b83c95b697da36ff912a6fa7bf:25681","cid":"cdnnode:127.0.0.1~b4b0f175f7aef583ff6ff8da6b00024d7772b165caa66ff8ef3a9dce6701b690","peerIp":"127.0.0.1","peerPort":8001,"path":"/qtdown/b4b/b4b0f175f7aef583ff6ff8da6b00024d7772b165caa66ff8ef3a9dce6701b690","downLink":20480}]
2019-02-03 13:57:52.244 DEBU sign:4456-1549173472.085 : client range:0-4194303 cost:0.002 from peer:127.0.0.1:8001, readCost:0.002, length:25681
```

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


