### PR TITLE
feature: add 'docs' target in Makefile to generate API/CLI docs easily

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,3 +61,8 @@ check:
 	@echo "Begin to check supernode code formats."
 	./hack/check-supernode.sh
 .PHONY: check
+
+docs:
+	@echo "Begin to generate docs of API/CLI"
+	./hack/generate-docs.sh
+.PHONY: docs

--- a/hack/build-client.sh
+++ b/hack/build-client.sh
@@ -3,17 +3,16 @@ DFDAEMON_BINARY_NAME=dfdaemon
 DFGET_BINARY_NAME=dfget
 PKG=github.com/dragonflyoss/Dragonfly
 BUILD_IMAGE=golang:1.10.4
-GOARCH=$(go env GOARCH)
-GOOS=$(go env GOOS)
-BUILD=$(git rev-parse HEAD)
-BUILD_PATH=bin/${GOOS}_${GOARCH}
-USE_DOCKER=${USE_DOCKER:-"0"}
 
 curDir=$(cd "$(dirname "$0")" && pwd)
 cd "${curDir}" || return
 BUILD_SOURCE_HOME=$(cd ".." && pwd)
 
 . ./env.sh
+
+BUILD=$(git rev-parse HEAD)
+BUILD_PATH=bin/${GOOS}_${GOARCH}
+USE_DOCKER=${USE_DOCKER:-"0"}
 
 create-dirs() {
     cd "${BUILD_SOURCE_HOME}" || return

--- a/hack/generate-docs.sh
+++ b/hack/generate-docs.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+curDir=$(cd "$(dirname "$0")" && pwd)
+cd "${curDir}" || return
+
+. ./env.sh
+
+generate-cli-docs(){
+    BUILD_PATH=bin/${GOOS}_${GOARCH}
+    CLI_DOCS_DIR=$(cd "../docs/cli_reference" && pwd)
+    DFGET_BIN_PATH=../"${BUILD_PATH}"/dfget
+    DFDAEMON_BIN_PATH=../"${BUILD_PATH}"/dfdaemon
+
+    ${DFGET_BIN_PATH} gen-doc -p "${CLI_DOCS_DIR}" || return
+    ${DFDAEMON_BIN_PATH} gen-doc -p "${CLI_DOCS_DIR}" || return
+    echo "Generate: CLI docs in ${CLI_DOCS_DIR}" 
+}
+
+main () {
+    case "$1" in
+        cli)
+            generate-cli-docs
+        ;;
+        *)
+            generate-cli-docs
+        ;;  
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
Signed-off-by: fengzixu <hnustphoenix@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

1. add 'docs' target in Makefile to generate API/CLI docs easily.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixed: #375 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

just makefile

### Ⅳ. Describe how to verify it

I run the command as below:

```
make build
cd hack
./generate_docs.sh cli
./generate_docs.sh
```

```
make build
make docs
```

Thoes commands can help us generate CLI docs successfully.

### Ⅴ. Special notes for reviews


