### PR TITLE
feature: add trust hosts params for dfdaemon

### DIFF
--- a/cmd/dfdaemon/app/options/options.go
+++ b/cmd/dfdaemon/app/options/options.go
@@ -74,6 +74,10 @@ type Options struct {
 
 	// Key file path.
 	KeyFile string
+
+	// TrustHosts includes the trusted hosts which dfdaemon forward their
+	// requests directly when dfdaemon is used to http_proxy mode.
+	TrustHosts []string
 }
 
 // NewOption returns the default options.
@@ -115,5 +119,5 @@ func (o *Options) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&o.Registry, "registry", "https://index.docker.io", "registry addr(https://abc.xx.x or http://abc.xx.x) and must exist if dfdaemon is used to mirror mode")
 	fs.StringVar(&o.DownRule, "rule", "", "download the url by P2P if url matches the specified pattern,format:reg1,reg2,reg3")
 	fs.BoolVar(&o.Notbs, "notbs", true, "not try back source to download if throw exception")
-
+	fs.StringSliceVar(&o.TrustHosts, "trust-hosts", o.TrustHosts, "list of trusted hosts which dfdaemon forward their requests directly, comma separated.")
 }

--- a/dfdaemon/global/global.go
+++ b/dfdaemon/global/global.go
@@ -51,6 +51,10 @@ type CommandParam struct {
 	// Registry addr and must exist if dfdaemon is used to mirror mode,
 	// format: https://xxx.xx.x:port or http://xxx.xx.x:port.
 	Registry string
+
+	// TrustHosts includes the trusted hosts as keys of the map which dfdaemon forward their
+	// requests directly when dfdaemon is used to http_proxy mode.
+	TrustHosts map[string]string
 }
 
 var (

--- a/dfdaemon/initializer/initializer.go
+++ b/dfdaemon/initializer/initializer.go
@@ -229,6 +229,13 @@ func initParam(options *options.Options) {
 		}
 	}
 
+	parsedTrustHosts := make(map[string]string)
+	for _, trustHost := range options.TrustHosts {
+		if _, ok := parsedTrustHosts[trustHost]; !ok {
+			parsedTrustHosts[trustHost] = trustHost
+		}
+	}
+
 	// copy options to g.CommandLine so we do not break anything, but finally
 	// we should get rid of g.CommandLine totally.
 	g.CommandLine = global.CommandParam{
@@ -240,5 +247,6 @@ func initParam(options *options.Options) {
 		Notbs:      options.Notbs,
 		HostIP:     options.HostIP,
 		Registry:   options.Registry,
+		TrustHosts: parsedTrustHosts,
 	}
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

As dfdaemon be used to http_proxy mode, all the requests with host
are not local ip of dfdaemon then client will got a 403 error code.

Add a trust-hosts command line params and determine the request wether
be trusted or not, if it's trusted we directly forward them.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

Related to issue:
https://github.com/dragonflyoss/Dragonfly/issues/385

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

None

### Ⅳ. Describe how to verify it

1. `./dfdaemon --trust-hosts repo.image.local,ui.repo.image.local,t1.repo.image.local`

2. inscure-registry be configured` ["repo.image.local","ui.repo.image.local","t1.repo.image.local", "t2.repo.image.local"]`

3. docker.service file be configured `Environment="HTTP_PROXY=http://127.0.0.1:65001"`

4. docker pull repo.image.local/nginx which download image successfully

5. docker pull t2.repo.image.local/nginx which not in the `--trust-hosts` 403 error be raised.

--






### Ⅴ. Special notes for reviews


/cc @allencloud  @lowzj  
