### PR TITLE
feature: use bucket as the parent sub dir of key

### DIFF
--- a/supernode/store/errors.go
+++ b/supernode/store/errors.go
@@ -28,7 +28,7 @@ var (
 	ErrKeyNotFound = StorageError{codeKeyNotFound, "the key not found"}
 
 	// ErrEmptyKey is an error when the key is empty.
-	ErrEmptyKey = StorageError{codeKeyNotFound, "the key is empty"}
+	ErrEmptyKey = StorageError{codeEmptyKey, "the key is empty"}
 
 	// ErrInvalidValue represents the value is invalid.
 	ErrInvalidValue = StorageError{codeInvalidValue, "invalid value"}

--- a/supernode/store/store.go
+++ b/supernode/store/store.go
@@ -23,6 +23,8 @@ import (
 
 	cutil "github.com/dragonflyoss/Dragonfly/common/util"
 	"github.com/dragonflyoss/Dragonfly/supernode/config"
+
+	"github.com/pkg/errors"
 )
 
 // Store is a wrapper of the storage which implements the interface of StorageDriver.
@@ -98,8 +100,9 @@ func (s *Store) PutBytes(ctx context.Context, raw *Raw, data []byte) error {
 
 // Remove the data from the storage based on raw information.
 func (s *Store) Remove(ctx context.Context, raw *Raw) error {
-	if err := checkEmptyKey(raw); err != nil {
-		return err
+	if raw == nil || (cutil.IsEmptyStr(raw.Key) &&
+		cutil.IsEmptyStr(raw.Bucket)) {
+		return errors.Wrapf(ErrEmptyKey, "cannot set both key and bucket empty at the same time")
 	}
 	return s.driver.Remove(ctx, raw)
 }


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
For the local storage driver, there are three variables that determine the path to the storage file.

+ baseDir: the root dir of the storage
+ bucket: the sub dir of one file
+ key: the file name

When the caller put something to the storage, and the storage should create the dir If the parent directory of the file isn't exist,

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
Updated.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


