### PR TITLE
feature: make client queue size configurable

### DIFF
--- a/cmd/dfget/app/root.go
+++ b/cmd/dfget/app/root.go
@@ -192,27 +192,26 @@ func initFlags() {
 		"md5 value input from user for the requested downloading file to enhance security")
 	flagSet.StringVarP(&cfg.Identifier, "identifier", "i", "",
 		"The usage of identifier is making different downloading tasks generate different downloading task IDs even if they have the same URLs. conflict with --md5.")
+
 	flagSet.StringVar(&cfg.CallSystem, "callsystem", "",
 		"The name of dfget caller which is for debugging. Once set, it will be passed to all components around the request to make debugging easy")
-
 	flagSet.StringVarP(&cfg.Pattern, "pattern", "p", "p2p",
 		"download pattern, must be p2p/cdn/source, cdn and source do not support flag --totallimit")
-
 	flagSet.StringVarP(&filter, "filter", "f", "",
 		"filter some query params of URL, use char '&' to separate different params"+
 			"\neg: -f 'key&sign' will filter 'key' and 'sign' query param"+
 			"\nin this way, different but actually the same URLs can reuse the same downloading task")
-
 	flagSet.StringSliceVar(&cfg.Header, "header", nil,
 		"http header, eg: --header='Accept: *' --header='Host: abc'")
-
 	flagSet.StringSliceVarP(&cfg.Node, "node", "n", nil,
 		"specify the addresses(IP:port) of supnernodes")
-
 	flagSet.BoolVar(&cfg.Notbs, "notbs", false,
 		"disable back source downloading for requested file when p2p fails to download it")
 	flagSet.BoolVar(&cfg.DFDaemon, "dfdaemon", false,
 		"identify whether the request is from dfdaemon")
+	flagSet.IntVar(&cfg.ClientQueueSize, "clientqueue", config.DefaultClientQueueSize,
+		"specify the size of client queue which controls the number of pieces that can be processed simultaneously")
+
 	// others
 	flagSet.BoolVarP(&cfg.ShowBar, "showbar", "b", false,
 		"show progress bar, it is conflict with '--console'")

--- a/dfget/config/config.go
+++ b/dfget/config/config.go
@@ -196,8 +196,10 @@ type Config struct {
 	// Help show help information.
 	Help bool `json:"help,omitempty"`
 
-	// Client queue size.
-	// TODO: support setupFlags
+	// ClientQueueSize is the size of client queue
+	// which controls the number of pieces that can be processed simultaneously.
+	// It is only useful when the pattern not equals "source".
+	// The default value is 6.
 	ClientQueueSize int `json:"clientQueueSize,omitempty"`
 
 	// Start time.

--- a/dfget/core/downloader/p2p_downloader/p2p_downloader.go
+++ b/dfget/core/downloader/p2p_downloader/p2p_downloader.go
@@ -104,7 +104,7 @@ func (p2p *P2PDownloader) init() {
 	p2p.queue = util.NewQueue(0)
 	p2p.queue.Put(NewPieceSimple(p2p.taskID, p2p.node, config.TaskStatusStart))
 
-	p2p.clientQueue = util.NewQueue(config.DefaultClientQueueSize)
+	p2p.clientQueue = util.NewQueue(p2p.cfg.ClientQueueSize)
 
 	p2p.clientFilePath = helper.GetTaskFile(p2p.taskFileName, p2p.cfg.RV.DataDir)
 	p2p.serviceFilePath = helper.GetServiceFile(p2p.taskFileName, p2p.cfg.RV.DataDir)


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

The field of `ClientQueueSize` controls the number of pieces that can be processed simultaneously.
And this PR makes it to be configured either as a command line or as a configuration file and be passed to the p2p downloader.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

Add it in the integration test later.

### Ⅳ. Describe how to verify it

Eg:
```
dfget -u "https://github.com/dragonflyoss/Dragonfly/releases/download/v0.2.1/df-client_0.2.1_linux_amd64.tar.gz" --clientqueue=6  -o /tmp/dfclient.tar.gz
```

### Ⅴ. Special notes for reviews


