### PR TITLE
 feature: add proxy dns server

### DIFF
--- a/cmd/dfdaemon/app/options/options.go
+++ b/cmd/dfdaemon/app/options/options.go
@@ -84,6 +84,9 @@ type Options struct {
 	// ConfigPath is the path of dfdaemon's configuration file.
 	// default value is: /etc/dragonfly/dfdaemon.yml
 	ConfigPath string
+
+	// resolver dns server
+	Resolver string
 }
 
 // NewOption returns the default options.
@@ -125,7 +128,7 @@ func (o *Options) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&o.DownRule, "rule", "", "download the url by P2P if url matches the specified pattern,format:reg1,reg2,reg3")
 	fs.BoolVar(&o.Notbs, "notbs", true, "not try back source to download if throw exception")
 	fs.StringSliceVar(&o.TrustHosts, "trust-hosts", o.TrustHosts, "list of trusted hosts which dfdaemon forward their requests directly, comma separated.")
-
+	fs.StringVar(&o.Resolver, "resolver", o.Resolver, "proxy dns server address")
 	fs.StringVar(&o.ConfigPath, "config", constant.DefaultConfigPath,
 		"the path of dfdaemon's configuration file")
 }

--- a/dfdaemon/global/global.go
+++ b/dfdaemon/global/global.go
@@ -57,6 +57,9 @@ type CommandParam struct {
 	// TrustHosts includes the trusted hosts as keys of the map which dfdaemon forward their
 	// requests directly when dfdaemon is used to http_proxy mode.
 	TrustHosts map[string]string
+
+	// resolver dns server
+	Resolver string
 }
 
 var (

--- a/dfdaemon/initializer/initializer.go
+++ b/dfdaemon/initializer/initializer.go
@@ -248,6 +248,7 @@ func initParam(options *options.Options) {
 		HostIP:     options.HostIP,
 		Registry:   options.Registry,
 		TrustHosts: parsedTrustHosts,
+		Resolver:   options.Resolver,
 	}
 
 	initProperties(options)


### PR DESCRIPTION
支持harbor https private public
docker run -d --name dfclient1 -p 65001:65001 -v /etc/dragonfly.conf:/etc/dragonfly.conf dfclient:wp --registry https://x.x.x --resolver 10.0.0.120

supornode 使用 host 网络模式
docker run -d --name supernode --restart=always --net host     dragonflyoss/supernode:0.3.0 -Dsupernode.advertiseIp=10.0.0.124

在echo "nameserver 10.0.0.120" >>/etc/resolv.conf

[root@localhost ~]# docker logout   http://127.0.0.1:65001
Removing login credentials for 127.0.0.1:65001
[root@localhost ~]# docker pull   127.0.0.1:65001/library/python
Using default tag: latest
Error response from daemon: pull access denied for 127.0.0.1:65001/library/python, repository does not exist or may require 'docker login'
[root@localhost ~]# docker login   http://127.0.0.1:65001
Username: admin
Password:
WARNING! Your password will be stored unencrypted in /root/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Login Succeeded
[root@localhost ~]# docker pull   127.0.0.1:65001/library/python
Using default tag: latest
latest: Pulling from library/python
Digest: sha256:ce2b6fbe7d9dc28bbd332a6b9349b7040f0ffde81f1f14e121085eacfc4c0c3c
Status: Image is up to date for 127.0.0.1:65001/library/python:latest
[root@localhost ~]# curl http://127.0.0.1:65001/env
map[dfPattern:[] home:/root/ param:{DfPath:/dfclient/dfget DFRepo:/root/.small-dragonfly/dfdaemon/data/ RateLimit:20M CallSystem:com_ops_dragonfly URLFilter:Signature&Expires&OSSAccessKeyId Notbs:true HostIP:127.0.0.1 Registry:https://x.x.x TrustHosts:map[] Resolver:10.0.0.120}]