### PR TITLE
fix:  the speed will be slower and slower when multiple dfgets are executed consecutively on the same machine

### DIFF
--- a/dfget/core/downloader/p2p_downloader/p2p_downloader.go
+++ b/dfget/core/downloader/p2p_downloader/p2p_downloader.go
@@ -243,6 +243,7 @@ func (p2p *P2PDownloader) getPullRate(data *types.PullPieceTaskResponseContinueD
 	}
 	p2p.pullRateTime = time.Now()
 
+	start := time.Now()
 	var localRate int
 	if p2p.cfg.LocalLimit > 0 {
 		localRate = p2p.cfg.LocalLimit
@@ -270,6 +271,7 @@ func (p2p *P2PDownloader) getPullRate(data *types.PullPieceTaskResponseContinueD
 		p2p.rateLimiter.SetRate(util.TransRate(localRate))
 		return
 	}
+	logrus.Infof("pull rate result:%d cost:%d", reqRate, time.Since(start))
 	p2p.rateLimiter.SetRate(util.TransRate(reqRate))
 }
 

--- a/dfget/core/uploader/peer_server.go
+++ b/dfget/core/uploader/peer_server.go
@@ -249,6 +249,7 @@ func (ps *peerServer) oneFinishHandler(w http.ResponseWriter, r *http.Request) {
 	if v, ok := ps.syncTaskMap.Load(taskFileName); ok {
 		task := v.(*taskConfig)
 		task.taskID = taskID
+		task.rateLimit = 0
 		task.cid = cid
 		task.superNode = superNode
 		task.finished = true
@@ -399,7 +400,9 @@ func (ps *peerServer) calculateRateLimit(clientRate int) int {
 	// for each key and value present in the map
 	f := func(key, value interface{}) bool {
 		if task, ok := value.(*taskConfig); ok {
-			total += task.rateLimit
+			if !task.finished {
+				total += task.rateLimit
+			}
 		}
 		return true
 	}

--- a/dfget/core/uploader/peer_server_test.go
+++ b/dfget/core/uploader/peer_server_test.go
@@ -540,6 +540,7 @@ func (s *PeerServerTestSuite) TestOneFinishHandler(c *check.C) {
 		if ok {
 			tt, ok := t.(*taskConfig)
 			c.Assert(ok, check.Equals, true)
+			c.Assert(tt.rateLimit, check.Equals, 0)
 			c.Assert(tt.finished, check.Equals, true)
 		}
 	}


### PR DESCRIPTION
…cuted consecutively on the same machine

Signed-off-by: lowzj <zj3142063@gmail.com>

### Ⅰ. Describe what this PR did
Bugfix: the speed will be slower and slower when multiple dfgets are executed consecutively on the same machine.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


