### PR TITLE
feature: add httpFileLength field for taskInfo

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -593,7 +593,13 @@ definitions:
       fileLength:
         type: "integer"
         description: |
-          The length of the file dfget requests to download in bytes.
+          The length of the file dfget requests to download in bytes
+          which including the header and the trailer of each piece.
+        format: "int64"
+      httpFileLength:
+        type: "integer"
+        description: |
+          The length of the source file in bytes.
         format: "int64"
       pieceSize:
         type: "integer"

--- a/apis/types/task_info.go
+++ b/apis/types/task_info.go
@@ -39,7 +39,8 @@ type TaskInfo struct {
 	//
 	Dfdaemon bool `json:"dfdaemon,omitempty"`
 
-	// The length of the file dfget requests to download in bytes.
+	// The length of the file dfget requests to download in bytes
+	// which including the header and the trailer of each piece.
 	//
 	FileLength int64 `json:"fileLength,omitempty"`
 
@@ -49,6 +50,10 @@ type TaskInfo struct {
 	// from source server as user's wish.
 	//
 	Headers map[string]string `json:"headers,omitempty"`
+
+	// The length of the source file in bytes.
+	//
+	HTTPFileLength int64 `json:"httpFileLength,omitempty"`
 
 	// special attribute of remote source file. This field is used with taskURL to generate new taskID to
 	// identify different downloading task of remote source file. For example, if user A and user B uses


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
A task not only maintains the source file size,  but also maintains a total file size after handled into pieces. 

In fact, The existing field `fileLength` indicates that the total file size after handled into pieces. So I add a filed named `httpFileLength` to maintain the source file size.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

None.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


