### PR TITLE
feature: add getter function for supernode cdn file path

### DIFF
--- a/common/util/string_util.go
+++ b/common/util/string_util.go
@@ -1,0 +1,30 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use rl file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package util
+
+// SubString returns the subString of {str} which begins at {start} and end at {end}.
+func SubString(str string, start, end int) string {
+	runes := []rune(str)
+	length := len(runes)
+	if start < 0 || start > length ||
+		end < 0 || end > length ||
+		start > end {
+		return ""
+	}
+
+	return string(runes[start:end])
+}

--- a/common/util/string_util_test.go
+++ b/common/util/string_util_test.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package util
+
+import (
+	"github.com/go-check/check"
+)
+
+type StringUtilSuite struct{}
+
+func init() {
+	check.Suite(&StringUtilSuite{})
+}
+
+func (suite *StringUtilSuite) TestSubString(c *check.C) {
+	var cases = []struct {
+		str      string
+		start    int
+		end      int
+		expected string
+	}{
+		{"abcdef", 1, 3, "bc"},
+		{"abcdef", -1, 3, ""},
+		{"abcdef", 0, 9, ""},
+		{"abcdef", 3, 1, ""},
+	}
+
+	for _, v := range cases {
+		c.Check(SubString(v.str, v.start, v.end), check.Equals, v.expected)
+	}
+}

--- a/supernode/config/global_variable.go
+++ b/supernode/config/global_variable.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"path"
+)
+
+var (
+	// HTTPSubPath is the name of the parent directory where the upload files are stored.
+	HTTPSubPath = "qtdown"
+
+	// DownloadSubPath is the name of the parent directory where the downloaded files are stored.
+	DownloadSubPath = "download"
+
+	// DownloadHome is the parent directory where the downloaded files are stored
+	// which is a relative path.
+	DownloadHome = path.Join("/repo", DownloadSubPath)
+
+	// UploadHome is the parent directory where the upload files are stored
+	// which is a relative path.
+	UploadHome = path.Join("/repo", HTTPSubPath)
+)

--- a/supernode/daemon/mgr/cdn/path_util.go
+++ b/supernode/daemon/mgr/cdn/path_util.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cdn
+
+import (
+	"path"
+
+	cutil "github.com/dragonflyoss/Dragonfly/common/util"
+	"github.com/dragonflyoss/Dragonfly/supernode/config"
+)
+
+func getDownloadPath(taskID string) string {
+	return path.Join(config.DownloadHome, cutil.SubString(taskID, 0, 3), taskID)
+}
+
+func getMetaDataPath(taskID string) string {
+	return path.Join(config.DownloadHome, cutil.SubString(taskID, 0, 3), taskID+".meta")
+}
+
+func getMd5DataPath(taskID string) string {
+	return path.Join(config.DownloadHome, cutil.SubString(taskID, 0, 3), taskID+".md5")
+}
+
+func getUploadPath(taskID string) string {
+	return path.Join(config.UploadHome, cutil.SubString(taskID, 0, 3), taskID)
+}
+
+func getHTTPPathStr(taskID string) string {
+	return path.Join(config.HTTPSubPath, cutil.SubString(taskID, 0, 3), taskID)
+}
+
+func deleteTaskFiles(taskID string, deleteUploadFile bool) error {
+	if err := cutil.DeleteFile(getDownloadPath(taskID)); err != nil {
+		return err
+	}
+
+	if err := cutil.DeleteFile(getMetaDataPath(taskID)); err != nil {
+		return err
+	}
+
+	if err := cutil.DeleteFile(getMd5DataPath(taskID)); err != nil {
+		return err
+	}
+
+	if !deleteUploadFile {
+		return nil
+	}
+	return cutil.DeleteFile(getUploadPath(taskID))
+}

--- a/supernode/daemon/mgr/cdn/path_util_test.go
+++ b/supernode/daemon/mgr/cdn/path_util_test.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cdn
+
+import (
+	"testing"
+
+	"github.com/go-check/check"
+)
+
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
+
+func init() {
+	check.Suite(&CDNPathUtilTestSuite{})
+}
+
+type CDNPathUtilTestSuite struct {
+}
+
+func (s *CDNPathUtilTestSuite) TestGetDownloadPath(c *check.C) {
+	taskID := "00c4e7b174af7ed61c414b36ef82810ac0c98142c03e5748c00e1d1113f3c882"
+
+	c.Check(getDownloadPath(taskID), check.Equals,
+		"/repo/download/00c/00c4e7b174af7ed61c414b36ef82810ac0c98142c03e5748c00e1d1113f3c882")
+
+	c.Check(getUploadPath(taskID), check.Equals,
+		"/repo/qtdown/00c/00c4e7b174af7ed61c414b36ef82810ac0c98142c03e5748c00e1d1113f3c882")
+
+	c.Check(getMetaDataPath(taskID), check.Equals,
+		"/repo/download/00c/00c4e7b174af7ed61c414b36ef82810ac0c98142c03e5748c00e1d1113f3c882.meta")
+
+	c.Check(getMd5DataPath(taskID), check.Equals,
+		"/repo/download/00c/00c4e7b174af7ed61c414b36ef82810ac0c98142c03e5748c00e1d1113f3c882.md5")
+
+	c.Check(getHTTPPathStr(taskID), check.Equals,
+		"qtdown/00c/00c4e7b174af7ed61c414b36ef82810ac0c98142c03e5748c00e1d1113f3c882")
+}


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Supernode will store the downloaded files as a cache with CDN. And this pull request define some file paths that CDN will use. 

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes part of #348

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

Added.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


