### PR TITLE
refactor: extract the common const code to the common folder

### DIFF
--- a/common/constants/dfget_super_code.go
+++ b/common/constants/dfget_super_code.go
@@ -1,0 +1,91 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package constants
+
+// This file defines the code required for both dfget and supernode.
+
+var cmmap = make(map[int]string)
+
+func init() {
+	cmmap[Success] = "success"
+
+	cmmap[CodeSystemError] = "system error"
+	cmmap[CodeParamError] = "param is illegal"
+	cmmap[CodeTargetNotFound] = "target not found"
+
+	cmmap[CodePeerFinish] = "peer task end"
+	cmmap[CodePeerContinue] = "peer task go on"
+	cmmap[CodePeerWait] = "peer task wait"
+	cmmap[CodePeerLimited] = "peer down limit"
+	cmmap[CodeSuperFail] = "super node sync source fail"
+	cmmap[CodeUnknownError] = "unknown error"
+	cmmap[CodeTaskConflict] = "task conflict"
+	cmmap[CodeURLNotReachable] = "url is not reachable"
+	cmmap[CodeNeedAuth] = "need auth"
+	cmmap[CodeWaitAuth] = "wait auth"
+}
+
+// GetMsgByCode gets the description of the code.
+func GetMsgByCode(code int) string {
+	if v, ok := cmmap[code]; ok {
+		return v
+	}
+	return ""
+}
+
+const (
+	// HTTPError represents that there is an error between client and server.
+	HTTPError = -100
+)
+
+/* the response code returned by supernode */
+const (
+	// Success represents the request is success.
+	Success = 200
+
+	CodeSystemError    = 500
+	CodeParamError     = 501
+	CodeTargetNotFound = 502
+
+	CodePeerFinish      = 600
+	CodePeerContinue    = 601
+	CodePeerWait        = 602
+	CodePeerLimited     = 603
+	CodeSuperFail       = 604
+	CodeUnknownError    = 607
+	CodeTaskConflict    = 608
+	CodeURLNotReachable = 609
+	CodeNeedAuth        = 610
+	CodeWaitAuth        = 611
+	CodeSourceError     = 612
+)
+
+/* the code of task result that dfget will report to supernode */
+const (
+	ResultFail    = 500
+	ResultSuc     = 501
+	ResultInvalid = 502
+	// ResultSemiSuc represents the result is partial successful.
+	ResultSemiSuc = 503
+)
+
+/* the code of task status that dfget will report to supernode */
+const (
+	TaskStatusStart   = 700
+	TaskStatusRunning = 701
+	TaskStatusFinish  = 702
+)

--- a/dfget/config/constants.go
+++ b/dfget/config/constants.go
@@ -20,41 +20,6 @@ import (
 	"time"
 )
 
-/* the response code from supernode */
-const (
-	// HTTPError represents that there is an error between client and server.
-	HTTPError = -100
-	// Success represents the request is success.
-	Success       = 200
-	ResultFail    = 500
-	ResultSuc     = 501
-	ResultInvalid = 502
-	// ResultSemiSuc represents the result is partial successful.
-	ResultSemiSuc = 503
-)
-
-/* report status of task to supernode */
-const (
-	TaskStatusStart   = 700
-	TaskStatusRunning = 701
-	TaskStatusFinish  = 702
-)
-
-/* the task code get from supernode */
-const (
-	TaskCodeFinish          = 600
-	TaskCodeContinue        = 601
-	TaskCodeWait            = 602
-	TaskCodeLimited         = 603
-	TaskCodeSuperFail       = 604
-	TaskCodeUnknownError    = 605
-	TaskCodeTaskConflict    = 606
-	TaskCodeURLNotReachable = 607
-	TaskCodeNeedAuth        = 608
-	TaskCodeWaitAuth        = 609
-	TaskCodeSourceError     = 610
-)
-
 /* the reason of backing to source */
 const (
 	BackSourceReasonNone          = 0

--- a/dfget/core/api/supernode_api_test.go
+++ b/dfget/core/api/supernode_api_test.go
@@ -20,8 +20,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/dragonflyoss/Dragonfly/dfget/config"
+	"github.com/dragonflyoss/Dragonfly/common/constants"
 	"github.com/dragonflyoss/Dragonfly/dfget/types"
+
 	"github.com/go-check/check"
 )
 
@@ -67,12 +68,12 @@ func (s *SupernodeAPITestSuite) TestSupernodeAPI_Register(c *check.C) {
 	c.Assert(r, check.NotNil)
 	c.Assert(r.Code, check.Equals, 0)
 
-	res.Code = config.Success
+	res.Code = constants.Success
 	res.Data = &types.RegisterResponseData{FileLength: int64(32)}
 	s.mock.postJSON = s.mock.createPostJSONFunc(200, []byte(res.String()), nil)
 	r, e = s.api.Register(ip, createRegisterRequest())
 	c.Assert(r, check.NotNil)
-	c.Assert(r.Code, check.Equals, config.Success)
+	c.Assert(r.Code, check.Equals, constants.Success)
 	c.Assert(r.Data.FileLength, check.Equals, res.Data.FileLength)
 }
 
@@ -80,7 +81,7 @@ func (s *SupernodeAPITestSuite) TestSupernodeAPI_PullPieceTask(c *check.C) {
 	ip := "127.0.0.1"
 
 	res := &types.PullPieceTaskResponse{BaseResponse: &types.BaseResponse{}}
-	res.Code = config.TaskCodeFinish
+	res.Code = constants.CodePeerFinish
 	res.Data = []byte(`{"fileLength":2}`)
 	s.mock.get = s.mock.createGetFunc(200, []byte(res.String()), nil)
 

--- a/dfget/core/core.go
+++ b/dfget/core/core.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dragonflyoss/Dragonfly/common/constants"
 	cutil "github.com/dragonflyoss/Dragonfly/common/util"
 	"github.com/dragonflyoss/Dragonfly/dfget/config"
 	"github.com/dragonflyoss/Dragonfly/dfget/core/api"
@@ -149,7 +150,7 @@ func registerToSuperNode(cfg *config.Config, register regist.SupernodeRegister) 
 
 	result, e := register.Register(cfg.RV.PeerPort)
 	if e != nil {
-		if e.Code == config.TaskCodeNeedAuth {
+		if e.Code == constants.CodeNeedAuth {
 			return nil, e
 		}
 		cfg.BackSourceReason = config.BackSourceReasonRegisterFail

--- a/dfget/core/downloader/p2p_downloader/piece.go
+++ b/dfget/core/downloader/p2p_downloader/piece.go
@@ -20,8 +20,8 @@ import (
 	"bytes"
 	"encoding/json"
 
+	"github.com/dragonflyoss/Dragonfly/common/constants"
 	"github.com/dragonflyoss/Dragonfly/common/util"
-	"github.com/dragonflyoss/Dragonfly/dfget/config"
 )
 
 // Piece contains all information of a piece.
@@ -90,7 +90,7 @@ func NewPieceSimple(taskID string, node string, status int) *Piece {
 		TaskID:    taskID,
 		SuperNode: node,
 		Status:    status,
-		Result:    config.ResultInvalid,
+		Result:    constants.ResultInvalid,
 		Content:   &bytes.Buffer{},
 	}
 }

--- a/dfget/core/downloader/p2p_downloader/power_client.go
+++ b/dfget/core/downloader/p2p_downloader/power_client.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dragonflyoss/Dragonfly/common/constants"
 	cutil "github.com/dragonflyoss/Dragonfly/common/util"
 	"github.com/dragonflyoss/Dragonfly/dfget/config"
 	"github.com/dragonflyoss/Dragonfly/dfget/core/api"
@@ -148,7 +149,7 @@ func (pc *PowerClient) createDownloadRequest() *api.DownloadRequest {
 
 func (pc *PowerClient) successPiece(content *bytes.Buffer) *Piece {
 	piece := NewPieceContent(pc.taskID, pc.node, pc.pieceTask.Cid, pc.pieceTask.Range,
-		config.ResultSemiSuc, config.TaskStatusRunning, content)
+		constants.ResultSemiSuc, constants.TaskStatusRunning, content)
 	piece.PieceSize = pc.pieceTask.PieceSize
 	piece.PieceNum = pc.pieceTask.PieceNum
 	return piece
@@ -156,7 +157,7 @@ func (pc *PowerClient) successPiece(content *bytes.Buffer) *Piece {
 
 func (pc *PowerClient) failPiece() *Piece {
 	return NewPiece(pc.taskID, pc.node, pc.pieceTask.Cid, pc.pieceTask.Range,
-		config.ResultFail, config.TaskStatusRunning)
+		constants.ResultFail, constants.TaskStatusRunning)
 }
 
 func (pc *PowerClient) is2xxStatus(code int) bool {

--- a/dfget/core/helper/test_helper.go
+++ b/dfget/core/helper/test_helper.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/dragonflyoss/Dragonfly/common/constants"
 	"github.com/dragonflyoss/Dragonfly/common/util"
 	"github.com/dragonflyoss/Dragonfly/dfget/config"
 	"github.com/dragonflyoss/Dragonfly/dfget/types"
@@ -164,13 +165,13 @@ func CreateRegisterFunc() RegisterFuncType {
 		case "":
 			return newResponse(501, "invalid source url"), nil
 		case "http://taobao.com":
-			return newResponse(config.TaskCodeNeedAuth, "need auth"), nil
+			return newResponse(constants.CodeNeedAuth, "need auth"), nil
 		case "http://github.com":
-			return newResponse(config.TaskCodeWaitAuth, "wait auth"), nil
+			return newResponse(constants.CodeWaitAuth, "wait auth"), nil
 		case "http://x.com":
-			return newResponse(config.TaskCodeURLNotReachable, "not reachable"), nil
+			return newResponse(constants.CodeURLNotReachable, "not reachable"), nil
 		case "http://lowzj.com":
-			resp := newResponse(config.Success, "")
+			resp := newResponse(constants.Success, "")
 			resp.Data = &types.RegisterResponseData{
 				TaskID:     "a",
 				FileLength: 100,

--- a/dfget/core/regist/register.go
+++ b/dfget/core/regist/register.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/dragonflyoss/Dragonfly/common/constants"
 	"github.com/dragonflyoss/Dragonfly/common/util"
 	"github.com/dragonflyoss/Dragonfly/dfget/config"
 	"github.com/dragonflyoss/Dragonfly/dfget/core/api"
@@ -68,10 +69,10 @@ func (s *supernodeRegister) Register(peerPort int) (*RegisterResult, *errors.DFG
 			logrus.Errorf("register to node:%s error:%v", nodes[i], e)
 			continue
 		}
-		if resp.Code == config.Success || resp.Code == config.TaskCodeNeedAuth {
+		if resp.Code == constants.Success || resp.Code == constants.CodeNeedAuth {
 			break
 		}
-		if resp.Code == config.TaskCodeWaitAuth && retryTimes < 3 {
+		if resp.Code == constants.CodeWaitAuth && retryTimes < 3 {
 			i--
 			retryTimes++
 			logrus.Infof("sleep 2.5s to wait auth(%d/3)...", retryTimes)
@@ -94,12 +95,12 @@ func (s *supernodeRegister) Register(peerPort int) (*RegisterResult, *errors.DFG
 
 func (s *supernodeRegister) checkResponse(resp *types.RegisterResponse, e error) *errors.DFGetError {
 	if e != nil {
-		return errors.New(config.HTTPError, e.Error())
+		return errors.New(constants.HTTPError, e.Error())
 	}
 	if resp == nil {
-		return errors.New(config.HTTPError, "empty response, unknown error")
+		return errors.New(constants.HTTPError, "empty response, unknown error")
 	}
-	if resp.Code != config.Success {
+	if resp.Code != constants.Success {
 		return errors.New(resp.Code, resp.Msg)
 	}
 	return nil

--- a/dfget/core/regist/register_test.go
+++ b/dfget/core/regist/register_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/dragonflyoss/Dragonfly/common/constants"
 	"github.com/dragonflyoss/Dragonfly/dfget/config"
 	. "github.com/dragonflyoss/Dragonfly/dfget/core/helper"
 	"github.com/go-check/check"
@@ -90,26 +91,26 @@ func (s *RegistTestSuite) TestSupernodeRegister_Register(c *check.C) {
 	}
 
 	cfg.Node = []string{""}
-	f(config.HTTPError, "connection refused", nil)
+	f(constants.HTTPError, "connection refused", nil)
 
 	cfg.Node = []string{"x"}
 	f(501, "invalid source url", nil)
 
 	cfg.Node = []string{"x"}
 	cfg.URL = "http://taobao.com"
-	f(config.TaskCodeNeedAuth, "need auth", nil)
+	f(constants.CodeNeedAuth, "need auth", nil)
 
 	cfg.Node = []string{"x"}
 	cfg.URL = "http://github.com"
-	f(config.TaskCodeWaitAuth, "wait auth", nil)
+	f(constants.CodeWaitAuth, "wait auth", nil)
 
 	cfg.Node = []string{"x"}
 	cfg.URL = "http://lowzj.com"
-	f(config.Success, "", &RegisterResult{
+	f(constants.Success, "", &RegisterResult{
 		Node: "x", RemainderNodes: []string{}, URL: cfg.URL, TaskID: "a",
 		FileLength: 100, PieceSize: 10})
 
-	f(config.HTTPError, "empty response, unknown error", nil)
+	f(constants.HTTPError, "empty response, unknown error", nil)
 }
 
 func (s *RegistTestSuite) TestSupernodeRegister_constructRegisterRequest(c *check.C) {

--- a/dfget/types/pull_piece_task_response.go
+++ b/dfget/types/pull_piece_task_response.go
@@ -19,7 +19,7 @@ package types
 import (
 	"encoding/json"
 
-	"github.com/dragonflyoss/Dragonfly/dfget/config"
+	"github.com/dragonflyoss/Dragonfly/common/constants"
 )
 
 // PullPieceTaskResponse is the response of PullPieceTaskRequest.
@@ -38,7 +38,7 @@ func (res *PullPieceTaskResponse) String() string {
 
 // FinishData gets structured data from json.RawMessage when the task is finished.
 func (res *PullPieceTaskResponse) FinishData() *PullPieceTaskResponseFinishData {
-	if res.Code != config.TaskCodeFinish || res.Data == nil {
+	if res.Code != constants.CodePeerFinish || res.Data == nil {
 		return nil
 	}
 	if res.data == nil {
@@ -53,7 +53,7 @@ func (res *PullPieceTaskResponse) FinishData() *PullPieceTaskResponseFinishData 
 
 // ContinueData gets structured data from json.RawMessage when the task is continuing.
 func (res *PullPieceTaskResponse) ContinueData() []*PullPieceTaskResponseContinueData {
-	if res.Code != config.TaskCodeContinue || res.Data == nil {
+	if res.Code != constants.CodePeerContinue || res.Data == nil {
 		return nil
 	}
 	if res.data == nil {

--- a/dfget/types/types_test.go
+++ b/dfget/types/types_test.go
@@ -23,7 +23,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dragonflyoss/Dragonfly/dfget/config"
+	"github.com/dragonflyoss/Dragonfly/common/constants"
+
 	"github.com/go-check/check"
 )
 
@@ -80,7 +81,7 @@ func (suite *TypesSuite) TestPullPieceTaskResponse_FinishData(c *check.C) {
 
 	c.Assert(res.FinishData(), check.IsNil)
 
-	res.Code = config.TaskCodeFinish
+	res.Code = constants.CodePeerFinish
 	c.Assert(res.FinishData(), check.IsNil)
 
 	res.Data = []byte("x")
@@ -98,7 +99,7 @@ func (suite *TypesSuite) TestPullPieceTaskResponse_ContinueData(c *check.C) {
 
 	c.Assert(res.ContinueData(), check.IsNil)
 
-	res.Code = config.TaskCodeContinue
+	res.Code = constants.CodePeerContinue
 	c.Assert(res.ContinueData(), check.IsNil)
 
 	res.Data = []byte("x")


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

In the process of dfget interacting with supernode, and both parties reached an agreement on the return code in order to better understand each other. So we should make codes as a public part.

 For supernode, there are three kinds of status codes: 
+ the code from dfget: PeerTaskRequestResult, PeerTaskRequestStatus
+ the result code  returned to the dfget：ResultCode
+ the status information maintained in memory：PeerPieceStatus, PeerTaskStatus, CdnStatus, PreheatTaskStatus

And the code of `PeerTaskRequestResult` and `PeerTaskRequestStatus` from dfget will converted to the status of `PeerPieceStatus` and `PeerTaskStatus` by supernode.

<image width="480" height="550" src="https://user-images.githubusercontent.com/31209634/54409805-9aea8900-4723-11e9-9ccd-9c505643514c.png" />



### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

None.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

I named this file as `dfget_super_code.go`. And we can also add a file named `dfget_daemon_code.go` to define the result code between `dfget` and `dfdaemon`  in the future.


In addition, I have drawn a very simple state code transformation diagram and for reference only.

<image  src="https://user-images.githubusercontent.com/31209634/54410064-d20d6a00-4724-11e9-925f-7f2ca2b6e772.png"/>

