### PR TITLE
feature: register the supernode as a peer before starting the server

### DIFF
--- a/cmd/supernode/app/root.go
+++ b/cmd/supernode/app/root.go
@@ -130,11 +130,13 @@ func runSuperNode() error {
 		return err
 	}
 
-	if err = d.Run(); err != nil {
-		logrus.Errorf("failed to run daemon: %v", err)
+	// register supernode
+	if err := d.RegisterSuperNode(); err != nil {
+		logrus.Errorf("failed to register super node: %v", err)
 		return err
 	}
-	return nil
+
+	return d.Run()
 }
 
 // initLog initializes log Level and log format of daemon.

--- a/supernode/config/config.go
+++ b/supernode/config/config.go
@@ -46,6 +46,16 @@ func (c *Config) GetSuperCID(taskID string) string {
 	return fmt.Sprintf("%s%s", c.cIDPrefix, taskID)
 }
 
+// SetSuperPID sets the value of supernode PID.
+func (c *Config) SetSuperPID(pid string) {
+	c.superNodePID = pid
+}
+
+// GetSuperPID returns the pid string for supernode.
+func (c *Config) GetSuperPID() string {
+	return c.superNodePID
+}
+
 // NewBaseProperties create a instant with default values.
 func NewBaseProperties() *BaseProperties {
 	home := filepath.Join(string(filepath.Separator), "home", "admin", "supernode")
@@ -143,4 +153,7 @@ type BaseProperties struct {
 
 	// cIDPrefix s a prefix string used to indicate that the CID is supernode.
 	cIDPrefix string
+
+	// superNodePID is the ID of supernode, which is the same as peer ID of dfget.
+	superNodePID string
 }


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Add supernode info as the config of supernode daemon, and register the supernode as a peer before starting the daemon server.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
None.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


