### PR TITLE
feature: add scripts to build rpm and deb packages for dfdaemon and dfget

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,3 +66,16 @@ docs:
 	@echo "Begin to generate docs of API/CLI"
 	./hack/generate-docs.sh
 .PHONY: docs
+
+rpm:
+	./hack/package.sh rpm
+.PHONY: rpm
+
+deb:
+	./hack/package.sh deb
+.PHONY: deb
+
+dist:
+	./hack/package.sh
+.PHONY: dist
+

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ USE_DOCKER?=0 # Default: build components in the local environment.
 clean:
 	@echo "Begin to clean redundant files."
 	@rm -rf ./bin
+	@rm -rf ./release
 .PHONY: clean
 
 build-dirs:

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ deb:
 	./hack/package.sh deb
 .PHONY: deb
 
-dist:
+release:
 	./hack/package.sh
-.PHONY: dist
+.PHONY: release
 

--- a/hack/after-install.sh
+++ b/hack/after-install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+ln -s /opt/dragonfly/df-client/dfget /usr/local/bin/dfget
+ln -s /opt/dragonfly/df-client/dfdaemon /usr/local/bin/dfdaemon

--- a/hack/before-remove.sh
+++ b/hack/before-remove.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+rm -f /usr/local/bin/dfget
+rm -f /usr/local/bin/dfdaemon

--- a/hack/build-supernode.sh
+++ b/hack/build-supernode.sh
@@ -10,8 +10,8 @@ USE_DOCKER=${USE_DOCKER:-"0"}
 
 build-supernode-docker() {
     docker run --rm -it \
-        -v ${BUILD_SOURCE_HOME}:${BUILD_SOURCE_HOME} \
-        -w ${BUILD_SOURCE_HOME} \
+        -v "${BUILD_SOURCE_HOME}:${BUILD_SOURCE_HOME}" \
+        -w "${BUILD_SOURCE_HOME}" \
         maven:3.6-jdk-8 ./hack/build-supernode.sh
 }
 

--- a/hack/build-supernode.sh
+++ b/hack/build-supernode.sh
@@ -9,10 +9,9 @@ BIN_DIR="${BUILD_SOURCE_HOME}/bin"
 USE_DOCKER=${USE_DOCKER:-"0"}
 
 build-supernode-docker() {
-    docker run --rm -it \
-        -v "${BUILD_SOURCE_HOME}:${BUILD_SOURCE_HOME}" \
-        -w "${BUILD_SOURCE_HOME}" \
-        maven:3.6-jdk-8 ./hack/build-supernode.sh
+    cd "${SUPERNODE_SOURCE_HOME}" || return
+    mvn clean package -DskipTests docker:build -e
+    cp "${SUPERNODE_BIN}/supernode.jar"  "${BIN_DIR}/${SUPERNODE_BINARY_NAME}"
 }
 
 build-supernode-local(){

--- a/hack/build-supernode.sh
+++ b/hack/build-supernode.sh
@@ -9,9 +9,10 @@ BIN_DIR="${BUILD_SOURCE_HOME}/bin"
 USE_DOCKER=${USE_DOCKER:-"0"}
 
 build-supernode-docker() {
-    cd "${SUPERNODE_SOURCE_HOME}" || return
-    mvn clean package -DskipTests docker:build -e
-    cp "${SUPERNODE_BIN}/supernode.jar"  "${BIN_DIR}/${SUPERNODE_BINARY_NAME}"
+    docker run --rm -it \
+        -v ${BUILD_SOURCE_HOME}:${BUILD_SOURCE_HOME} \
+        -w ${BUILD_SOURCE_HOME} \
+        maven:3.6-jdk-8 ./hack/build-supernode.sh
 }
 
 build-supernode-local(){

--- a/hack/package.sh
+++ b/hack/package.sh
@@ -24,7 +24,6 @@ main() {
     then
         echo "Begin to package with docker."
         FPM="docker run --rm -it -v $(pwd):$(pwd) -w $(pwd) inoc603/fpm:alpine"
-        echo ${FPM}
     else
         echo "Begin to package in local environment."
         FPM="fpm"

--- a/hack/package.sh
+++ b/hack/package.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+USE_DOCKER=${USE_DOCKER:-"0"}
+VERSION=${VERSION:-"0.0.$(date +%s)"}
+
+curDir=$(cd "$(dirname "$0")" && pwd)
+cd "${curDir}" || return
+BUILD_SOURCE_HOME=$(cd ".." && pwd)
+
+. ./env.sh
+
+BUILD_PATH=bin/${GOOS}_${GOARCH}
+DFDAEMON_BINARY_NAME=dfdaemon
+DFGET_BINARY_NAME=dfget
+
+main() {
+    cd "${BUILD_SOURCE_HOME}" || return
+    # Maybe we should use a variable to set the directory for release,
+    # however using a variable after `rm -rf` seems risky.
+    mkdir -p release
+    rm -rf release/*
+
+    if [ "1" == "${USE_DOCKER}" ]
+    then
+        echo "Begin to package with docker."
+        FPM="docker run --rm -it -v $(pwd):$(pwd) -w $(pwd) inoc603/fpm:alpine"
+        echo ${FPM}
+    else
+        echo "Begin to package in local environment."
+        FPM="fpm"
+    fi
+
+    case "$1" in
+        rpm )
+            build_rpm
+            ;;
+        deb )
+            build_deb
+            ;;
+        * )
+            build_rpm
+            build_deb
+            ;;
+    esac
+}
+
+# TODO: Add description
+DFGET_DESCRIPTION="dfget"
+DFDAEMON_DESCRIPTION="dfdaemon"
+# TODO: Add maintainer
+MAINTAINER="dragonflyoss"
+
+build_rpm() {
+    ${FPM} -s dir -t rpm -f -p release --rpm-os=linux \
+        --description "${DFGET_DESCRIPTION}" \
+        --maintainer "${MAINTAINER}" \
+        -n dfget -v ${VERSION} \
+		${BUILD_PATH}/dfget=${INSTALL_HOME}/${INSTALL_CLIENT_PATH}/dfget
+
+    ${FPM} -s dir -t rpm -f -p release --rpm-os=linux \
+        --description "${DFDAEMON_DESCRIPTION}" \
+        --maintainer "${MAINTAINER}" \
+        -n dfdaemon -v ${VERSION} \
+        -d dfget \
+		${BUILD_PATH}/dfdaemon=${INSTALL_HOME}/${INSTALL_CLIENT_PATH}/dfdaemon
+}
+
+build_deb() {
+    ${FPM} -s dir -t deb -f -p release \
+        --description "${DFGET_DESCRIPTION}" \
+        --maintainer "${MAINTAINER}" \
+        -n dfget -v ${VERSION} \
+		${BUILD_PATH}/dfget=${INSTALL_HOME}/${INSTALL_CLIENT_PATH}/dfget
+
+    ${FPM} -s dir -t deb -f -p release \
+        --description "${DFDAEMON_DESCRIPTION}" \
+        --maintainer "${MAINTAINER}" \
+        -n dfdaemon -v ${VERSION} \
+        -d dfget \
+		${BUILD_PATH}/dfdaemon=${INSTALL_HOME}/${INSTALL_CLIENT_PATH}/dfdaemon
+}
+
+main "$@"

--- a/hack/package.sh
+++ b/hack/package.sh
@@ -53,30 +53,30 @@ build_rpm() {
     ${FPM} -s dir -t rpm -f -p release --rpm-os=linux \
         --description "${DFGET_DESCRIPTION}" \
         --maintainer "${MAINTAINER}" \
-        -n dfget -v ${VERSION} \
-		${BUILD_PATH}/dfget=${INSTALL_HOME}/${INSTALL_CLIENT_PATH}/dfget
+        -n dfget -v "${VERSION}" \
+	"${BUILD_PATH}/${DFGET_BINARY_NAME}=${INSTALL_HOME}/${INSTALL_CLIENT_PATH}/${DFGET_BINARY_NAME}"
 
     ${FPM} -s dir -t rpm -f -p release --rpm-os=linux \
         --description "${DFDAEMON_DESCRIPTION}" \
         --maintainer "${MAINTAINER}" \
-        -n dfdaemon -v ${VERSION} \
+        -n dfdaemon -v "${VERSION}" \
         -d dfget \
-		${BUILD_PATH}/dfdaemon=${INSTALL_HOME}/${INSTALL_CLIENT_PATH}/dfdaemon
+	"${BUILD_PATH}/${DFDAEMON_BINARY_NAME}=${INSTALL_HOME}/${INSTALL_CLIENT_PATH}/${DFDAEMON_BINARY_NAME}"
 }
 
 build_deb() {
     ${FPM} -s dir -t deb -f -p release \
         --description "${DFGET_DESCRIPTION}" \
         --maintainer "${MAINTAINER}" \
-        -n dfget -v ${VERSION} \
-		${BUILD_PATH}/dfget=${INSTALL_HOME}/${INSTALL_CLIENT_PATH}/dfget
+        -n dfget -v "${VERSION}" \
+	"${BUILD_PATH}/${DFGET_BINARY_NAME}=${INSTALL_HOME}/${INSTALL_CLIENT_PATH}/${DFGET_BINARY_NAME}"
 
     ${FPM} -s dir -t deb -f -p release \
         --description "${DFDAEMON_DESCRIPTION}" \
         --maintainer "${MAINTAINER}" \
-        -n dfdaemon -v ${VERSION} \
+        -n dfdaemon -v "${VERSION}" \
         -d dfget \
-		${BUILD_PATH}/dfdaemon=${INSTALL_HOME}/${INSTALL_CLIENT_PATH}/dfdaemon
+	"${BUILD_PATH}/${DFDAEMON_BINARY_NAME}=${INSTALL_HOME}/${INSTALL_CLIENT_PATH}/${DFDAEMON_BINARY_NAME}"
 }
 
 main "$@"

--- a/hack/package.sh
+++ b/hack/package.sh
@@ -44,38 +44,29 @@ main() {
 }
 
 # TODO: Add description
-DFGET_DESCRIPTION="dfget"
-DFDAEMON_DESCRIPTION="dfdaemon"
+DFCLIENT_DESCRIPTION="df-client"
 # TODO: Add maintainer
 MAINTAINER="dragonflyoss"
 
 build_rpm() {
     ${FPM} -s dir -t rpm -f -p release --rpm-os=linux \
-        --description "${DFGET_DESCRIPTION}" \
+        --description "${DFCLIENT_DESCRIPTION}" \
         --maintainer "${MAINTAINER}" \
-        -n dfget -v "${VERSION}" \
-	"${BUILD_PATH}/${DFGET_BINARY_NAME}=${INSTALL_HOME}/${INSTALL_CLIENT_PATH}/${DFGET_BINARY_NAME}"
-
-    ${FPM} -s dir -t rpm -f -p release --rpm-os=linux \
-        --description "${DFDAEMON_DESCRIPTION}" \
-        --maintainer "${MAINTAINER}" \
-        -n dfdaemon -v "${VERSION}" \
-        -d dfget \
+        --after-install ./hack/after-install.sh \
+        --before-remove ./hack/before-remove.sh \
+        -n df-client -v "${VERSION}" \
+	"${BUILD_PATH}/${DFGET_BINARY_NAME}=${INSTALL_HOME}/${INSTALL_CLIENT_PATH}/${DFGET_BINARY_NAME}" \
 	"${BUILD_PATH}/${DFDAEMON_BINARY_NAME}=${INSTALL_HOME}/${INSTALL_CLIENT_PATH}/${DFDAEMON_BINARY_NAME}"
 }
 
 build_deb() {
     ${FPM} -s dir -t deb -f -p release \
-        --description "${DFGET_DESCRIPTION}" \
+        --description "${DFCLIENT_DESCRIPTION}" \
         --maintainer "${MAINTAINER}" \
-        -n dfget -v "${VERSION}" \
-	"${BUILD_PATH}/${DFGET_BINARY_NAME}=${INSTALL_HOME}/${INSTALL_CLIENT_PATH}/${DFGET_BINARY_NAME}"
-
-    ${FPM} -s dir -t deb -f -p release \
-        --description "${DFDAEMON_DESCRIPTION}" \
-        --maintainer "${MAINTAINER}" \
-        -n dfdaemon -v "${VERSION}" \
-        -d dfget \
+        --after-install ./hack/after-install.sh \
+        --before-remove ./hack/before-remove.sh \
+        -n df-client -v "${VERSION}" \
+	"${BUILD_PATH}/${DFGET_BINARY_NAME}=${INSTALL_HOME}/${INSTALL_CLIENT_PATH}/${DFGET_BINARY_NAME}" \
 	"${BUILD_PATH}/${DFDAEMON_BINARY_NAME}=${INSTALL_HOME}/${INSTALL_CLIENT_PATH}/${DFDAEMON_BINARY_NAME}"
 }
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

This PR add scripts to build rpm and deb packages for dfdaemon and dfget, with [fpm](https://github.com/jordansissel/fpm).

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #183

I think since people may want to use dfget outside a docker container, we should provide easy installation.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

This PR only adds a packaging script. 

### Ⅳ. Describe how to verify it

First `make build-client USE_DOCKER=1 GOOS=linux` to build the binaries for **linux**, then

```
make release USE_DOCKER=1 VERSION=0.3.0
```

This will build rpm and deb packages for dfdaemon and dfget to `release/`. If you don't want to use docker, you can [install fpm](https://fpm.readthedocs.io/en/latest/installing.html) on your local machine, and drop `USE_DOCKER=1`. 

You can also `make rpm VERSION=0.3.0` or `make deb VERSION=0.3.0` to build rpm or deb packages separately.

You can verify the installation in docker containers.

```
docker run --rm -it -v $(pwd):$(pwd) -w $(pwd) centos:7 \
    bash -c "ls -l release/ && rpm -i release/*.rpm && ls -l /opt/dragonfly/df-client"

docker run --rm -it -v $(pwd):$(pwd) -w $(pwd) ubuntu:14.04 \
    bash -c "ls -l release/ && dpkg -i release/*.deb && ls -l /opt/dragonfly/df-client"
```

### Ⅴ. Special notes for reviews

It seems how to version the package is still under discussion in #391 , so currently I think it's better to set the version explicitly. If `VERSION` is not set, the default version will be `0.0.$(date +%s)`.

The new supernode written in go doesn't seem production ready, and I can't find a build script for it, so I didn't package it. I'm not sure whether we should include the java supernode in the distribution, so it's also not packaged. However it's easy to include it if we've decided to do so.

The packages still needs more metadata, like description, maintainers, etc.

Currently we only build packages for `amd64`, other architecture can be added if necessary.