### PR TITLE
test: fix data race caused by TestLaunchPeerServer

### DIFF
--- a/dfget/core/uploader/uploader_test.go
+++ b/dfget/core/uploader/uploader_test.go
@@ -90,8 +90,9 @@ func (s *UploaderLaunchTestSuite) TestLaunchPeerServer(c *check.C) {
 		{port, 0, "start peer server error"},
 	}
 
+	cfg := createConfig(s.workHome, 0)
 	for _, v := range cases {
-		cfg := createConfig(s.workHome, v.port)
+		cfg.RV.PeerPort = v.port
 		port, err := LaunchPeerServer(cfg)
 
 		c.Assert(port, check.Equals, v.expectedPort)


### PR DESCRIPTION
Signed-off-by: lowzj <zj3142063@gmail.com>

### Ⅰ. Describe what this PR did

When submitting a new pull request, the unit-test-golang CI flow is always failed caused by `TestLaunchPeerServer`, following are error messages:

```bash
==================
WARNING: DATA RACE
Write at 0x00c4200ec500 by goroutine 119:
  github.com/dragonflyoss/Dragonfly/dfget/core/helper.CreateConfig()
      /go/src/github.com/dragonflyoss/Dragonfly/dfget/core/helper/test_helper.go:45 +0x32a
  github.com/dragonflyoss/Dragonfly/dfget/core/uploader.createConfig()
      /go/src/github.com/dragonflyoss/Dragonfly/dfget/core/uploader/uploader_test.go:258 +0x4e
  github.com/dragonflyoss/Dragonfly/dfget/core/uploader.(*UploaderLaunchTestSuite).TestLaunchPeerServer()
      /go/src/github.com/dragonflyoss/Dragonfly/dfget/core/uploader/uploader_test.go:94 +0x2c5
  runtime.call32()
      /usr/local/go/src/runtime/asm_amd64.s:573 +0x3a
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:308 +0xc0
  github.com/dragonflyoss/Dragonfly/vendor/github.com/go-check/check.(*suiteRunner).forkTest.func1()
      /go/src/github.com/dragonflyoss/Dragonfly/vendor/github.com/go-check/check/check.go:772 +0x954
  github.com/dragonflyoss/Dragonfly/vendor/github.com/go-check/check.(*suiteRunner).forkCall.func1()
      /go/src/github.com/dragonflyoss/Dragonfly/vendor/github.com/go-check/check/check.go:666 +0x89

Previous read at 0x00c4200ec500 by goroutine 13:
  github.com/dragonflyoss/Dragonfly/vendor/github.com/sirupsen/logrus.(*Entry).write()
      /go/src/github.com/dragonflyoss/Dragonfly/vendor/github.com/sirupsen/logrus/entry.go:148 +0x238
  github.com/dragonflyoss/Dragonfly/vendor/github.com/sirupsen/logrus.Entry.log()
      /go/src/github.com/dragonflyoss/Dragonfly/vendor/github.com/sirupsen/logrus/entry.go:118 +0x32d
  github.com/dragonflyoss/Dragonfly/vendor/github.com/sirupsen/logrus.(*Entry).Info()
      /go/src/github.com/dragonflyoss/Dragonfly/vendor/github.com/sirupsen/logrus/entry.go:167 +0x110
  github.com/dragonflyoss/Dragonfly/vendor/github.com/sirupsen/logrus.(*Logger).Info()
      /go/src/github.com/dragonflyoss/Dragonfly/vendor/github.com/sirupsen/logrus/logger.go:197 +0x93
  github.com/dragonflyoss/Dragonfly/vendor/github.com/sirupsen/logrus.Info()
      /go/src/github.com/dragonflyoss/Dragonfly/vendor/github.com/sirupsen/logrus/exported.go:95 +0x68
  github.com/dragonflyoss/Dragonfly/dfget/core/uploader.serverGC()
      /go/src/github.com/dragonflyoss/Dragonfly/dfget/core/uploader/uploader.go:147 +0x109

Goroutine 119 (running) created at:
  github.com/dragonflyoss/Dragonfly/vendor/github.com/go-check/check.(*suiteRunner).forkCall()
      /go/src/github.com/dragonflyoss/Dragonfly/vendor/github.com/go-check/check/check.go:663 +0x419
  github.com/dragonflyoss/Dragonfly/vendor/github.com/go-check/check.(*suiteRunner).forkTest()
      /go/src/github.com/dragonflyoss/Dragonfly/vendor/github.com/go-check/check/check.go:754 +0x128
  github.com/dragonflyoss/Dragonfly/vendor/github.com/go-check/check.(*suiteRunner).runTest()
      /go/src/github.com/dragonflyoss/Dragonfly/vendor/github.com/go-check/check/check.go:809 +0x42
  github.com/dragonflyoss/Dragonfly/vendor/github.com/go-check/check.(*suiteRunner).run()
      /go/src/github.com/dragonflyoss/Dragonfly/vendor/github.com/go-check/check/check.go:615 +0x1e1
  github.com/dragonflyoss/Dragonfly/vendor/github.com/go-check/check.Run()
      /go/src/github.com/dragonflyoss/Dragonfly/vendor/github.com/go-check/check/run.go:92 +0x5a
  github.com/dragonflyoss/Dragonfly/vendor/github.com/go-check/check.RunAll()
      /go/src/github.com/dragonflyoss/Dragonfly/vendor/github.com/go-check/check/run.go:84 +0x130
  github.com/dragonflyoss/Dragonfly/vendor/github.com/go-check/check.TestingT()
      /go/src/github.com/dragonflyoss/Dragonfly/vendor/github.com/go-check/check/run.go:72 +0x641
  github.com/dragonflyoss/Dragonfly/dfget/core/uploader.Test()
      /go/src/github.com/dragonflyoss/Dragonfly/dfget/core/uploader/uploader_test.go:38 +0x38
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d

Goroutine 13 (finished) created at:
  github.com/dragonflyoss/Dragonfly/dfget/core/uploader.monitorAlive()
      /go/src/github.com/dragonflyoss/Dragonfly/dfget/core/uploader/uploader.go:192 +0x155
==================
```

