### PR TITLE
fix: don't exit when default config file is not exist

### DIFF
--- a/cmd/dfdaemon/app/options/options.go
+++ b/cmd/dfdaemon/app/options/options.go
@@ -22,6 +22,8 @@ import (
 	"path/filepath"
 
 	flag "github.com/spf13/pflag"
+
+	"github.com/dragonflyoss/Dragonfly/dfdaemon/constant"
 )
 
 // Options is the configuration
@@ -124,6 +126,6 @@ func (o *Options) AddFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&o.Notbs, "notbs", true, "not try back source to download if throw exception")
 	fs.StringSliceVar(&o.TrustHosts, "trust-hosts", o.TrustHosts, "list of trusted hosts which dfdaemon forward their requests directly, comma separated.")
 
-	fs.StringVar(&o.ConfigPath, "config", "/etc/dragonfly/dfdaemon.yml",
+	fs.StringVar(&o.ConfigPath, "config", constant.DefaultConfigPath,
 		"the path of dfdaemon's configuration file")
 }

--- a/dfdaemon/config/config.go
+++ b/dfdaemon/config/config.go
@@ -77,7 +77,7 @@ func (p *Properties) Load(path string) error {
 func (p *Properties) loadFromYaml(path string) error {
 	yamlFile, err := ioutil.ReadFile(path)
 	if err != nil {
-		return fmt.Errorf("read yaml config from %s error: %v", path, err)
+		return err
 	}
 	err = yaml.Unmarshal(yamlFile, p)
 	if err != nil {

--- a/dfdaemon/config/config_test.go
+++ b/dfdaemon/config/config_test.go
@@ -83,7 +83,7 @@ func (s *ConfigTestSuite) TestProperties_Load(c *check.C) {
 		errMsg   string
 		expected *Properties
 	}{
-		{create: false, content: "", errMsg: "read yaml", expected: nil},
+		{create: false, content: "", errMsg: "no such file or directory", expected: nil},
 		{create: true, content: "-", errMsg: "unmarshal yaml", expected: nil},
 		{create: true, content: "registries:\n - regx: '^['",
 			errMsg: "missing closing", expected: nil},

--- a/dfdaemon/constant/constant.go
+++ b/dfdaemon/constant/constant.go
@@ -39,3 +39,8 @@ const (
 	// CodeReqAuth represents that an authentication failure happens when executing dfget.
 	CodeReqAuth = 100 + iota
 )
+
+const (
+	// DefaultConfigPath the default path of dfdaemon configuration file.
+	DefaultConfigPath = "/etc/dragonfly/dfdaemon.yml"
+)

--- a/dfdaemon/initializer/initializer.go
+++ b/dfdaemon/initializer/initializer.go
@@ -257,7 +257,10 @@ func initProperties(ops *options.Options) {
 	props := config.NewProperties()
 	if err := props.Load(ops.ConfigPath); err != nil {
 		log.Errorf("init properties failed:%v", err)
-		os.Exit(constant.CodeExitConfigError)
+		if ops.ConfigPath != constant.DefaultConfigPath || !os.IsNotExist(err) {
+			fmt.Printf("init properties failed:%v\n", err)
+			os.Exit(constant.CodeExitConfigError)
+		}
 	}
 
 	var regs []*config.Registry


### PR DESCRIPTION
Signed-off-by: lowzj <zj3142063@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Dfdaemon doesn't exit when the default config file is not exist,  make it friendly for user.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


