### PR TITLE
feature: implement the progress mgr for get/delete info

### DIFF
--- a/common/errors/errors.go
+++ b/common/errors/errors.go
@@ -55,6 +55,7 @@ const (
 	codeSystemError
 	codeCDNFail
 	codeCDNWait
+	codePeerWait
 )
 
 // DfError represents a Dragonfly error.

--- a/common/errors/supernode_errors.go
+++ b/common/errors/supernode_errors.go
@@ -26,6 +26,9 @@ var (
 
 	// ErrCDNWait represents the cdn status is wait.
 	ErrCDNWait = DfError{codeCDNWait, "cdn status is wait"}
+
+	// ErrPeerWait represents the peer should wait.
+	ErrPeerWait = DfError{codePeerWait, "peer should wait"}
 )
 
 // IsSystemError check the error is a system error or not.
@@ -41,4 +44,9 @@ func IsCDNFail(err error) bool {
 // IsCDNWait check the error is CDNWait or not.
 func IsCDNWait(err error) bool {
 	return checkError(err, codeCDNWait)
+}
+
+// IsPeerWait check the error is PeerWait or not.
+func IsPeerWait(err error) bool {
+	return checkError(err, codePeerWait)
 }

--- a/supernode/daemon/mgr/progress/progress_manager_test.go
+++ b/supernode/daemon/mgr/progress/progress_manager_test.go
@@ -1,0 +1,102 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package progress
+
+import (
+	"testing"
+
+	errorType "github.com/dragonflyoss/Dragonfly/common/errors"
+
+	"github.com/go-check/check"
+	"github.com/willf/bitset"
+)
+
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
+
+func init() {
+	check.Suite(&ProgressManagerTestSuite{})
+}
+
+type ProgressManagerTestSuite struct {
+}
+
+func (s *ProgressManagerTestSuite) TestGetSuccessfulPieces(c *check.C) {
+	var cases = []struct {
+		clientBitset *bitset.BitSet
+		cdnBitset    *bitset.BitSet
+		expected     []int
+		errCheck     func(error) bool
+	}{
+		{
+			clientBitset: bitset.New(16).Set(1).Set(9),
+			cdnBitset:    bitset.New(16).Set(1).Set(9),
+			expected:     []int{0, 1},
+			errCheck:     errorType.IsNilError,
+		},
+		{
+			clientBitset: bitset.New(16).Set(9),
+			cdnBitset:    bitset.New(16).Set(1).Set(9),
+			expected:     []int{1},
+			errCheck:     errorType.IsNilError,
+		},
+		{
+			clientBitset: bitset.New(16).Set(2).Set(9),
+			cdnBitset:    bitset.New(16).Set(1).Set(9),
+			expected:     []int{1},
+			errCheck:     errorType.IsNilError,
+		},
+	}
+
+	for _, v := range cases {
+		result, err := getSuccessfulPieces(v.clientBitset, v.cdnBitset)
+		c.Check(v.errCheck(err), check.Equals, true)
+		c.Check(result, check.DeepEquals, v.expected)
+	}
+}
+
+func (s *ProgressManagerTestSuite) TestGetAvailablePieces(c *check.C) {
+	var cases = []struct {
+		clientBitset  *bitset.BitSet
+		cdnBitset     *bitset.BitSet
+		runningPieces []int
+		expected      []int
+		errCheck      func(error) bool
+	}{
+		{
+			clientBitset:  bitset.New(24).Set(8),
+			cdnBitset:     bitset.New(24).Set(1).Set(9),
+			runningPieces: []int{1},
+			expected:      []int{0},
+			errCheck:      errorType.IsNilError,
+		},
+		{
+			clientBitset:  bitset.New(24).Set(8),
+			cdnBitset:     bitset.New(24).Set(1).Set(9).Set(18),
+			runningPieces: []int{1},
+			expected:      nil,
+			errCheck:      errorType.IsCDNFail,
+		},
+	}
+
+	for _, v := range cases {
+		result, err := getAvailablePieces(v.clientBitset, v.cdnBitset, v.runningPieces)
+		c.Check(v.errCheck(err), check.Equals, true)
+		c.Check(result, check.DeepEquals, v.expected)
+	}
+}

--- a/supernode/daemon/mgr/progress/progress_state.go
+++ b/supernode/daemon/mgr/progress/progress_state.go
@@ -18,7 +18,7 @@ type clientState struct {
 	pieceBitSet *bitset.BitSet
 
 	// runningPiece maintains the pieces currently being downloaded from dstCID to srcCID.
-	// key:pieceNum,value:dstCID
+	// key:pieceNum,value:dstPID
 	runningPiece *cutil.SyncMap
 }
 
@@ -59,6 +59,8 @@ func newClientState() *clientState {
 
 func newPeerState() *peerState {
 	return &peerState{
-		producerLoad: cutil.NewAtomicInt(0),
+		producerLoad:      cutil.NewAtomicInt(0),
+		clientErrorCount:  cutil.NewAtomicInt(0),
+		serviceErrorCount: cutil.NewAtomicInt(0),
 	}
 }

--- a/supernode/daemon/mgr/progress_mgr.go
+++ b/supernode/daemon/mgr/progress_mgr.go
@@ -4,7 +4,26 @@ import (
 	"context"
 
 	"github.com/dragonflyoss/Dragonfly/apis/types"
+	cutil "github.com/dragonflyoss/Dragonfly/common/util"
 )
+
+// PeerState maintains peer related information.
+type PeerState struct {
+	// PeerID identifies a peer uniquely.
+	PeerID string
+
+	// ProducerLoad is the load of download services provided by the current node.
+	ProducerLoad int32
+
+	// ClientErrorCount maintains the number of times that PeerID failed to downloaded from the other peer nodes.
+	ClientErrorCount int32
+
+	// ServiceErrorCount maintains the number of times that the other peer nodes failed to downloaded from the PeerID.
+	ServiceErrorCount int32
+
+	// ServiceDownTime the down time of the peer service.
+	ServiceDownTime int64
+}
 
 // ProgressMgr is responsible for maintaining the correspondence between peer and pieces.
 type ProgressMgr interface {
@@ -12,17 +31,34 @@ type ProgressMgr interface {
 	InitProgress(ctx context.Context, taskID, peerID, clientID string) error
 
 	// UpdateProgress update the correlation information between peers and pieces.
-	// 1. update the info about srcCid to tell the scheduler that corresponding peer has the piece now.
-	// 2. update the info about dstCid to tell the scheduler that someone has downloaded the piece form here.
+	// 1. update the info about srcCID to tell the scheduler that corresponding peer has the piece now.
+	// 2. update the info about dstPID to tell the scheduler that someone has downloaded the piece form here.
 	// Scheduler will calculate the load and times of error/success for every peer to make better decisions.
-	UpdateProgress(ctx context.Context, taskID, srcCID, dstCID, srcPID, dstPID, pieceRange string, pieceStatus int) error
+	UpdateProgress(ctx context.Context, taskID, srcCID, srcPID, dstPID string, pieceNum, pieceStatus int) error
 
-	// GetPieceByCID get all pieces with specified clientID.
-	GetPieceByCID(ctx context.Context, taskID, clientID, pieceStatus string) (pieceNums []int, err error)
+	// GetPieceProgressByCID get all pieces progress with specified clientID.
+	// The filter parameter depends on the specific implementation.
+	GetPieceProgressByCID(ctx context.Context, taskID, clientID, filter string) (pieceNums []int, err error)
 
-	// GetPeersByPieceNum get all peers ID with specified taskID and pieceNum.
-	GetPeersByPieceNum(ctx context.Context, taskID string, pieceNum int) (peerIDs []string, err error)
+	// DeletePieceProgressByCID delete the pieces progress with specified clientID.
+	DeletePieceProgressByCID(ctx context.Context, taskID, clientID string) (err error)
+
+	// GetPeerIDsByPieceNum gets all peerIDs with specified taskID and pieceNum.
+	GetPeerIDsByPieceNum(ctx context.Context, taskID string, pieceNum int) (peerIDs []string, err error)
+
+	// DeletePeerIDByPieceNum deletes the peerID which means that
+	// the peer no longer provides the service for the pieceNum of taskID.
+	DeletePeerIDByPieceNum(ctx context.Context, taskID string, pieceNum int, peerID string) error
+
+	// GetPeerStateByPeerID gets peer state with specified peerID.
+	GetPeerStateByPeerID(ctx context.Context, peerID string) (peerState *PeerState, err error)
+
+	// DeletePeerStateByPeerID deletes the peerState by PeerID.
+	DeletePeerStateByPeerID(ctx context.Context, peerID string) error
 
 	// GetPeersByTaskID get all peers info with specified taskID.
 	GetPeersByTaskID(ctx context.Context, taskID string) (peersInfo []*types.PeerInfo, err error)
+
+	// GetBlackInfoByPeerID get black info with specified peerID.
+	GetBlackInfoByPeerID(ctx context.Context, peerID string) (dstPIDMap *cutil.SyncMap, err error)
 }


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
For `ProgreeMgr`, it will maintain the correspondence between the peers and pieces as follows:

+ ClientID->PieceNums
+ PieceNum->PeerIDs

**NOTE:**

+ A `ClientID` corresponds to a unique peer and task.
+ A `PieceNum`  corresponds to a unique piece.
+ A `PeerID` corresponds to a unique peer node.

And the information should be readable and writable. So I updated the get and delete interfaces as follows:

```
// GetPieceProgressByCID get all pieces progress with specified clientID.
// And the pieceStatus should be one of the `PieceRunning`,`PieceSuccess` and `PieceAvailable`.
GetPieceProgressByCID(ctx context.Context, taskID, clientID, pieceStatus string) (pieceNums []int, err error)

// DeletePieceProgressByCID delete the pieces progress with specified clientID.
DeletePieceProgressByCID(ctx context.Context, taskID, clientID string) (err error)

// GetPeerIDsByPieceNum gets all peerIDs with specified taskID and pieceNum.
GetPeerIDsByPieceNum(ctx context.Context, taskID string, pieceNum int) (peerIDs []string, err error)

// DeletePeerIDByPieceNum deletes the peerID wich means that
// the peer no longer provides the service for the pieceNum of taskID.
DeletePeerIDByPieceNum(ctx context.Context, taskID string, pieceNum int, peerID string) error

```

In the mean time, `ProgreeMgr` will maintain some information of a peer.
```
// PeerState maintains peer related information.
type PeerState struct {
// PeerID identifies a peer uniquely.
PeerID string

// ProducerLoad is the load of download services provided by the current node.
ProducerLoad int32

// ClientErrorCount maintains the number of times that PeerID failed to downloaded from the other peer nodes.
ClientErrorCount int32

// ServiceErrorCount maintains the number of times that the other peer nodes failed to downloaded from the PeerID.
ServiceErrorCount int32

// ServiceDownTime the down time of the peer service.
ServiceDownTime int64
}
```
So I add the get and delete interfaces as follows:
```
// GetPeerStateByPeerID gets peer state with specified peerID.
GetPeerStateByPeerID(ctx context.Context, peerID string) (*PeerState, error)

// DeletePeerStateByPeerID deletes the peerState by PeerID.
DeletePeerStateByPeerID(ctx context.Context, peerID string) error

```

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.
### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
Added.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
Use `PieceNum` instead of `PieceRange` as the key of a piece.
