### PR TITLE
log: unify project logs

### DIFF
--- a/cmd/dfget/app/root.go
+++ b/cmd/dfget/app/root.go
@@ -28,6 +28,7 @@ import (
 	"github.com/dragonflyoss/Dragonfly/dfget/core"
 	"github.com/dragonflyoss/Dragonfly/dfget/errors"
 	"github.com/dragonflyoss/Dragonfly/dfget/util"
+	"github.com/dragonflyoss/Dragonfly/dflog"
 
 	errHandler "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -160,11 +161,11 @@ func transParams() error {
 func initClientLog() error {
 	logFilePath := path.Join(cfg.WorkHome, "logs", "dfclient.log")
 
-	util.InitLog(cfg.Verbose, logFilePath, cfg.Sign)
+	dflog.InitLog(cfg.Verbose, logFilePath, cfg.Sign)
 
 	// once cfg.Console is set, process should also output log to console
 	if cfg.Console {
-		util.InitConsoleLog(cfg.Verbose, cfg.Sign)
+		dflog.InitConsoleLog(cfg.Verbose, cfg.Sign)
 	}
 	return nil
 }

--- a/cmd/dfget/app/server.go
+++ b/cmd/dfget/app/server.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/dragonflyoss/Dragonfly/dfget/config"
 	"github.com/dragonflyoss/Dragonfly/dfget/core/uploader"
-	"github.com/dragonflyoss/Dragonfly/dfget/util"
+	"github.com/dragonflyoss/Dragonfly/dflog"
 
 	"github.com/spf13/cobra"
 )
@@ -77,5 +77,5 @@ func runServer() error {
 
 func initServerLog() error {
 	logFilePath := path.Join(cfg.WorkHome, "logs", "dfserver.log")
-	return util.InitLog(cfg.Verbose, logFilePath, cfg.Sign)
+	return dflog.InitLog(cfg.Verbose, logFilePath, cfg.Sign)
 }

--- a/cmd/dfget/app/version.go
+++ b/cmd/dfget/app/version.go
@@ -30,7 +30,7 @@ var versionCmd = &cobra.Command{
 	SilenceErrors: true,
 	SilenceUsage:  true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Printf("Version: %s\n", version.DFGetVersion)
+		fmt.Printf("%s\n", version.DFGetVersion)
 		return nil
 	},
 }

--- a/dflog/log_test.go
+++ b/dflog/log_test.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package util
+package dflog
 
 import (
 	"bufio"
@@ -25,12 +25,24 @@ import (
 	"os"
 	"path"
 	"strings"
+	"testing"
 
 	"github.com/go-check/check"
 	"github.com/sirupsen/logrus"
 )
 
-func (suite *DFGetUtilSuite) TestCreateLogger(c *check.C) {
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
+
+func init() {
+	check.Suite(&LogTestSuite{})
+}
+
+type LogTestSuite struct {
+}
+
+func (suite *LogTestSuite) TestCreateLogger(c *check.C) {
 	logger, tmpFile, r, err := tempFileAndLogger("debug", "x")
 	defer cleanTempFile(tmpFile, err)
 
@@ -55,7 +67,7 @@ func (suite *DFGetUtilSuite) TestCreateLogger(c *check.C) {
 	checkLogs(logrus.WarnLevel, "test")
 }
 
-func (suite *DFGetUtilSuite) TestCreateLogger_differentLevel(c *check.C) {
+func (suite *LogTestSuite) TestCreateLogger_differentLevel(c *check.C) {
 	var (
 		tmpPath     = "/tmp"
 		tmpFileName = fmt.Sprintf("dfget_test_%d.log", rand.Int63())
@@ -78,7 +90,7 @@ func (suite *DFGetUtilSuite) TestCreateLogger_differentLevel(c *check.C) {
 	testLevel("fatal", logrus.FatalLevel)
 }
 
-func (suite *DFGetUtilSuite) TestAddConsoleLog(c *check.C) {
+func (suite *LogTestSuite) TestAddConsoleLog(c *check.C) {
 	logger, tmpFile, r, err := tempFileAndLogger("debug", "")
 	defer cleanTempFile(tmpFile, err)
 
@@ -112,7 +124,7 @@ func (suite *DFGetUtilSuite) TestAddConsoleLog(c *check.C) {
 	})
 }
 
-func (suite *DFGetUtilSuite) TestIsDebug(c *check.C) {
+func (suite *LogTestSuite) TestIsDebug(c *check.C) {
 	var cases = []struct {
 		level    logrus.Level
 		expected bool


### PR DESCRIPTION
Signed-off-by: lowzj <zj3142063@gmail.com>

### Ⅰ. Describe what this PR did

move the file `log.go` from `dfget` to root path, all modules in Dragonfly use it to initialize log.




