### PR TITLE
docs: update dfget commandline description to rm trailing spaces

### DIFF
--- a/cmd/dfget/app/root.go
+++ b/cmd/dfget/app/root.go
@@ -43,12 +43,12 @@ var (
 var cfg = config.NewConfig()
 
 // dfgetDescription is used to describe dfget command in details.
-var dfgetDescription = `dfget is the client of Dragonfly which takes a role of 
-peer in a P2P network. When user triggers a file downloading task, dfget will 
-download the pieces of file from other peers. Meanwhile, it will act as an 
-uploader to support other peers to download pieces from it if it owns them. 
-In addition, dfget has the abilities to provide more advanced functionality, 
-such as network bandwidth limit, transmission encryption and so on.`
+var dfgetDescription = `dfget is the client of Dragonfly which takes a role of peer in a P2P network.
+When user triggers a file downloading task, dfget will download the pieces of
+file from other peers. Meanwhile, it will act as an uploader to support other
+peers to download pieces from it if it owns them. In addition, dfget has the
+abilities to provide more advanced functionality, such as network bandwidth
+limit, transmission encryption and so on.`
 
 var rootCmd = &cobra.Command{
 	Use:               "dfget",


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

update dfget commandline description to rm trailing spaces

I try to make every line of document are less than 80 chars.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
none

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
no need


### Ⅳ. Describe how to verify it
none

### Ⅴ. Special notes for reviews
none

