### PR TITLE
feature: add transparent proxy to extend dfdaemon's proxy mode

### DIFF
--- a/cmd/dfdaemon/app/options/options.go
+++ b/cmd/dfdaemon/app/options/options.go
@@ -63,6 +63,9 @@ type Options struct {
 	// Port that dfdaemon will listen, default: 65001.
 	Port uint
 
+	// ProxyPort is the port used by the dfdaemon transparent proxy
+	ProxyPort uint
+
 	// Registry addr and must exist if dfdaemon is used to mirror mode,
 	// format: https://xxx.xx.x:port or http://xxx.xx.x:port.
 	Registry string
@@ -115,6 +118,7 @@ func (o *Options) AddFlags(fs *flag.FlagSet) {
 	// http server config
 	fs.StringVar(&o.HostIP, "hostIp", "127.0.0.1", "dfdaemon host ip, default: 127.0.0.1")
 	fs.UintVar(&o.Port, "port", 65001, "dfdaemon will listen the port")
+	fs.UintVar(&o.ProxyPort, "proxyPort", 65002, "the port dfdaemon proxy listens on")
 	fs.StringVar(&o.CertFile, "certpem", "", "cert.pem file path")
 	fs.StringVar(&o.KeyFile, "keypem", "", "key.pem file path")
 

--- a/cmd/dfdaemon/app/root.go
+++ b/cmd/dfdaemon/app/root.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/dragonflyoss/Dragonfly/cmd/dfdaemon/app/options"
 	"github.com/dragonflyoss/Dragonfly/dfdaemon/initializer"
+	"github.com/dragonflyoss/Dragonfly/dfdaemon/proxy"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -52,6 +53,17 @@ func init() {
 // start to run dfdaemon server.
 func runDaemon() error {
 	initOption(opt)
+
+	s := http.Server{
+		Addr: ":65002",
+		Handler: proxy.New([]proxy.Rule{
+			{
+				Match: "/blobs/sha256/",
+			},
+		}),
+	}
+	fmt.Println(s.Addr)
+	go fmt.Println(s.ListenAndServe())
 
 	logrus.Infof("start dfdaemon param: %+v", opt)
 

--- a/cmd/dfdaemon/app/root.go
+++ b/cmd/dfdaemon/app/root.go
@@ -61,7 +61,9 @@ func runTransparentProxy(opt *options.Options) error {
 		Handler: tp,
 	}
 	logrus.Infof("launch dfdaemon transparent proxy on %s:%d", opt.HostIP, opt.ProxyPort)
-	go logrus.Fatalf("Transparent proxy stopped: %v", s.ListenAndServe())
+	go func() {
+		logrus.Fatalf("Transparent proxy stopped: %v", s.ListenAndServe())
+	}()
 	return nil
 }
 

--- a/dfdaemon/config/config.go
+++ b/dfdaemon/config/config.go
@@ -64,9 +64,8 @@ type Properties struct {
 	// with those origin schema and host.
 	Registries []*Registry `yaml:"registries"`
 	// Proxies is the list of rules for the transparent proxy. If no rules
-	// are provided, all requests will be proxied directly. Currently
-	// a request must go through all the rules to determine whether it
-	// should be proxied with dfget.
+	// are provided, all requests will be proxied directly. Request will be
+	// proxied with the first matching rule.
 	Proxies []*Proxy `yaml:"proxies"`
 }
 
@@ -202,6 +201,18 @@ type Proxy struct {
 	Direct   bool   `yaml:"direct"`
 
 	match *regexp.Regexp
+}
+
+func NewProxy(regx string, useHTTPS bool, direct bool) (*Proxy, error) {
+	p := &Proxy{
+		Regx:     regx,
+		UseHTTPS: useHTTPS,
+		Direct:   direct,
+	}
+	if err := p.init(); err != nil {
+		return nil, err
+	}
+	return p, nil
 }
 
 func (r *Proxy) init() (err error) {

--- a/dfdaemon/config/config.go
+++ b/dfdaemon/config/config.go
@@ -49,11 +49,25 @@ func NewProperties() *Properties {
 //           schema: https
 //           host: reg.com
 //           certs: ['/etc/ssl/reg.com/server.crt']
+//     proxies:
+//     # proxy all http image layer download requests with dfget
+//     - regx: blob/sha256/.*
+//     # change http requests to some-registry to https and proxy them with dfget
+//     - regx: some-registry/
+//       use_https: true
+//     # proxy requests directly, without dfget
+//     - regx: no-proxy-reg
+//       direct: true
 type Properties struct {
 	// Registries the more front the position, the higher priority.
 	// You could add an empty Registry at the end to proxy all other requests
 	// with those origin schema and host.
 	Registries []*Registry `yaml:"registries"`
+	// Proxies is the list of rules for the transparent proxy. If no rules
+	// are provided, all requests will be proxied directly. Currently
+	// a request must go through all the rules to determine whether it
+	// should be proxied with dfget.
+	Proxies []*Proxy `yaml:"proxies"`
 }
 
 // Load loads properties from config file.
@@ -61,6 +75,7 @@ func (p *Properties) Load(path string) error {
 	if err := util.LoadYaml(path, p); err != nil {
 		return err
 	}
+
 	var tmp []*Registry
 	for _, v := range p.Registries {
 		if v != nil {
@@ -71,6 +86,18 @@ func (p *Properties) Load(path string) error {
 		}
 	}
 	p.Registries = tmp
+
+	var tmpProxies []*Proxy
+	for _, v := range p.Proxies {
+		if v != nil {
+			if err := v.init(); err != nil {
+				return err
+			}
+			tmpProxies = append(tmpProxies, v)
+		}
+	}
+	p.Proxies = tmpProxies
+
 	return nil
 }
 
@@ -166,4 +193,22 @@ func (r *Registry) initTLSConfig() error {
 	}
 	r.tlsConfig = &tls.Config{RootCAs: roots}
 	return nil
+}
+
+// Proxy describe a regular expression matching rule for how to proxy a request
+type Proxy struct {
+	Regx     string `yaml:"regx"`
+	UseHTTPS bool   `yaml:"use_https"`
+	Direct   bool   `yaml:"direct"`
+
+	match *regexp.Regexp
+}
+
+func (r *Proxy) init() (err error) {
+	r.match, err = regexp.Compile(r.Regx)
+	return err
+}
+
+func (r *Proxy) Match(url string) bool {
+	return r.match != nil && r.match.MatchString(url)
 }

--- a/dfdaemon/config/config.go
+++ b/dfdaemon/config/config.go
@@ -203,6 +203,7 @@ type Proxy struct {
 	match *regexp.Regexp
 }
 
+// NewProxy returns a new proxy rule with given attributes
 func NewProxy(regx string, useHTTPS bool, direct bool) (*Proxy, error) {
 	p := &Proxy{
 		Regx:     regx,
@@ -220,6 +221,7 @@ func (r *Proxy) init() (err error) {
 	return err
 }
 
+// Match checks if the given url matches the rule
 func (r *Proxy) Match(url string) bool {
 	return r.match != nil && r.match.MatchString(url)
 }

--- a/dfdaemon/handler/root_handler.go
+++ b/dfdaemon/handler/root_handler.go
@@ -38,7 +38,7 @@ func Proxy(w http.ResponseWriter, r *http.Request) {
 	)
 
 	if err = amendRequest(r); err != nil {
-		sendResponse(w, http.StatusForbidden, err.Error())
+		http.Error(w, err.Error(), http.StatusForbidden)
 		logrus.Errorf("%v", err)
 		return
 	}
@@ -47,7 +47,7 @@ func Proxy(w http.ResponseWriter, r *http.Request) {
 
 	hostIP := util.ExtractHost(r.URL.Host)
 	if reg, err = matchRegistry(hostIP, global.Properties.Registries); err != nil {
-		sendResponse(w, http.StatusForbidden, err.Error())
+		http.Error(w, err.Error(), http.StatusForbidden)
 		logrus.Warnf("%v", err)
 		return
 	}
@@ -112,9 +112,4 @@ func amendRequest(r *http.Request) error {
 		r.URL.Scheme = "http"
 	}
 	return nil
-}
-
-func sendResponse(w http.ResponseWriter, code int, resp string) {
-	w.WriteHeader(code)
-	fmt.Fprintf(w, "%s", resp)
 }

--- a/dfdaemon/handler/root_handler.go
+++ b/dfdaemon/handler/root_handler.go
@@ -38,7 +38,7 @@ func Proxy(w http.ResponseWriter, r *http.Request) {
 	)
 
 	if err = amendRequest(r); err != nil {
-		http.Error(w, err.Error(), http.StatusForbidden)
+		sendResponse(w, http.StatusForbidden, err.Error())
 		logrus.Errorf("%v", err)
 		return
 	}
@@ -47,7 +47,7 @@ func Proxy(w http.ResponseWriter, r *http.Request) {
 
 	hostIP := util.ExtractHost(r.URL.Host)
 	if reg, err = matchRegistry(hostIP, global.Properties.Registries); err != nil {
-		http.Error(w, err.Error(), http.StatusForbidden)
+		sendResponse(w, http.StatusForbidden, err.Error())
 		logrus.Warnf("%v", err)
 		return
 	}
@@ -112,4 +112,9 @@ func amendRequest(r *http.Request) error {
 		r.URL.Scheme = "http"
 	}
 	return nil
+}
+
+func sendResponse(w http.ResponseWriter, code int, resp string) {
+	w.WriteHeader(code)
+	fmt.Fprintf(w, "%s", resp)
 }

--- a/dfdaemon/handler/transport.go
+++ b/dfdaemon/handler/transport.go
@@ -84,10 +84,12 @@ func NewDFRoundTripper(cfg *tls.Config) *DFRoundTripper {
 // fix resource release
 func (roundTripper *DFRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if roundTripper.ShouldUseDfget(req) {
+		logrus.Debugf("round trip with dfget: %s", req.URL.String())
 		if res, err := roundTripper.download(req, req.URL.String()); err == nil || !exception.IsNotAuth(err) {
 			return res, err
 		}
 	}
+	logrus.Debugf("round trip directly: %s %s", req.Method, req.URL.String())
 	req.Host = req.URL.Host
 	req.Header.Set("Host", req.Host)
 	res, err := roundTripper.Round.RoundTrip(req)

--- a/dfdaemon/handler/transport.go
+++ b/dfdaemon/handler/transport.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"net"
 	"net/http"
+	"os"
 	"regexp"
 	"time"
 
@@ -99,14 +100,12 @@ func (roundTripper *DFRoundTripper) RoundTrip(req *http.Request) (*http.Response
 // download uses dfget to download
 func (roundTripper *DFRoundTripper) download(req *http.Request, urlString string) (*http.Response, error) {
 	dstPath, err := roundTripper.downloadByGetter(urlString, req.Header, uuid.New())
-	// dstPath, err := roundTripper.downloadByGetter(urlString, req.Header, urlString)
 	if err != nil {
 		logrus.Errorf("download fail: %v", err)
 		return nil, err
 	}
-	// defer os.Remove(dstPath)
+	defer os.Remove(dstPath)
 
-	logrus.Debugln(dstPath)
 	fileReq, err := http.NewRequest("GET", "file:///"+dstPath, nil)
 	if err != nil {
 		return nil, err

--- a/dfdaemon/proxy/proxy.go
+++ b/dfdaemon/proxy/proxy.go
@@ -1,0 +1,132 @@
+package proxy
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"regexp"
+	"time"
+
+	"github.com/dragonflyoss/Dragonfly/dfdaemon/handler"
+	"github.com/sirupsen/logrus"
+)
+
+func New(rules []Rule) *TransparentProxy {
+	proxy := &TransparentProxy{}
+	proxy.SetRules(rules)
+	return proxy
+}
+
+type Rule struct {
+	Match    string
+	match    *regexp.Regexp
+	UseHTTPS bool
+	Direct   bool
+}
+
+type TransparentProxy struct {
+	rules []Rule
+}
+
+func (proxy *TransparentProxy) SetRules(rules []Rule) error {
+	compiled := []Rule{}
+	for i, r := range rules {
+		reg, err := regexp.Compile(r.Match)
+		if err != nil {
+			return fmt.Errorf("rule %d is invalid: %s", i, err.Error())
+		}
+		compiled = append(compiled, Rule{
+			Match:    r.Match,
+			match:    reg,
+			UseHTTPS: r.UseHTTPS,
+			Direct:   r.Direct,
+		})
+	}
+	proxy.rules = compiled
+	return nil
+}
+
+func (proxy *TransparentProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodConnect {
+		handleHTTPS(w, r)
+	} else {
+		proxy.handleHTTP(w, r)
+	}
+}
+
+func (proxy *TransparentProxy) handleHTTP(w http.ResponseWriter, req *http.Request) {
+	rt := handler.NewDFRoundTripper(nil)
+	rt.ShouldUseDfget = proxy.ShouldUseDfget
+	if proxy.ShouldUseDfget(req) {
+		logrus.Debugf("Dfget proxy: %s", req.URL.String())
+	} else {
+		logrus.Debugf("Direct proxy: %s %s", req.Method, req.URL.String())
+	}
+	req.Header.Del("Accept-Encoding")
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+	defer resp.Body.Close()
+	copyHeader(w.Header(), resp.Header)
+	w.WriteHeader(resp.StatusCode)
+	io.Copy(w, resp.Body)
+}
+
+func (proxy *TransparentProxy) ShouldUseDfget(req *http.Request) bool {
+	if req.Method != http.MethodGet {
+		return false
+	}
+
+	useDfget := false
+	for _, rule := range proxy.rules {
+		if rule.match.MatchString(req.URL.String()) {
+			if rule.Direct {
+				return false
+			}
+			useDfget = true
+			if rule.UseHTTPS {
+				req.URL.Scheme = "https"
+			}
+		}
+	}
+	return useDfget
+}
+
+func handleHTTPS(w http.ResponseWriter, r *http.Request) {
+	logrus.Debugf("Tunneling https request %s", r.URL.String())
+	dst, err := net.DialTimeout("tcp", r.Host, 10*time.Second)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "Hijacking not supported", http.StatusInternalServerError)
+		return
+	}
+	client_conn, _, err := hijacker.Hijack()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+	}
+
+	go copyAndClose(dst, client_conn)
+	go copyAndClose(client_conn, dst)
+}
+
+func copyAndClose(dst io.WriteCloser, src io.ReadCloser) {
+	io.Copy(dst, src)
+	dst.Close()
+	src.Close()
+}
+
+func copyHeader(dst, src http.Header) {
+	for k, vv := range src {
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
+}

--- a/dfdaemon/proxy/proxy_test.go
+++ b/dfdaemon/proxy/proxy_test.go
@@ -1,0 +1,88 @@
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/dragonflyoss/Dragonfly/dfdaemon/config"
+	"github.com/stretchr/testify/assert"
+)
+
+type testItem struct {
+	URL      string
+	Direct   bool
+	UseHTTPS bool
+}
+
+type testCase struct {
+	Error error
+	Rules []*config.Proxy
+	Items []testItem
+}
+
+func newTestCase() *testCase {
+	return &testCase{}
+}
+
+func (tc *testCase) WithRule(regx string, direct bool, useHTTPS bool) *testCase {
+	if tc.Error != nil {
+		return tc
+	}
+
+	var r *config.Proxy
+	r, tc.Error = config.NewProxy(regx, useHTTPS, direct)
+	tc.Rules = append(tc.Rules, r)
+	return tc
+}
+
+func (tc *testCase) WithTest(url string, direct bool, useHTTPS bool) *testCase {
+	tc.Items = append(tc.Items, testItem{url, direct, useHTTPS})
+	return tc
+}
+
+func (tc *testCase) Test(t *testing.T) {
+	a := assert.New(t)
+	if !a.Nil(tc.Error) {
+		return
+	}
+	tp, err := New(tc.Rules)
+	if !a.Nil(err) {
+		return
+	}
+	for _, item := range tc.Items {
+		req, err := http.NewRequest("GET", item.URL, nil)
+		if !a.Nil(err) {
+			continue
+		}
+		if !a.Equal(tp.ShouldUseDfget(req), !item.Direct) {
+			fmt.Println(item.URL)
+		}
+		if item.UseHTTPS {
+			a.Equal(req.URL.Scheme, "https")
+		} else {
+			a.Equal(req.URL.Scheme, "http")
+		}
+	}
+}
+
+func TestMatch(t *testing.T) {
+	newTestCase().
+		WithRule("/blobs/sha256/", false, false).
+		WithTest("http://index.docker.io/v2/blobs/sha256/xxx", false, false).
+		WithTest("http://index.docker.io/v2/auth", true, false).
+		Test(t)
+
+	newTestCase().
+		WithRule("/a/d", false, true).
+		WithRule("/a/b", true, false).
+		WithRule("/a", false, false).
+		WithRule("/a/c", true, false).
+		WithRule("/a/e", false, true).
+		WithTest("http://h/a", false, false).   // should match /a
+		WithTest("http://h/a/b", true, false).  // should match /a/b
+		WithTest("http://h/a/c", false, false). // should match /a, not /a/c
+		WithTest("http://h/a/d", false, true).  // should match /a/d and use https
+		WithTest("http://h/a/e", false, false). // should match /a, not /a/e
+		Test(t)
+}

--- a/dfdaemon/proxy/proxy_test.go
+++ b/dfdaemon/proxy/proxy_test.go
@@ -55,7 +55,7 @@ func (tc *testCase) Test(t *testing.T) {
 		if !a.Nil(err) {
 			continue
 		}
-		if !a.Equal(tp.ShouldUseDfget(req), !item.Direct) {
+		if !a.Equal(tp.shouldUseDfget(req), !item.Direct) {
 			fmt.Println(item.URL)
 		}
 		if item.UseHTTPS {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Add a transparent proxy for dfdaemon. HTTP GET requests can be proxied with dfget if it matches the proxy rule. Other methods, including CONNECT for HTTPS requests will be proxied directly.

To handle CONNECT request properly, we can't use the default http mux. So I created a new http server dedicated for proxy, the port can be configured with `--proxyPort` cli flag, with a default value of `65002`. Proxy rules can be configured in dfdaemon.yml

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #478 
fixes #449 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

The rule matching is tested in dfdaemon/proxy/proxy_test.go

I haven't write integration test yet.

### Ⅳ. Describe how to verify it

Start dfdaemon with verbose logging and the following config file:

```yaml
proxies:
- regx: /blobs/sha256
- regx: github.com
  use_https: true
```

Set HTTP_PROXY of docker daemon to `http://127.0.0.1:65002`, and pull images. If the registry is an insecure registry, requests for image layers will be fetch with dfget. Otherwise requests will be proxied directly.

Look for these log lines:\
`round trip directly: $method $url` -> direct proxy \
`round trip with dfget: $url` -> with dfget

The `use_https` can be used to proxy registries with only https service. The proxy will change the request scheme before proxying it. You can test this with curl, although this is not how the proxy is meant to be used:

`curl -I http://github.com` -> returns 301 redirect to https://github.com
`http_proxy=http://127.0.0.1:65002 curl -I http://github.com` -> returns content of https://github.com directly

Of course you can set an https registry as insecure in docker daemon's config, and add a rule with `use_http: true` to match it, then pull images from it to see if it works. 

### Ⅴ. Special notes for reviews

I haven't write any documentation yet. I'll add documentation when the code is reviewed.
