### PR TITLE
bugfix: update the implementation of local storage

### DIFF
--- a/supernode/store/errors.go
+++ b/supernode/store/errors.go
@@ -1,0 +1,86 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package store
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	// ErrKeyNotFound is an error which will be returned
+	// when the key can not be found.
+	ErrKeyNotFound = StorageError{codeKeyNotFound, "the key not found"}
+
+	// ErrEmptyKey is an error when the key is empty.
+	ErrEmptyKey = StorageError{codeKeyNotFound, "the key is empty"}
+
+	// ErrInvalidValue represents the value is invalid.
+	ErrInvalidValue = StorageError{codeInvalidValue, "invalid value"}
+
+	// ErrRangeNotSatisfiable represents the length of file is insufficient.
+	ErrRangeNotSatisfiable = StorageError{codeRangeNotSatisfiable, "range not satisfiable"}
+)
+
+const (
+	codeKeyNotFound = iota
+	codeEmptyKey
+	codeInvalidValue
+	codeRangeNotSatisfiable
+)
+
+// StorageError represents a storage error.
+type StorageError struct {
+	Code int
+	Msg  string
+}
+
+func (s StorageError) Error() string {
+	return fmt.Sprintf("{\"Code\":%d,\"Msg\":\"%s\"}", s.Code, s.Msg)
+}
+
+// IsNilError check the error is nil or not.
+func IsNilError(err error) bool {
+	return err == nil
+}
+
+// IsKeyNotFound check the error is the key cannot be found.
+func IsKeyNotFound(err error) bool {
+	return checkError(err, codeKeyNotFound)
+}
+
+// IsEmptyKey check the error is the key is empty or nil.
+func IsEmptyKey(err error) bool {
+	return checkError(err, codeEmptyKey)
+}
+
+// IsInvalidValue check the error is the value is invalid or not.
+func IsInvalidValue(err error) bool {
+	return checkError(err, codeInvalidValue)
+}
+
+// IsRangeNotSatisfiable check the error is a
+// range not exist error or not.
+func IsRangeNotSatisfiable(err error) bool {
+	return checkError(err, codeRangeNotSatisfiable)
+}
+
+func checkError(err error, code int) bool {
+	e, ok := errors.Cause(err).(StorageError)
+	return ok && e.Code == code
+}

--- a/supernode/store/storage_driver.go
+++ b/supernode/store/storage_driver.go
@@ -18,18 +18,8 @@ package store
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"time"
-)
-
-var (
-	// ErrNotFound is an error which will be returned
-	// when the key can not be found.
-	ErrNotFound = fmt.Errorf("the key not found")
-
-	// ErrEmptyKey is an error when the key is empty.
-	ErrEmptyKey = fmt.Errorf("the key is empty")
 )
 
 // StorageDriver defines an interface to manage the data stored in the driver.
@@ -40,10 +30,9 @@ var (
 // the different pieces of the same file concurrently.
 type StorageDriver interface {
 	// Get data from the storage based on raw information.
-	// The data should be written into the writer as io stream.
 	// If the length<=0, the driver should return all data from the raw.offest.
 	// Otherwise, just return the data which starts from raw.offset and the length is raw.length.
-	Get(ctx context.Context, raw *Raw, writer io.Writer) error
+	Get(ctx context.Context, raw *Raw) (io.Reader, error)
 
 	// Get data from the storage based on raw information.
 	// The data should be returned in bytes.

--- a/supernode/store/store.go
+++ b/supernode/store/store.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strings"
 
+	cutil "github.com/dragonflyoss/Dragonfly/common/util"
 	"github.com/dragonflyoss/Dragonfly/supernode/config"
 )
 
@@ -65,16 +65,16 @@ func (s *Store) Name() string {
 }
 
 // Get the data from the storage driver in io stream.
-func (s *Store) Get(ctx context.Context, raw *Raw, writer io.Writer) error {
-	if err := isEmptyKey(raw.Key); err != nil {
-		return err
+func (s *Store) Get(ctx context.Context, raw *Raw) (io.Reader, error) {
+	if err := checkEmptyKey(raw); err != nil {
+		return nil, err
 	}
-	return s.driver.Get(ctx, raw, writer)
+	return s.driver.Get(ctx, raw)
 }
 
 // GetBytes gets the data from the storage driver in bytes.
 func (s *Store) GetBytes(ctx context.Context, raw *Raw) ([]byte, error) {
-	if err := isEmptyKey(raw.Key); err != nil {
+	if err := checkEmptyKey(raw); err != nil {
 		return nil, err
 	}
 	return s.driver.GetBytes(ctx, raw)
@@ -82,7 +82,7 @@ func (s *Store) GetBytes(ctx context.Context, raw *Raw) ([]byte, error) {
 
 // Put puts data into the storage in io stream.
 func (s *Store) Put(ctx context.Context, raw *Raw, data io.Reader) error {
-	if err := isEmptyKey(raw.Key); err != nil {
+	if err := checkEmptyKey(raw); err != nil {
 		return err
 	}
 	return s.driver.Put(ctx, raw, data)
@@ -90,7 +90,7 @@ func (s *Store) Put(ctx context.Context, raw *Raw, data io.Reader) error {
 
 // PutBytes puts data into the storage in bytes.
 func (s *Store) PutBytes(ctx context.Context, raw *Raw, data []byte) error {
-	if err := isEmptyKey(raw.Key); err != nil {
+	if err := checkEmptyKey(raw); err != nil {
 		return err
 	}
 	return s.driver.PutBytes(ctx, raw, data)
@@ -98,7 +98,7 @@ func (s *Store) PutBytes(ctx context.Context, raw *Raw, data []byte) error {
 
 // Remove the data from the storage based on raw information.
 func (s *Store) Remove(ctx context.Context, raw *Raw) error {
-	if err := isEmptyKey(raw.Key); err != nil {
+	if err := checkEmptyKey(raw); err != nil {
 		return err
 	}
 	return s.driver.Remove(ctx, raw)
@@ -108,15 +108,16 @@ func (s *Store) Remove(ctx context.Context, raw *Raw) error {
 // If that, and return some info that in the form of struct StorageInfo.
 // If not, return the ErrNotFound.
 func (s *Store) Stat(ctx context.Context, raw *Raw) (*StorageInfo, error) {
-	if err := isEmptyKey(raw.Key); err != nil {
+	if err := checkEmptyKey(raw); err != nil {
 		return nil, err
 	}
 	return s.driver.Stat(ctx, raw)
 }
 
-func isEmptyKey(str string) error {
-	if strings.TrimSpace(str) == "" {
+func checkEmptyKey(raw *Raw) error {
+	if raw == nil || cutil.IsEmptyStr(raw.Key) {
 		return ErrEmptyKey
 	}
+
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
This pull request fixes the following problems:

1. Return an `io.Reader` instead of passing in an `io.Writer` for the `Get` interface of `StorageDriver`.
2. Unify the type of error.
3. Add a global lock for the operation of remove file.
4. Return directly when the `Raw` is nil. Otherwise it will trigger panic.

For the first item in the list, I need to make some explanations.

If we passing a `io.Writer`, the storage will copy the data from the storage to the writer whether the data in the writer has been taken out. And if not, it will take up a lot of physical memory. I try to use `io.Pipe` to solve this problem. 

According to the docs, the `io.Pipe` creates a synchronous in-memory pipe.  And each Write to the PipeWriter blocks until it has satisfied one or more Reads from the PipeReader that fully consume the written data. So we can translate big files with minimal memory.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

Updated.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


