### PR TITLE
feature: add realMd5 field for taskInfo

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -634,6 +634,12 @@ definitions:
           md5 checksum for the resource to distribute. dfget catches this parameter from dfget's CLI
           and passes it to supernode. When supernode finishes downloading file/image from the source location,
           it will validate the source file with this md5 value to check whether this is a valid file.
+      realMd5:
+        type: "string"
+        description: |
+          when supernode finishes downloading file/image from the source location,
+          the md5 sum of the source file will be calculated as the value of the realMd5.
+          And it will be used to compare with md5 value to check whether this is a valid file.
       identifier:
         type: "string"
         description: |

--- a/apis/types/task_info.go
+++ b/apis/types/task_info.go
@@ -90,6 +90,12 @@ type TaskInfo struct {
 	//
 	RawURL string `json:"rawURL,omitempty"`
 
+	// when supernode finishes downloading file/image from the source location,
+	// the md5 sum of the source file will be calculated as the value of the realMd5.
+	// And it will be used to compare with md5 value to check whether this is a valid file.
+	//
+	RealMd5 string `json:"realMd5,omitempty"`
+
 	// taskURL is generated from rawURL. rawURL may contains some queries or parameter, dfget will filter some queries via
 	// --filter parameter of dfget. The usage of it is that different rawURL may generate the same taskID.
 	//


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

We should keep two MD5 values for taskInfo.
+ Md5. It's passed by caller which means the expected md5 value of the task file. For example, dfget will catch it from dfget's CLI and pass it to supernode. 
+ RealMd5. It's the real MD5 sum value which calculated by the downloaded file. 

When supernode finishes downloading file/image from the source location, and the supernode will validate the RealMd5 value with the Md5 value to check whether the downloaded file is valid.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

None.
### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
None.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


