### PR TITLE
bugfix: add context for the interface of storage driver

### DIFF
--- a/supernode/store/local_storage_test.go
+++ b/supernode/store/local_storage_test.go
@@ -18,6 +18,7 @@ package store
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -108,10 +109,10 @@ func (s *LocalStorageSuite) TestGetPutBytes(c *check.C) {
 
 	for _, v := range cases {
 		// put
-		s.storeLocal.PutBytes(v.raw, v.data)
+		s.storeLocal.PutBytes(context.Background(), v.raw, v.data)
 
 		// get
-		result, err := s.storeLocal.GetBytes(v.raw)
+		result, err := s.storeLocal.GetBytes(context.Background(), v.raw)
 		c.Assert(err, check.IsNil)
 		c.Assert(string(result), check.Equals, v.expected)
 
@@ -159,11 +160,11 @@ func (s *LocalStorageSuite) TestGetPut(c *check.C) {
 
 	for _, v := range cases {
 		// put
-		s.storeLocal.Put(v.raw, v.data)
+		s.storeLocal.Put(context.Background(), v.raw, v.data)
 
 		// get
 		buf1 := new(bytes.Buffer)
-		err := s.storeLocal.Get(v.raw, buf1)
+		err := s.storeLocal.Get(context.Background(), v.raw, buf1)
 		c.Assert(err, check.IsNil)
 		c.Assert(buf1.String(), check.Equals, v.expected)
 
@@ -195,7 +196,7 @@ func (s *LocalStorageSuite) TestGetPrefix(c *check.C) {
 // helper function
 
 func (s *LocalStorageSuite) checkStat(raw *Raw, c *check.C) {
-	info, err := s.storeLocal.Stat(raw)
+	info, err := s.storeLocal.Stat(context.Background(), raw)
 	c.Assert(err, check.IsNil)
 
 	cfg := s.storeLocal.config.(*localStorage)
@@ -212,9 +213,9 @@ func (s *LocalStorageSuite) checkStat(raw *Raw, c *check.C) {
 }
 
 func (s *LocalStorageSuite) checkRemove(raw *Raw, c *check.C) {
-	err := s.storeLocal.Remove(raw)
+	err := s.storeLocal.Remove(context.Background(), raw)
 	c.Assert(err, check.IsNil)
 
-	_, err = s.storeLocal.Stat(raw)
+	_, err = s.storeLocal.Stat(context.Background(), raw)
 	c.Assert(err, check.DeepEquals, ErrNotFound)
 }

--- a/supernode/store/storage_driver.go
+++ b/supernode/store/storage_driver.go
@@ -17,6 +17,7 @@
 package store
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"time"
@@ -42,31 +43,31 @@ type StorageDriver interface {
 	// The data should be written into the writer as io stream.
 	// If the length<=0, the driver should return all data from the raw.offest.
 	// Otherwise, just return the data which starts from raw.offset and the length is raw.length.
-	Get(raw *Raw, writer io.Writer) error
+	Get(ctx context.Context, raw *Raw, writer io.Writer) error
 
 	// Get data from the storage based on raw information.
 	// The data should be returned in bytes.
 	// If the length<=0, the storage driver should return all data from the raw.offest.
 	// Otherwise, just return the data which starts from raw.offset and the length is raw.length.
-	GetBytes(raw *Raw) ([]byte, error)
+	GetBytes(ctx context.Context, raw *Raw) ([]byte, error)
 
 	// Put the data into the storage with raw information.
 	// The storage will get data from io.Reader as io stream.
 	// If the offset>0, the storage driver should starting at byte raw.offset off.
-	Put(raw *Raw, data io.Reader) error
+	Put(ctx context.Context, raw *Raw, data io.Reader) error
 
 	// PutBytes puts the data into the storage with raw information.
 	// The data is passed in bytes.
 	// If the offset>0, the storage driver should starting at byte raw.offset off.
-	PutBytes(raw *Raw, data []byte) error
+	PutBytes(ctx context.Context, raw *Raw, data []byte) error
 
 	// Remove the data from the storage based on raw information.
-	Remove(raw *Raw) error
+	Remove(ctx context.Context, raw *Raw) error
 
 	// Stat determine whether the data exists based on raw information.
 	// If that, and return some info that in the form of struct StorageInfo.
 	// If not, return the ErrNotFound.
-	Stat(raw *Raw) (*StorageInfo, error)
+	Stat(ctx context.Context, raw *Raw) (*StorageInfo, error)
 }
 
 // Raw identifies a piece of data uniquely.

--- a/supernode/store/store.go
+++ b/supernode/store/store.go
@@ -17,6 +17,7 @@
 package store
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -54,53 +55,53 @@ func NewStore(name string, cfg interface{}) (*Store, error) {
 }
 
 // Get the data from the storage driver in io stream.
-func (s *Store) Get(raw *Raw, writer io.Writer) error {
+func (s *Store) Get(ctx context.Context, raw *Raw, writer io.Writer) error {
 	if err := isEmptyKey(raw.key); err != nil {
 		return err
 	}
-	return s.driver.Get(raw, writer)
+	return s.driver.Get(ctx, raw, writer)
 }
 
 // GetBytes gets the data from the storage driver in bytes.
-func (s *Store) GetBytes(raw *Raw) ([]byte, error) {
+func (s *Store) GetBytes(ctx context.Context, raw *Raw) ([]byte, error) {
 	if err := isEmptyKey(raw.key); err != nil {
 		return nil, err
 	}
-	return s.driver.GetBytes(raw)
+	return s.driver.GetBytes(ctx, raw)
 }
 
 // Put puts data into the storage in io stream.
-func (s *Store) Put(raw *Raw, data io.Reader) error {
+func (s *Store) Put(ctx context.Context, raw *Raw, data io.Reader) error {
 	if err := isEmptyKey(raw.key); err != nil {
 		return err
 	}
-	return s.driver.Put(raw, data)
+	return s.driver.Put(ctx, raw, data)
 }
 
 // PutBytes puts data into the storage in bytes.
-func (s *Store) PutBytes(raw *Raw, data []byte) error {
+func (s *Store) PutBytes(ctx context.Context, raw *Raw, data []byte) error {
 	if err := isEmptyKey(raw.key); err != nil {
 		return err
 	}
-	return s.driver.PutBytes(raw, data)
+	return s.driver.PutBytes(ctx, raw, data)
 }
 
 // Remove the data from the storage based on raw information.
-func (s *Store) Remove(raw *Raw) error {
+func (s *Store) Remove(ctx context.Context, raw *Raw) error {
 	if err := isEmptyKey(raw.key); err != nil {
 		return err
 	}
-	return s.driver.Remove(raw)
+	return s.driver.Remove(ctx, raw)
 }
 
 // Stat determine whether the data exists based on raw information.
 // If that, and return some info that in the form of struct StorageInfo.
 // If not, return the ErrNotFound.
-func (s *Store) Stat(raw *Raw) (*StorageInfo, error) {
+func (s *Store) Stat(ctx context.Context, raw *Raw) (*StorageInfo, error) {
 	if err := isEmptyKey(raw.key); err != nil {
 		return nil, err
 	}
-	return s.driver.Stat(raw)
+	return s.driver.Stat(ctx, raw)
 }
 
 func isEmptyKey(str string) error {


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
1. Add a `context` parameter for the interface of storage driver which carries deadlines, cancelation signals, and other request-scoped values across API boundaries and between processes.
2. update the local storage implementation.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

None.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


