### PR TITLE
feature: make supernode configurable for dfget with dfdaemon

### DIFF
--- a/cmd/dfdaemon/app/options/options.go
+++ b/cmd/dfdaemon/app/options/options.go
@@ -84,6 +84,9 @@ type Options struct {
 	// ConfigPath is the path of dfdaemon's configuration file.
 	// default value is: /etc/dragonfly/dfdaemon.yml
 	ConfigPath string
+
+	// SupernodeList specify supernode list.
+	SupernodeList []string
 }
 
 // NewOption returns the default options.
@@ -125,6 +128,7 @@ func (o *Options) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&o.DownRule, "rule", "", "download the url by P2P if url matches the specified pattern,format:reg1,reg2,reg3")
 	fs.BoolVar(&o.Notbs, "notbs", true, "not try back source to download if throw exception")
 	fs.StringSliceVar(&o.TrustHosts, "trust-hosts", o.TrustHosts, "list of trusted hosts which dfdaemon forward their requests directly, comma separated.")
+	fs.StringSliceVar(&o.SupernodeList, "node", o.SupernodeList, "specify the addresses(IP:port) of supnernodes that will be passed to dfget.")
 
 	fs.StringVar(&o.ConfigPath, "config", constant.DefaultConfigPath,
 		"the path of dfdaemon's configuration file")

--- a/dfdaemon/downloader/dfget/dfget.go
+++ b/dfdaemon/downloader/dfget/dfget.go
@@ -43,18 +43,21 @@ type DFGetter struct {
 	callSystem string
 	// the notbs param of dfget
 	notbs bool
+
+	supernodes []string
 }
 
 var _ downloader.Interface = &DFGetter{}
 
 // NewDFGetter returns the default DFGetter.
-func NewDFGetter(dstDir, callSystem string, notbs bool, rateLimit, urlFilter string) *DFGetter {
+func NewDFGetter(dstDir, callSystem string, notbs bool, rateLimit, urlFilter string, supernodes []string) *DFGetter {
 	return &DFGetter{
 		dstDir:     dstDir,
 		callSystem: callSystem,
 		notbs:      notbs,
 		rateLimit:  rateLimit,
 		urlFilter:  urlFilter,
+		supernodes: supernodes,
 	}
 }
 
@@ -95,6 +98,9 @@ func (dfGetter *DFGetter) parseCommand(url string, header map[string][]string, n
 	if strings.TrimSpace(dfGetter.rateLimit) != "" {
 		args = append(append(args, "-s"), dfGetter.rateLimit)
 		args = append(append(args, "--totallimit"), dfGetter.rateLimit)
+	}
+	if dfGetter.supernodes != nil && len(dfGetter.supernodes) > 0 {
+		args = append(append(args, "--node"), strings.Join(dfGetter.supernodes, ","))
 	}
 
 	if header != nil {

--- a/dfdaemon/global/global.go
+++ b/dfdaemon/global/global.go
@@ -57,6 +57,9 @@ type CommandParam struct {
 	// TrustHosts includes the trusted hosts as keys of the map which dfdaemon forward their
 	// requests directly when dfdaemon is used to http_proxy mode.
 	TrustHosts map[string]string
+
+	// SupernodeList specify supernode list.
+	SupernodeList []string
 }
 
 var (

--- a/dfdaemon/handler/transport.go
+++ b/dfdaemon/handler/transport.go
@@ -74,6 +74,7 @@ func NewDFRoundTripper(cfg *tls.Config) *DFRoundTripper {
 			global.CommandLine.Notbs,
 			global.CommandLine.RateLimit,
 			global.CommandLine.URLFilter,
+			global.CommandLine.SupernodeList,
 		),
 	}
 }

--- a/dfdaemon/initializer/initializer.go
+++ b/dfdaemon/initializer/initializer.go
@@ -239,15 +239,16 @@ func initParam(options *options.Options) {
 	// copy options to g.CommandLine so we do not break anything, but finally
 	// we should get rid of g.CommandLine totally.
 	g.CommandLine = global.CommandParam{
-		DfPath:     options.DfPath,
-		DFRepo:     options.DFRepo,
-		RateLimit:  options.RateLimit,
-		CallSystem: options.CallSystem,
-		URLFilter:  options.URLFilter,
-		Notbs:      options.Notbs,
-		HostIP:     options.HostIP,
-		Registry:   options.Registry,
-		TrustHosts: parsedTrustHosts,
+		DfPath:        options.DfPath,
+		DFRepo:        options.DFRepo,
+		RateLimit:     options.RateLimit,
+		CallSystem:    options.CallSystem,
+		URLFilter:     options.URLFilter,
+		Notbs:         options.Notbs,
+		HostIP:        options.HostIP,
+		Registry:      options.Registry,
+		TrustHosts:    parsedTrustHosts,
+		SupernodeList: options.SupernodeList,
 	}
 
 	initProperties(options)


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Add a `super-nodes` flag for dfdaemon.
The reason to do this is that we can only configure the supernode which used by dfget through the configuration file(`/etc/dragonfly.conf` in default). It may be more convenient  in the test environment or the scenario that someone who just want to have a try with dragonfly quickly.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

None.

### Ⅳ. Describe how to verify it

1. Start dfdaemon with `dfdaemon --super-nodes 127.0.0.1,192.168.33.12 --registry https://index.docker.io`.
NOTE: set your own supernode IP.

2. Configure Docker Daemon.

3. Use docker client to pull a test image: `docker pull busybox:latest`.

4. Check the logs with `grep "do register to" ~/.small-dragonfly/logs/dfclient.log`
If the output of command above has content like
```
2019-04-03 08:44:01.377 INFO sign:14707-1554281041.247 : do register to one of [127.0.0.1 192.168.33.12 127.0.0.1 192.168.33.12]
```
and then it proves that this PR works.

### Ⅴ. Special notes for reviews


