### PR TITLE
feature: dfdaemon supports proxing https registries

### DIFF
--- a/cmd/dfdaemon/app/options/options.go
+++ b/cmd/dfdaemon/app/options/options.go
@@ -78,6 +78,10 @@ type Options struct {
 	// TrustHosts includes the trusted hosts which dfdaemon forward their
 	// requests directly when dfdaemon is used to http_proxy mode.
 	TrustHosts []string
+
+	// ConfigPath is the path of dfdaemon's configuration file.
+	// default value is: /etc/dragonfly/dfdaemon.yml
+	ConfigPath string
 }
 
 // NewOption returns the default options.
@@ -88,7 +92,6 @@ func NewOption() *Options {
 		if absPath, err := filepath.Abs(path); err == nil {
 			defaultPath = filepath.Dir(absPath) + "/dfget"
 		}
-
 	}
 
 	o := &Options{
@@ -120,4 +123,7 @@ func (o *Options) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&o.DownRule, "rule", "", "download the url by P2P if url matches the specified pattern,format:reg1,reg2,reg3")
 	fs.BoolVar(&o.Notbs, "notbs", true, "not try back source to download if throw exception")
 	fs.StringSliceVar(&o.TrustHosts, "trust-hosts", o.TrustHosts, "list of trusted hosts which dfdaemon forward their requests directly, comma separated.")
+
+	fs.StringVar(&o.ConfigPath, "config", "/etc/dragonfly/dfdaemon.yml",
+		"the path of dfdaemon's configuration file")
 }

--- a/dfdaemon/config/config.go
+++ b/dfdaemon/config/config.go
@@ -1,0 +1,181 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+// -----------------------------------------------------------------------------
+// Properties
+
+// NewProperties create a new properties with default values.
+func NewProperties() *Properties {
+	return &Properties{}
+}
+
+// Properties holds all configurable properties of dfdaemon.
+// The default path is '/etc/dragonfly/dfdaemon.yml'
+// For examples:
+//     registries:
+//         - regx: (^localhost$)|(^127.0.0.1$)
+//           schema: http
+//           host: a.com
+//         - regx: ^reg.com:1001$
+//           schema: http
+//           host: reg.com
+//         - regx: ^reg.com:1002$
+//           schema: https
+//           host: reg.com
+//           certs: ['/etc/ssl/reg.com/server.crt']
+type Properties struct {
+	// Registries the more front the position, the higher priority.
+	// You could add an empty Registry at the end to proxy all other requests
+	// with those origin schema and host.
+	Registries []*Registry `yaml:"registries"`
+}
+
+// Load loads properties from config file.
+func (p *Properties) Load(path string) error {
+	if err := p.loadFromYaml(path); err != nil {
+		return err
+	}
+	var tmp []*Registry
+	for _, v := range p.Registries {
+		if v != nil {
+			if err := v.init(); err != nil {
+				return err
+			}
+			tmp = append(tmp, v)
+		}
+	}
+	p.Registries = tmp
+	return nil
+}
+
+func (p *Properties) loadFromYaml(path string) error {
+	yamlFile, err := ioutil.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read yaml config from %s error: %v", path, err)
+	}
+	err = yaml.Unmarshal(yamlFile, p)
+	if err != nil {
+		return fmt.Errorf("unmarshal yaml error:%v", err)
+	}
+	return nil
+}
+
+// -----------------------------------------------------------------------------
+// Registry
+
+// NewRegistry create and init registry proxy with the giving values.
+func NewRegistry(schema, host, regx string, certs []string) (*Registry, error) {
+	reg := &Registry{
+		Schema: schema,
+		Host:   host,
+		Certs:  certs,
+		Regx:   regx,
+	}
+	if err := reg.init(); err != nil {
+		return nil, err
+	}
+	return reg, nil
+}
+
+// Registry is the proxied registry base information.
+type Registry struct {
+	// Schema can be 'http', 'https' or empty. It will use dfdaemon's schema if
+	// it's empty.
+	Schema string `yaml:"schema"`
+
+	// Host is the host of proxied registry, including ip and port.
+	Host string `yaml:"host"`
+
+	// Certs is the path of server-side certification. It should be provided when
+	// the 'Schema' is 'https' and the dfdaemon is worked on proxy pattern and
+	// the proxied registry is self-certificated.
+	// The server-side certification could be get by using this command:
+	// openssl x509 -in <(openssl s_client -showcerts -servername xxx -connect xxx:443 -prexit 2>/dev/null)
+	Certs []string `yaml:"certs"`
+
+	// Regx is a regular expression, dfdaemon use this registry to process the
+	// requests whose host is matched.
+	Regx string `yaml:"regx"`
+
+	compiler  *regexp.Regexp
+	tlsConfig *tls.Config
+}
+
+// Match reports whether the Registry matches the string s.
+func (r *Registry) Match(s string) bool {
+	return r.compiler != nil && r.compiler.MatchString(s)
+}
+
+// TLSConfig returns a initialized tls.Config instance.
+func (r *Registry) TLSConfig() *tls.Config {
+	return r.tlsConfig
+}
+
+func (r *Registry) init() error {
+	if err := r.validate(); err != nil {
+		return err
+	}
+
+	c, err := regexp.Compile(r.Regx)
+	if err != nil {
+		return err
+	}
+	r.compiler = c
+
+	return r.initTLSConfig()
+}
+
+func (r *Registry) validate() error {
+	r.Schema = strings.ToLower(r.Schema)
+	if r.Schema != "http" && r.Schema != "https" && r.Schema != "" {
+		return fmt.Errorf("invalid schema:%s", r.Schema)
+	}
+	return nil
+}
+
+func (r *Registry) initTLSConfig() error {
+	size := len(r.Certs)
+	if size <= 0 {
+		r.tlsConfig = &tls.Config{InsecureSkipVerify: true}
+		return nil
+	}
+
+	roots := x509.NewCertPool()
+	for i := 0; i < size; i++ {
+		cert, err := ioutil.ReadFile(r.Certs[i])
+		if err != nil {
+			return err
+		}
+		if !roots.AppendCertsFromPEM(cert) {
+			return fmt.Errorf("invalid cert:%s", r.Certs[i])
+		}
+	}
+	r.tlsConfig = &tls.Config{RootCAs: roots}
+	return nil
+}

--- a/dfdaemon/config/config_test.go
+++ b/dfdaemon/config/config_test.go
@@ -1,0 +1,197 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-check/check"
+)
+
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
+
+func init() {
+	check.Suite(&ConfigTestSuite{})
+}
+
+var testCrt = `-----BEGIN CERTIFICATE-----
+MIICKzCCAZQCCQDZrCsm2rX81DANBgkqhkiG9w0BAQUFADBaMQswCQYDVQQGEwJD
+TjERMA8GA1UECAwIWmhlamlhbmcxETAPBgNVBAcMCEhhbmd6aG91MQ4wDAYDVQQK
+DAVsb3d6ajEVMBMGA1UEAwwMZGZkYWVtb24uY29tMB4XDTE5MDIyNTAyNDYwN1oX
+DTE5MDMyNzAyNDYwN1owWjELMAkGA1UEBhMCQ04xETAPBgNVBAgMCFpoZWppYW5n
+MREwDwYDVQQHDAhIYW5nemhvdTEOMAwGA1UECgwFbG93emoxFTATBgNVBAMMDGRm
+ZGFlbW9uLmNvbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAtX1VzZRg1tgF
+D0AFkUW2FpakkrhRzFuukWepoN0LfFSS/rNf8v1823de1SkpXBHsm2pMf94BIdmY
+NDWH1tk27i4V5xydjNqxbdjjNjGHedBAM2tRQWWQuJAEo12sWUVYwDyN7RbL6wnz
+7Egeac023FA9JhfMxaDvJHqJHVuKW3kCAwEAATANBgkqhkiG9w0BAQUFAAOBgQCT
+VrDbo4m3QkcUT8ohuAUD8OHjTwJAuoxqVdHm+SpgjBYMLQgqXAPwaTGsIvx+32h2
+J88xU3xXABE5QsNNbqLcMgQoXeMmqk1WuUhxXzTXT5h5gdW53faxV5M5Cb3zI8My
+PPpBF5Cw+khgkJcY/ezKjHIvyABJwdzW8aAqwDBFAQ==
+-----END CERTIFICATE-----`
+
+type ConfigTestSuite struct {
+	workHome string
+	crtPath  string
+}
+
+func (s *ConfigTestSuite) SetUpSuite(c *check.C) {
+	s.workHome, _ = ioutil.TempDir("/tmp", "dfget-ConfigTestSuite-")
+	s.crtPath = filepath.Join(s.workHome, "server.crt")
+	ioutil.WriteFile(s.crtPath, []byte(testCrt), os.ModePerm)
+}
+
+func (s *ConfigTestSuite) TearDownSuite(c *check.C) {
+	if s.workHome != "" {
+		os.RemoveAll(s.workHome)
+	}
+}
+
+func (s *ConfigTestSuite) TestProperties_Load(c *check.C) {
+	var f = func(schema ...string) *Properties {
+		var tmp []*Registry
+		for _, s := range schema {
+			r := &Registry{Schema: s}
+			r.init()
+			tmp = append(tmp, r)
+		}
+		return &Properties{Registries: tmp}
+	}
+	var cases = []struct {
+		create   bool
+		content  string
+		errMsg   string
+		expected *Properties
+	}{
+		{create: false, content: "", errMsg: "read yaml", expected: nil},
+		{create: true, content: "-", errMsg: "unmarshal yaml", expected: nil},
+		{create: true, content: "registries:\n - regx: '^['",
+			errMsg: "missing closing", expected: nil},
+		{create: true, content: "registries:\n  -", errMsg: "", expected: f()},
+		{
+			create:   true,
+			content:  "registries:\n  - schema: http",
+			errMsg:   "",
+			expected: f("http"),
+		},
+	}
+	for idx, v := range cases {
+		filename := filepath.Join(s.workHome, fmt.Sprintf("test-%d", idx))
+		if v.create {
+			ioutil.WriteFile(filename, []byte(v.content), os.ModePerm)
+		}
+		p := &Properties{}
+		err := p.Load(filename)
+		if v.expected != nil {
+			c.Assert(err, check.IsNil)
+			c.Assert(len(p.Registries), check.Equals, len(v.expected.Registries))
+			for i := 0; i < len(v.expected.Registries); i++ {
+				c.Assert(p.Registries[i], check.DeepEquals, v.expected.Registries[i])
+			}
+		} else {
+			c.Assert(err, check.NotNil)
+			c.Assert(strings.Contains(err.Error(), v.errMsg), check.Equals, true,
+				check.Commentf("error:%v expected:%s", err, v.errMsg))
+		}
+	}
+}
+
+func (s *ConfigTestSuite) TestRegistry_Match(c *check.C) {
+	var cases = []struct {
+		regx      string
+		str       string
+		errNotNil bool
+		matched   bool
+	}{
+		{regx: "[a.com", str: "a.com", errNotNil: true, matched: false},
+		{regx: "a.com", str: "a.com", matched: true},
+		{regx: "a.com", str: "ba.com", matched: true},
+		{regx: "a.com", str: "a.comm", matched: true},
+		{regx: "^a.com", str: "ba.com", matched: false},
+		{regx: "^a.com$", str: "ba.com", matched: false},
+		{regx: "^a.com$", str: "a.comm", matched: false},
+		{regx: "^a.com$", str: "a.com", matched: true},
+		{regx: "", str: "a.com", matched: true},
+	}
+
+	for _, v := range cases {
+		reg, err := NewRegistry("", "", v.regx, nil)
+		if v.errNotNil {
+			c.Assert(err, check.NotNil)
+		} else {
+			c.Assert(err, check.IsNil)
+			c.Assert(reg.Match(v.str), check.Equals, v.matched,
+				check.Commentf("%v", v))
+		}
+	}
+}
+
+func (s *ConfigTestSuite) TestRegistry_validate(c *check.C) {
+	var cases = []struct {
+		schema string
+		err    string
+	}{
+		{schema: "http", err: ""},
+		{schema: "https", err: ""},
+		{schema: "", err: ""},
+		{schema: "x", err: "invalid schema.*"},
+	}
+
+	for _, v := range cases {
+		reg := Registry{Schema: v.schema}
+		err := reg.init()
+		if v.err == "" {
+			c.Assert(err, check.IsNil)
+		} else {
+			c.Assert(err, check.NotNil)
+			c.Assert(err, check.ErrorMatches, v.err)
+		}
+	}
+}
+
+func (s *ConfigTestSuite) TestRegistry_initTLSConfig(c *check.C) {
+	invalidCrt := filepath.Join(s.workHome, "invalid.crt")
+	ioutil.WriteFile(invalidCrt, nil, os.ModePerm)
+
+	var cases = []struct {
+		crt string
+		err string
+	}{
+		{s.workHome, "read.*"},
+		{s.crtPath, ""},
+		{invalidCrt, "invalid cert.*"},
+	}
+
+	for _, v := range cases {
+		reg := Registry{Certs: []string{v.crt}}
+		err := reg.initTLSConfig()
+		if v.err == "" {
+			c.Assert(err, check.IsNil)
+			c.Assert(reg.TLSConfig(), check.NotNil)
+		} else {
+			c.Assert(reg.TLSConfig(), check.IsNil)
+			c.Assert(err, check.NotNil)
+			c.Assert(err, check.ErrorMatches, v.err)
+		}
+	}
+}

--- a/dfdaemon/global/global.go
+++ b/dfdaemon/global/global.go
@@ -20,7 +20,9 @@ import (
 	"regexp"
 	"sync"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
+
+	"github.com/dragonflyoss/Dragonfly/dfdaemon/config"
 )
 
 // CommandParam is a struct that stores all the command line parameters
@@ -76,6 +78,9 @@ var (
 	// DFPattern is the url patterns. Dfdaemon starts downloading by P2P if the downloading url matches DFPattern.
 	DFPattern = make(map[string]*regexp.Regexp)
 
+	// Properties holds all properties get from dfdaemon's config file.
+	Properties *config.Properties
+
 	rwMutex sync.RWMutex
 )
 
@@ -89,7 +94,7 @@ func UpdateDFPattern(reg string) {
 	if compiledReg, err := regexp.Compile(reg); err == nil {
 		DFPattern[reg] = compiledReg
 	} else {
-		log.Warnf("pattern:%s is invalid", reg)
+		logrus.Warnf("pattern:%s is invalid", reg)
 	}
 }
 
@@ -114,7 +119,7 @@ func MatchDfPattern(location string) bool {
 			useGetter = true
 			break
 		}
-		log.Debugf("location:%s not match reg:%s", location, key)
+		logrus.Debugf("location:%s not match reg:%s", location, key)
 	}
 	return useGetter
 }

--- a/dfdaemon/handler/root_handler.go
+++ b/dfdaemon/handler/root_handler.go
@@ -17,79 +17,104 @@
 package handler
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
+	"github.com/dragonflyoss/Dragonfly/dfdaemon/config"
 	"github.com/dragonflyoss/Dragonfly/dfdaemon/global"
 	"github.com/dragonflyoss/Dragonfly/dfdaemon/util"
 )
 
-// Process makes the dfdaemon as a reverse proxy to download image layers by dragonfly
-func Process(w http.ResponseWriter, r *http.Request) {
+// Proxy makes the dfdaemon as a reverse proxy to download image layers by dragonfly
+func Proxy(w http.ResponseWriter, r *http.Request) {
+	var (
+		target *url.URL
+		reg    *config.Registry
+		err    error
+	)
 
-	if r.URL.Host == "" {
-		r.URL.Host = r.Host
-		if r.URL.Host == "" {
-			r.URL.Host = r.Header.Get("Host")
-		}
-		if r.URL.Host == "" {
-			// if host is still empty, we need skip to forward it.
-			w.WriteHeader(http.StatusForbidden)
-			log.Errorf("url host is empty")
-			return
-		}
-	}
-	r.Host = r.URL.Host
-	r.Header.Set("Host", r.Host)
-	if r.URL.Scheme == "" {
-		if global.UseHTTPS {
-			r.URL.Scheme = "https"
-		} else {
-			r.URL.Scheme = "http"
-		}
-
-	}
-	log.Debugf("pre access:%s", r.URL.String())
-
-	targetURL := new(url.URL)
-	*targetURL = *r.URL
-	targetURL.Path = ""
-	targetURL.RawQuery = ""
-
-	hostIP := util.ExtractHost(r.URL.Host)
-	trustHost := global.CommandLine.TrustHosts[hostIP]
-	switch hostIP {
-	case "127.0.0.1", "localhost", global.CommandLine.HostIP:
-		if len(global.CommandLine.Registry) > 0 {
-			targetURL.Host = global.RegDomain
-			targetURL.Scheme = global.RegProto
-		} else {
-			log.Warnf("registry not config but url host is %s", hostIP)
-		}
-	case trustHost:
-		// if the hostIP is trusted, we should forward it directly.
-		targetURL.Host = r.URL.Host
-		targetURL.Scheme = r.URL.Scheme
-	default:
-		// non localhost access should be denied explicitly, otherwise we
-		// are falling into a dead loop: a reverse proxy for itself.
-		// TODO: we do not need such check actually, anything that served
-		// by dfdaemon should only be accessed by localhost which should
-		// be controlled by the listener addr.
-		w.WriteHeader(http.StatusForbidden)
-		log.Warnf("%s is forbidden to forward", hostIP)
+	if err = amendRequest(r); err != nil {
+		sendResponse(w, http.StatusForbidden, err.Error())
+		logrus.Errorf("%v", err)
 		return
 	}
 
-	log.Debugf("post access:%s", targetURL.String())
+	logrus.Debugf("pre access:%v", r)
 
-	// TODO: do we really need to construct this every time?
-	reverseProxy := httputil.NewSingleHostReverseProxy(targetURL)
+	hostIP := util.ExtractHost(r.URL.Host)
+	if reg, err = matchRegistry(hostIP, global.Properties.Registries); err != nil {
+		sendResponse(w, http.StatusForbidden, err.Error())
+		logrus.Warnf("%v", err)
+		return
+	}
+	target = proxyURL(r.URL, reg)
 
-	reverseProxy.Transport = NewDFRoundTripper()
+	logrus.Debugf("post access:%s", target)
 
+	reverseProxy := httputil.NewSingleHostReverseProxy(target)
+	reverseProxy.Transport = NewDFRoundTripper(reg.TLSConfig())
 	reverseProxy.ServeHTTP(w, r)
+}
+
+func matchRegistry(host string, reg []*config.Registry) (*config.Registry, error) {
+	for i := 0; i < len(reg); i++ {
+		if reg[i].Match(host) {
+			return reg[i], nil
+		}
+	}
+	return nil, fmt.Errorf("no matched registry for %s", host)
+}
+
+func proxyURL(origin *url.URL, reg *config.Registry) (proxy *url.URL) {
+	if origin == nil || reg == nil {
+		return nil
+	}
+
+	proxy = new(url.URL)
+	*proxy = *origin
+	proxy.Path = ""
+	proxy.RawQuery = ""
+
+	if reg.Schema != "" {
+		proxy.Scheme = reg.Schema
+	}
+	if reg.Host != "" {
+		proxy.Host = reg.Host
+	}
+	return proxy
+}
+
+func amendRequest(r *http.Request) error {
+	if r.URL.Host != "" {
+		return nil
+	}
+	r.URL.Host = r.Host
+	if r.URL.Host == "" {
+		r.URL.Host = r.Header.Get("Host")
+	}
+	if r.URL.Host == "" {
+		// if host is still empty, we need skip to forward it.
+		return fmt.Errorf("url host is empty")
+	}
+	r.Host = r.URL.Host
+	r.Header.Set("Host", r.Host)
+
+	if r.URL.Scheme != "" {
+		return nil
+	}
+	if global.UseHTTPS {
+		r.URL.Scheme = "https"
+	} else {
+		r.URL.Scheme = "http"
+	}
+	return nil
+}
+
+func sendResponse(w http.ResponseWriter, code int, resp string) {
+	w.WriteHeader(code)
+	fmt.Fprintf(w, "%s", resp)
 }

--- a/dfdaemon/handler/transport.go
+++ b/dfdaemon/handler/transport.go
@@ -49,7 +49,11 @@ type DFRoundTripper struct {
 }
 
 // NewDFRoundTripper return the default DFRoundTripper.
-func NewDFRoundTripper() *DFRoundTripper {
+func NewDFRoundTripper(cfg *tls.Config) *DFRoundTripper {
+	if cfg == nil {
+		cfg = &tls.Config{InsecureSkipVerify: true}
+	}
+
 	return &DFRoundTripper{
 		Round: &http.Transport{
 			DialContext: (&net.Dialer{
@@ -60,7 +64,7 @@ func NewDFRoundTripper() *DFRoundTripper {
 			IdleConnTimeout:       90 * time.Second,
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
-			TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig:       cfg,
 		},
 		Round2: http.NewFileTransport(http.Dir("/")),
 

--- a/dfdaemon/muxconf/muxconf.go
+++ b/dfdaemon/muxconf/muxconf.go
@@ -25,7 +25,7 @@ import (
 // InitMux initialize web router of dfdaemon
 func InitMux() {
 	router := map[string]func(http.ResponseWriter, *http.Request){
-		"/":       handler.Process,
+		"/":       handler.Proxy,
 		"/args":   handler.GetArgs,
 		"/debug/": handler.DebugInfo,
 		"/env":    handler.GetEnv,

--- a/dfget/config/config.go
+++ b/dfget/config/config.go
@@ -43,8 +43,8 @@ import (
 // Properties
 
 // Properties holds all configurable Properties.
-// Support INI(or conf) and YAML(since 0.2.0).
-// Before 0.2.0, only support INI config and only have one property(node):
+// Support INI(or conf) and YAML(since 0.3.0).
+// Before 0.3.0, only support INI config and only have one property(node):
 // 		[node]
 // 		address=127.0.0.1,10.10.10.1
 // Since 0.2.0, the INI config is just to be compatible with previous versions.

--- a/dfget/config/constants.go
+++ b/dfget/config/constants.go
@@ -80,7 +80,7 @@ const (
 
 /* properties */
 const (
-	DefaultYamlConfigFile  = "/etc/dragonfly.yaml"
+	DefaultYamlConfigFile  = "/etc/dragonfly/dfget.yml"
 	DefaultIniConfigFile   = "/etc/dragonfly.conf"
 	DefaultNode            = "127.0.0.1"
 	DefaultLocalLimit      = 20 * 1024 * 1024


### PR DESCRIPTION
Signed-off-by: lowzj <zj3142063@gmail.com>

---

### Ⅰ. Describe what this PR did

This pull request implements a way to support registries which use `https` schema in `dfdaemon`'s proxy pattern:
* configure docker daemon
    * set `dfdaemon` host as `http_proxy`
    * set your registry hosts as `insecure-registries`
    * bypass proxy for your registry auth hosts
* `dfdaemon` get the http requests, change them to `https` schema and send https request to the real registries

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #205 
related #347 

### Ⅲ. Why don't you add test cases (unit test/integration test)?
### Ⅳ. Describe how to verify it

Here's a example to pull images from a https registry(`registry.cn-hangzhou.aliyuncs.com`) by using proxy pattern:

* create dfdaemon's config file: `/etc/dragonfly/dfdaemon.yml`, and start `dfdaemon`
  ```yaml
  registries:
      - regx: "^registry.cn-hangzhou.aliyuncs.com$"
        schema: https
        host: registry.cn-hangzhou.aliyuncs.com
  ```
* change your docker daemon config file: `/etc/docker/daemon.json`, and restart `docker daemon`
  ```json
  {
      "insecure-registries" : [
          "registry.cn-hangzhou.aliyuncs.com"
      ],
      "proxies": {
          "default": {
              "httpProxy": "http://127.0.0.1:65001",
          }
      }
  }
  ```
* pull a image by dragonfly
  ```shell
  docker pull registry.cn-hangzhou.aliyuncs.com/dragonflyoss/supernode:0.2.1
  ```

### Ⅴ. Special notes for reviews
@Starnop @godliness 