### PR TITLE
[feature] hijack https requests with self-signed certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ getter.log*
 docs/.build/themes/
 docs/.build/content/
 docs/.build/static/images/
+
+*.key
+*.crt

--- a/Makefile
+++ b/Makefile
@@ -80,3 +80,12 @@ release:
 	./hack/package.sh
 .PHONY: release
 
+df.key:
+	openssl genrsa -des3 -passout pass:x -out df.pass.key 2048
+	openssl rsa -passin pass:x -in df.pass.key -out df.key
+	rm df.pass.key
+
+df.crt: df.key
+	openssl req -new -key df.key -out df.csr
+	openssl x509 -req -sha256 -days 365 -in df.csr -signkey df.key -out df.crt
+	rm df.csr

--- a/dfdaemon/config/config.go
+++ b/dfdaemon/config/config.go
@@ -19,12 +19,15 @@ package config
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"regexp"
 	"strings"
 
 	"github.com/dragonflyoss/Dragonfly/common/util"
+
+	"github.com/pkg/errors"
 )
 
 // -----------------------------------------------------------------------------
@@ -49,6 +52,7 @@ func NewProperties() *Properties {
 //           schema: https
 //           host: reg.com
 //           certs: ['/etc/ssl/reg.com/server.crt']
+//
 //     proxies:
 //     # proxy all http image layer download requests with dfget
 //     - regx: blob/sha256/.*
@@ -58,6 +62,14 @@ func NewProperties() *Properties {
 //     # proxy requests directly, without dfget
 //     - regx: no-proxy-reg
 //       direct: true
+//
+//     hijack_https:
+//	 # key pair used to hijack https requests
+//       cert: df.crt
+//       key: df.key
+//	 hosts:
+//       - regx: mirror.aliyuncs.com:443
+//	   certs:
 type Properties struct {
 	// Registries the more front the position, the higher priority.
 	// You could add an empty Registry at the end to proxy all other requests
@@ -67,6 +79,116 @@ type Properties struct {
 	// are provided, all requests will be proxied directly. Request will be
 	// proxied with the first matching rule.
 	Proxies []*Proxy `yaml:"proxies"`
+
+	// HijackHTTPS is the list of hosts whose https requests should be hijacked
+	// by dfdaemon. Dfdaemon will be able to proxy requests from them with dfget
+	// if the url matches the proxy rules
+	HijackHTTPS *HijackConfig `yaml:"hijack_https"`
+}
+
+// HijackConfig represents how dfdaemon hijacks http requests
+type HijackConfig struct {
+	Cert  string        `yaml:"cert"`
+	Key   string        `yaml:"key"`
+	Hosts []*HijackHost `yaml:"hosts"`
+}
+
+// HijackHost is a hijack rule for the hosts that matches Regx
+type HijackHost struct {
+	Regx  *Regexp   `yaml:"regx"`
+	Certs *CertPool `yaml:"certs"`
+}
+
+// CertPool is a wrapper around x509.CertPool, which can be unmarshalled and
+// constructed from a list of filenames
+type CertPool struct {
+	files []string
+	*x509.CertPool
+}
+
+// UnmarshalYAML implements yaml.Unmarshaller
+func (cp *CertPool) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	return cp.unmarshal(unmarshal)
+}
+
+// UnmarshalJSON implements json.Unmarshaller
+func (cp *CertPool) UnmarshalJSON(b []byte) error {
+	return cp.unmarshal(func(v interface{}) error { return json.Unmarshal(b, v) })
+}
+
+func (cp *CertPool) unmarshal(unmarshal func(interface{}) error) error {
+	if err := unmarshal(&cp.files); err != nil {
+		return err
+	}
+
+	pool, err := certPoolFromFiles(cp.files...)
+	if err != nil {
+		return err
+	}
+
+	cp.CertPool = pool
+	return nil
+}
+
+// Regexp is simple wrapper around regexp.Regexp to make it unmarshallable from a string
+type Regexp struct {
+	*regexp.Regexp
+}
+
+// NewRegexp returns new Regexp instance compiled from the given string
+func NewRegexp(exp string) (*Regexp, error) {
+	r, err := regexp.Compile(exp)
+	if err != nil {
+		return nil, err
+	}
+	return &Regexp{r}, nil
+}
+
+// UnmarshalYAML implements yaml.Unmarshaller
+func (r *Regexp) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	return r.unmarshal(unmarshal)
+}
+
+// UnmarshalJSON implements json.Unmarshaller
+func (r *Regexp) UnmarshalJSON(b []byte) error {
+	return r.unmarshal(func(v interface{}) error { return json.Unmarshal(b, v) })
+}
+
+func (r *Regexp) unmarshal(unmarshal func(interface{}) error) error {
+	var s string
+	if err := unmarshal(&s); err != nil {
+		return err
+	}
+	exp, err := regexp.Compile(s)
+	if err == nil {
+		r.Regexp = exp
+	}
+	return err
+}
+
+// MarshalJSON implements json.Marshaller to print the regexp
+func (r *Regexp) MarshalJSON() ([]byte, error) {
+	return json.Marshal(r.String())
+}
+
+// certPoolFromFiles returns an *x509.CertPool constructed from the given files.
+// If no files are given, (nil, nil) will be returned.
+func certPoolFromFiles(files ...string) (*x509.CertPool, error) {
+	if len(files) == 0 {
+		return nil, nil
+	}
+
+	roots := x509.NewCertPool()
+	for _, f := range files {
+		cert, err := ioutil.ReadFile(f)
+		if err != nil {
+			return nil, errors.Wrapf(err, "read cert file %s", f)
+		}
+		if !roots.AppendCertsFromPEM(cert) {
+			return nil, errors.Errorf("invalid cert: %s", f)
+		}
+	}
+	return roots, nil
 }
 
 // Load loads properties from config file.
@@ -85,17 +207,6 @@ func (p *Properties) Load(path string) error {
 		}
 	}
 	p.Registries = tmp
-
-	var tmpProxies []*Proxy
-	for _, v := range p.Proxies {
-		if v != nil {
-			if err := v.init(); err != nil {
-				return err
-			}
-			tmpProxies = append(tmpProxies, v)
-		}
-	}
-	p.Proxies = tmpProxies
 
 	return nil
 }
@@ -196,32 +307,26 @@ func (r *Registry) initTLSConfig() error {
 
 // Proxy describe a regular expression matching rule for how to proxy a request
 type Proxy struct {
-	Regx     string `yaml:"regx"`
-	UseHTTPS bool   `yaml:"use_https"`
-	Direct   bool   `yaml:"direct"`
-
-	match *regexp.Regexp
+	Regx     *Regexp `yaml:"regx"`
+	UseHTTPS bool    `yaml:"use_https"`
+	Direct   bool    `yaml:"direct"`
 }
 
 // NewProxy returns a new proxy rule with given attributes
 func NewProxy(regx string, useHTTPS bool, direct bool) (*Proxy, error) {
-	p := &Proxy{
-		Regx:     regx,
+	exp, err := NewRegexp(regx)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid regexp")
+	}
+
+	return &Proxy{
+		Regx:     exp,
 		UseHTTPS: useHTTPS,
 		Direct:   direct,
-	}
-	if err := p.init(); err != nil {
-		return nil, err
-	}
-	return p, nil
-}
-
-func (r *Proxy) init() (err error) {
-	r.match, err = regexp.Compile(r.Regx)
-	return err
+	}, nil
 }
 
 // Match checks if the given url matches the rule
 func (r *Proxy) Match(url string) bool {
-	return r.match != nil && r.match.MatchString(url)
+	return r.Regx != nil && r.Regx.MatchString(url)
 }

--- a/dfdaemon/handler/transport.go
+++ b/dfdaemon/handler/transport.go
@@ -85,6 +85,9 @@ func NewDFRoundTripper(cfg *tls.Config) *DFRoundTripper {
 // fix resource release
 func (roundTripper *DFRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if roundTripper.ShouldUseDfget(req) {
+		// delete the Accept-Encoding header to avoid returning the same cached
+		// result for different requests
+		req.Header.Del("Accept-Encoding")
 		logrus.Debugf("round trip with dfget: %s", req.URL.String())
 		if res, err := roundTripper.download(req, req.URL.String()); err == nil || !exception.IsNotAuth(err) {
 			return res, err
@@ -126,7 +129,8 @@ func (roundTripper *DFRoundTripper) downloadByGetter(url string, header map[stri
 	return roundTripper.Downloader.Download(url, header, name)
 }
 
-// needUseGetter whether to download by DFGetter
+// needUseGetter is the default value for ShouldUseDfget, which downloads all
+// images layers with dfget.
 func needUseGetter(req *http.Request) bool {
 	if req.Method != http.MethodGet {
 		return false

--- a/dfdaemon/proxy/proxy.go
+++ b/dfdaemon/proxy/proxy.go
@@ -1,24 +1,68 @@
 package proxy
 
 import (
-	"fmt"
+	"crypto/tls"
 	"io"
 	"net"
 	"net/http"
+	"net/http/httputil"
+	"sync"
 	"time"
 
 	"github.com/dragonflyoss/Dragonfly/dfdaemon/config"
 	"github.com/dragonflyoss/Dragonfly/dfdaemon/handler"
 
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
-// New returns a new transparent proxy with the given rules
-func New(rules []*config.Proxy) (*TransparentProxy, error) {
-	proxy := &TransparentProxy{}
-	if err := proxy.SetRules(rules); err != nil {
-		return nil, fmt.Errorf("invalid rules: %v", err)
+// Option is a functional option for configuring the proxy
+type Option func(p *TransparentProxy) error
+
+// WithCert sets the certificate to
+func WithCert(cert *tls.Certificate) Option {
+	return func(p *TransparentProxy) error {
+		p.cert = cert
+		return nil
 	}
+}
+
+// WithHTTPSHosts sets the rules for hijacking https requests
+func WithHTTPSHosts(hosts ...*config.HijackHost) Option {
+	return func(p *TransparentProxy) error {
+		p.httpsHosts = hosts
+		return nil
+	}
+}
+
+// WithCertFromFile is a convenient wrapper for WithCert, to read certificate from
+// the given file
+func WithCertFromFile(certFile, keyFile string) Option {
+	return func(p *TransparentProxy) error {
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return errors.Wrap(err, "load cert")
+		}
+		p.cert = &cert
+		return nil
+	}
+}
+
+// WithRules sets the proxy rules
+func WithRules(rules []*config.Proxy) Option {
+	return func(p *TransparentProxy) error { return p.SetRules(rules) }
+}
+
+// New returns a new transparent proxy with the given rules
+func New(opts ...Option) (*TransparentProxy, error) {
+	proxy := &TransparentProxy{}
+
+	for _, opt := range opts {
+		if err := opt(proxy); err != nil {
+			return nil, err
+		}
+	}
+
 	return proxy, nil
 }
 
@@ -26,6 +70,26 @@ func New(rules []*config.Proxy) (*TransparentProxy, error) {
 // if any defined proxy rules is matched
 type TransparentProxy struct {
 	rules []*config.Proxy
+
+	// httpsHosts is the list of hosts whose https requests will be hijacked
+	httpsHosts []*config.HijackHost
+
+	cert *tls.Certificate
+}
+
+// remoteConfig returns the tls.Config used to connect to the given remote host.
+// If the host should not be hijacked, nil will be returned.
+func (proxy *TransparentProxy) remoteConfig(host string) *tls.Config {
+	for _, h := range proxy.httpsHosts {
+		if h.Regx.MatchString(host) {
+			config := &tls.Config{}
+			if h.Certs != nil {
+				config.RootCAs = h.Certs.CertPool
+			}
+			return config
+		}
+	}
+	return nil
 }
 
 // SetRules change the rule lists of the proxy to the given rules
@@ -37,19 +101,14 @@ func (proxy *TransparentProxy) SetRules(rules []*config.Proxy) error {
 // ServeHTTP implements http.Handler.ServeHTTP
 func (proxy *TransparentProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodConnect {
-		handleHTTPS(w, r)
+		proxy.handleHTTPS(w, r)
 	} else {
 		proxy.handleHTTP(w, r)
 	}
 }
 
 func (proxy *TransparentProxy) handleHTTP(w http.ResponseWriter, req *http.Request) {
-	rt := handler.NewDFRoundTripper(nil)
-	rt.ShouldUseDfget = proxy.shouldUseDfget
-	// delete the Accept-Encoding header to avoid returning the same cached
-	// result for different requests
-	req.Header.Del("Accept-Encoding")
-	resp, err := rt.RoundTrip(req)
+	resp, err := proxy.roundTripper(nil).RoundTrip(req)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return
@@ -58,6 +117,12 @@ func (proxy *TransparentProxy) handleHTTP(w http.ResponseWriter, req *http.Reque
 	copyHeader(w.Header(), resp.Header)
 	w.WriteHeader(resp.StatusCode)
 	io.Copy(w, resp.Body)
+}
+
+func (proxy *TransparentProxy) roundTripper(tlsConfig *tls.Config) http.RoundTripper {
+	rt := handler.NewDFRoundTripper(tlsConfig)
+	rt.ShouldUseDfget = proxy.shouldUseDfget
+	return rt
 }
 
 // shouldUseDfget returns whether we should use dfget to proxy a request. It
@@ -79,10 +144,10 @@ func (proxy *TransparentProxy) shouldUseDfget(req *http.Request) bool {
 	return false
 }
 
-// handleHTTPS handles a CONNECT request and proxy an https request through an
+// tunnelHTTPS handles a CONNECT request and proxy an https request through an
 // http tunnel.
-func handleHTTPS(w http.ResponseWriter, r *http.Request) {
-	logrus.Debugf("Tunneling https request %s", r.URL.String())
+func tunnelHTTPS(w http.ResponseWriter, r *http.Request) {
+	logrus.Debugf("Tunneling https request for %s", r.Host)
 	dst, err := net.DialTimeout("tcp", r.Host, 10*time.Second)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -103,6 +168,52 @@ func handleHTTPS(w http.ResponseWriter, r *http.Request) {
 	go copyAndClose(clientConn, dst)
 }
 
+func (proxy *TransparentProxy) handleHTTPS(w http.ResponseWriter, r *http.Request) {
+	if proxy.cert == nil {
+		tunnelHTTPS(w, r)
+		return
+	}
+
+	cConfig := proxy.remoteConfig(r.Host)
+	if cConfig == nil {
+		tunnelHTTPS(w, r)
+		return
+	}
+
+	logrus.Debugln("hijack https request to", r.Host)
+
+	sConfig := new(tls.Config)
+	sConfig.Certificates = []tls.Certificate{*proxy.cert}
+
+	sConn, err := handshake(w, sConfig)
+	if err != nil {
+		logrus.Errorf("handshake failed for %s: %v", r.Host, err)
+		return
+	}
+	defer sConn.Close()
+
+	cConn, err := tls.Dial("tcp", r.Host, cConfig)
+	if err != nil {
+		logrus.Errorf("dial failed for %s: %v", r.Host, err)
+		return
+	}
+	defer cConn.Close()
+
+	rp := &httputil.ReverseProxy{
+		Director: func(r *http.Request) {
+			r.URL.Host = r.Host
+			r.URL.Scheme = "https"
+		},
+		Transport: proxy.roundTripper(cConfig),
+	}
+
+	// We have to wait until the connection is closed
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	http.Serve(&singleUseListener{&customCloseConn{sConn, wg.Done}}, rp)
+	wg.Wait()
+}
+
 func copyAndClose(dst io.WriteCloser, src io.ReadCloser) {
 	io.Copy(dst, src)
 	dst.Close()
@@ -115,4 +226,60 @@ func copyHeader(dst, src http.Header) {
 			dst.Add(k, v)
 		}
 	}
+}
+
+var okHeader = []byte("HTTP/1.1 200 OK\r\n\r\n")
+
+// handshake hijacks w's underlying net.Conn, responds to the CONNECT request
+// and manually performs the TLS handshake.
+func handshake(w http.ResponseWriter, config *tls.Config) (net.Conn, error) {
+	raw, _, err := w.(http.Hijacker).Hijack()
+	if err != nil {
+		http.Error(w, "no upstream", http.StatusServiceUnavailable)
+		return nil, err
+	}
+	if _, err = raw.Write(okHeader); err != nil {
+		raw.Close()
+		return nil, err
+	}
+	conn := tls.Server(raw, config)
+	if err = conn.Handshake(); err != nil {
+		conn.Close()
+		raw.Close()
+		return nil, err
+	}
+	return conn, nil
+}
+
+// A singleUseListener implements a net.Listener that returns the net.Conn specified
+// in c for the first Accept call, and return errors for the subsequent calls.
+type singleUseListener struct {
+	c net.Conn
+}
+
+func (l *singleUseListener) Accept() (net.Conn, error) {
+	if l.c == nil {
+		return nil, errors.New("closed")
+	}
+	c := l.c
+	l.c = nil
+	return c, nil
+}
+
+func (l *singleUseListener) Close() error { return nil }
+
+func (l *singleUseListener) Addr() net.Addr { return l.c.LocalAddr() }
+
+// A customCloseConn implements net.Conn and calls f before closing the underlying net.Conn
+type customCloseConn struct {
+	net.Conn
+	f func()
+}
+
+func (c *customCloseConn) Close() error {
+	if c.f != nil {
+		c.f()
+		c.f = nil
+	}
+	return c.Conn.Close()
 }

--- a/dfdaemon/proxy/proxy_test.go
+++ b/dfdaemon/proxy/proxy_test.go
@@ -46,7 +46,7 @@ func (tc *testCase) Test(t *testing.T) {
 	if !a.Nil(tc.Error) {
 		return
 	}
-	tp, err := New(tc.Rules)
+	tp, err := New(WithRules(tc.Rules))
 	if !a.Nil(err) {
 		return
 	}


### PR DESCRIPTION
Signed-off-by: inoc603 <inoc603@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Hijack https requests with self-signed certificates to enable the proxy to speed up https requests with dfget.

Users have to explicitly configure a registry in `insecure-registries` as well as in the new `hijack_https` configuration field introduced in this pr, to make this work. Other https requests will be tunneled directly as before.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

I'll add some mock tests for https later

### Ⅳ. Describe how to verify it

We can verify it with any docker mirror from aliyun like `xxx.mirror.aliyuncs.com` (replace this with a valid one).

`/etc/dragonfly/dfdaemon.yml`:

```yaml
proxies:
- regx: blobs/sha256

hijack_https:
  cert: df.crt
  key: df.key
  hosts:
  - regx: mirror.aliyuncs.com
```


Start dfdaemon with verbose logging:

```
dfdaemon --verbose
```

Then start or restart docker with these settings:

`/etc/docker/daemon.json`:

```json
{
  "insecure-registries": ["xxx.mirror.aliyuncs.com"],
  "registry-mirrors": ["https://xxx.mirror.aliyuncs.com"]
}
```

`/etc/systemd/system/docker.service.d/http-proxy.conf`:

```
[Service]
Environment="HTTP_PROXY=http://localhost:65002"
Environment="HTTPS_PROXY=http://localhost:65002"
```

Pull an image

```
docker pull mysql
```

Then check `dfdaemon.log` and search for `hijack https request` to verify that the requests are hijacked and proxied with dfget.

### Ⅴ. Special notes for reviews


