### PR TITLE
refactor: refactor and add unit-test for peer_server_executor.go

### DIFF
--- a/dfget/core/core_test.go
+++ b/dfget/core/core_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/dragonflyoss/Dragonfly/dfget/config"
 	. "github.com/dragonflyoss/Dragonfly/dfget/core/helper"
 	"github.com/dragonflyoss/Dragonfly/dfget/core/regist"
+	"github.com/dragonflyoss/Dragonfly/dfget/core/uploader"
 	"github.com/dragonflyoss/Dragonfly/dfget/util"
 
 	"github.com/go-check/check"
@@ -91,8 +92,8 @@ func (s *CoreTestSuite) TestRegisterToSupernode(c *check.C) {
 	cfg.Pattern = config.PatternSource
 	f(config.BackSourceReasonUserSpecified, true, nil)
 
+	uploader.SetupPeerServerExecutor(nil)
 	cfg.Pattern = config.PatternP2P
-
 	cfg.Node = []string{"x"}
 	cfg.URL = "http://x.com"
 	f(config.BackSourceReasonRegisterFail, true, nil)

--- a/dfget/core/helper/test_helper.go
+++ b/dfget/core/helper/test_helper.go
@@ -39,6 +39,8 @@ func CreateConfig(writer io.Writer, workHome string) *config.Config {
 	cfg.WorkHome = workHome
 	cfg.RV.MetaPath = path.Join(cfg.WorkHome, "meta", "host.meta")
 	cfg.RV.SystemDataDir = path.Join(cfg.WorkHome, "data")
+	util.CreateDirectory(path.Dir(cfg.RV.MetaPath))
+	util.CreateDirectory(cfg.RV.SystemDataDir)
 
 	logrus.StandardLogger().Out = writer
 	return cfg

--- a/dfget/core/uploader/peer_server_executor.go
+++ b/dfget/core/uploader/peer_server_executor.go
@@ -1,0 +1,150 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uploader
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/dragonflyoss/Dragonfly/dfget/config"
+	"github.com/dragonflyoss/Dragonfly/version"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	defaultExecutor PeerServerExecutor = &peerServerExecutor{}
+)
+
+// SetupPeerServerExecutor setup a giving executor instance instead of default implementation.
+func SetupPeerServerExecutor(executor PeerServerExecutor) {
+	defaultExecutor = executor
+}
+
+// GetPeerServerExecutor returns the current executor instance.
+func GetPeerServerExecutor() PeerServerExecutor {
+	return defaultExecutor
+}
+
+// StartPeerServerProcess starts an independent peer server process for uploading downloaded files
+// if it doesn't exist.
+// This function is invoked when dfget starts to download files in p2p pattern.
+func StartPeerServerProcess(cfg *config.Config) (port int, err error) {
+	if defaultExecutor != nil {
+		return defaultExecutor.StartPeerServerProcess(cfg)
+	}
+	return 0, fmt.Errorf("executor of peer server isn't be initiliazed")
+}
+
+// PeerServerExecutor starts an independent peer server process for uploading downloaded files.
+type PeerServerExecutor interface {
+	StartPeerServerProcess(cfg *config.Config) (port int, err error)
+}
+
+// ---------------------------------------------------------------------------
+// PeerServerExecutor default implementation
+
+type peerServerExecutor struct {
+}
+
+func (pe *peerServerExecutor) StartPeerServerProcess(cfg *config.Config) (port int, err error) {
+	if port = pe.checkPeerServerExist(cfg, 0); port > 0 {
+		return port, nil
+	}
+
+	cmd := exec.Command(os.Args[0], "server",
+		"--ip", cfg.RV.LocalIP,
+		"--meta", cfg.RV.MetaPath,
+		"--data", cfg.RV.SystemDataDir,
+		"--expiretime", cfg.RV.DataExpireTime.String(),
+		"--alivetime", cfg.RV.ServerAliveTime.String())
+	if cfg.Verbose {
+		cmd.Args = append(cmd.Args, "--verbose")
+	}
+
+	var stdout io.ReadCloser
+	if stdout, err = cmd.StdoutPipe(); err != nil {
+		return 0, err
+	}
+	if err = cmd.Start(); err == nil {
+		port, err = pe.readPort(stdout)
+	}
+	if err == nil && pe.checkPeerServerExist(cfg, port) <= 0 {
+		err = fmt.Errorf("invalid server on port:%d", port)
+		port = 0
+	}
+
+	return
+}
+
+func (pe *peerServerExecutor) readPort(r io.Reader) (int, error) {
+	done := make(chan error)
+	var port int32
+
+	go func() {
+		var n = 0
+		var portValue = 0
+		var err error
+		buf := make([]byte, 256)
+
+		n, err = r.Read(buf)
+		if err != nil {
+			done <- err
+		}
+
+		content := strings.TrimSpace(string(buf[:n]))
+		portValue, err = strconv.Atoi(content)
+		// avoid data race
+		atomic.StoreInt32(&port, int32(portValue))
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		return int(atomic.LoadInt32(&port)), err
+	case <-time.After(time.Second):
+		return 0, fmt.Errorf("get peer server's port timeout")
+	}
+}
+
+// checkPeerServerExist checks the peer server on port whether is available.
+// if the parameter port <= 0, it will get port from meta file and checks.
+func (pe *peerServerExecutor) checkPeerServerExist(cfg *config.Config, port int) int {
+	taskFileName := cfg.RV.TaskFileName
+	if port <= 0 {
+		port = getPortFromMeta(cfg.RV.MetaPath)
+	}
+
+	// check the peer server whether is available
+	result, err := checkServer(cfg.RV.LocalIP, port, cfg.RV.DataDir, taskFileName, cfg.TotalLimit)
+	logrus.Infof("local http result:%s err:%v, port:%d path:%s",
+		result, err, port, config.LocalHTTPPathCheck)
+
+	if err == nil {
+		if result == taskFileName {
+			logrus.Infof("use peer server on port:%d", port)
+			return port
+		}
+		logrus.Warnf("not found process on port:%d, version:%s", port, version.DFGetVersion)
+	}
+	return 0
+}

--- a/dfget/core/uploader/peer_server_executor_test.go
+++ b/dfget/core/uploader/peer_server_executor_test.go
@@ -1,0 +1,134 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uploader
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/dragonflyoss/Dragonfly/dfget/core/helper"
+	"github.com/dragonflyoss/Dragonfly/version"
+	"github.com/go-check/check"
+)
+
+func init() {
+	check.Suite(&PeerServerExecutorTestSuite{})
+}
+
+type PeerServerExecutorTestSuite struct {
+	workHome string
+	script   string
+
+	ip     string
+	port   int
+	server *http.Server
+}
+
+func (s *PeerServerExecutorTestSuite) SetUpSuite(c *check.C) {
+	s.workHome, _ = ioutil.TempDir("/tmp", "dfget-PeerServerTestSuite-")
+	s.script = path.Join(s.workHome, "script.sh")
+	s.writeScript("")
+	s.start()
+}
+
+func (s *PeerServerExecutorTestSuite) TearDownSuite(c *check.C) {
+	stopTestServer(s.server)
+	if s.workHome != "" {
+		os.RemoveAll(s.workHome)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// tests
+
+func (s *PeerServerExecutorTestSuite) TestSetupAndGetPeerServerExecutor(c *check.C) {
+	pe := GetPeerServerExecutor()
+	c.Assert(pe, check.NotNil)
+	_, ok := pe.(*peerServerExecutor)
+	c.Assert(ok, check.Equals, true)
+
+	SetupPeerServerExecutor(nil)
+	c.Assert(GetPeerServerExecutor(), check.IsNil)
+}
+
+func (s *PeerServerExecutorTestSuite) TestStartPeerServerProcess(c *check.C) {
+	cfg := helper.CreateConfig(nil, s.workHome)
+	cfg.RV.LocalIP = s.ip
+	os.Args[0] = s.script
+
+	SetupPeerServerExecutor(nil)
+	port, e := StartPeerServerProcess(cfg)
+	c.Assert(port, check.Equals, 0)
+	c.Assert(e, check.NotNil)
+
+	SetupPeerServerExecutor(&peerServerExecutor{})
+
+	// read pipe EOF
+	port, e = StartPeerServerProcess(cfg)
+	c.Assert(port, check.Equals, 0)
+	c.Assert(e, check.Equals, io.EOF)
+
+	// wait for reading pipe timeout
+	s.writeScript("sleep 2")
+	port, e = StartPeerServerProcess(cfg)
+	c.Assert(port, check.Equals, 0)
+	c.Assert(strings.Contains(e.Error(), "timeout"), check.Equals, true)
+
+	// invalid server
+	s.writeScript("echo 65555")
+	port, e = StartPeerServerProcess(cfg)
+	c.Assert(port, check.Equals, 0)
+	c.Assert(strings.Contains(e.Error(), "invalid server"), check.Equals, true)
+
+	// start a new server successfully
+	s.writeScript(fmt.Sprintf("echo %d", s.port))
+	port, e = StartPeerServerProcess(cfg)
+	c.Assert(port, check.Equals, s.port)
+	c.Assert(e, check.IsNil)
+
+	// use an existing server
+	s.writeScript("")
+	updateServicePortInMeta(cfg.RV.MetaPath, s.port)
+	port, e = StartPeerServerProcess(cfg)
+	c.Assert(port, check.Equals, s.port)
+	c.Assert(e, check.IsNil)
+}
+
+// ---------------------------------------------------------------------------
+// helper functions
+
+func (s *PeerServerExecutorTestSuite) start() {
+	var f http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
+		sendSuccess(w)
+		fmt.Fprint(w, "@"+version.DFGetVersion)
+	}
+	s.ip, s.port, s.server = startTestServer(f)
+}
+
+func (s *PeerServerExecutorTestSuite) writeScript(content string) {
+	buf := &bytes.Buffer{}
+	buf.WriteString("#!/bin/bash\n")
+	buf.WriteString(content)
+	buf.WriteString("\n")
+	ioutil.WriteFile(s.script, buf.Bytes(), os.ModePerm)
+}

--- a/dfget/core/uploader/uploader_helper_test.go
+++ b/dfget/core/uploader/uploader_helper_test.go
@@ -18,10 +18,14 @@ package uploader
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math/rand"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/dragonflyoss/Dragonfly/dfget/config"
 	"github.com/dragonflyoss/Dragonfly/dfget/core/helper"
@@ -64,6 +68,25 @@ func initHelper(fileName, workHome, content string) {
 		dataDir:   workHome,
 		rateLimit: defaultRateLimit,
 	})
+}
+
+func startTestServer(handler http.Handler) (ip string, port int, server *http.Server) {
+	// run a server
+	ip = "127.0.0.1"
+	port = rand.Intn(1000) + 63000
+	server = &http.Server{Addr: fmt.Sprintf("%s:%d", ip, port), Handler: handler}
+	go server.ListenAndServe()
+	return
+}
+
+func stopTestServer(server *http.Server) {
+	if server == nil {
+		return
+	}
+
+	c, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Minute))
+	server.Shutdown(c)
+	cancel()
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: lowzj <zj3142063@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

refactor `uploader.StartPeerServerProcess`:
* add interface `PeerServerExecutor` and an default implementation
* add unit-test for `peer_server_executor.go`
* fix: data race of function `readPort`
* fix: previous unit-test of `core` creates a temporary directory `dfget-CoreTestSuite-xxx` and don't delete it after testing.

one task of #352 : unit test of module uploader

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


