### PR TITLE
feaeture: add function GetCIDByPeerIDAndTaskID for dfgetTask

### DIFF
--- a/supernode/daemon/mgr/dfget_task_mgr.go
+++ b/supernode/daemon/mgr/dfget_task_mgr.go
@@ -18,6 +18,9 @@ type DfgetTaskMgr interface {
 	// Get a dfgetTask info with specified clientID and taskID.
 	Get(ctx context.Context, clientID, taskID string) (dfgetTask *types.DfGetTask, err error)
 
+	// GetCIDByPeerIDAndTaskID returns cid with specified peerID and taskID.
+	GetCIDByPeerIDAndTaskID(ctx context.Context, peerID, taskID string) (string, error)
+
 	// List returns the list of dfgetTask.
 	List(ctx context.Context, filter map[string]string) (dfgetTaskList []*types.DfGetTask, err error)
 

--- a/supernode/daemon/mgr/mock/mock_dfget_task_mgr.go
+++ b/supernode/daemon/mgr/mock/mock_dfget_task_mgr.go
@@ -65,6 +65,21 @@ func (mr *MockDfgetTaskMgrMockRecorder) Get(ctx, clientID, taskID interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockDfgetTaskMgr)(nil).Get), ctx, clientID, taskID)
 }
 
+// GetCIDByPeerIDAndTaskID mocks base method
+func (m *MockDfgetTaskMgr) GetCIDByPeerIDAndTaskID(ctx context.Context, peerID, taskID string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCIDByPeerIDAndTaskID", ctx, peerID, taskID)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCIDByPeerIDAndTaskID indicates an expected call of GetCIDByPeerIDAndTaskID
+func (mr *MockDfgetTaskMgrMockRecorder) GetCIDByPeerIDAndTaskID(ctx, peerID, taskID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCIDByPeerIDAndTaskID", reflect.TypeOf((*MockDfgetTaskMgr)(nil).GetCIDByPeerIDAndTaskID), ctx, peerID, taskID)
+}
+
 // List mocks base method
 func (m *MockDfgetTaskMgr) List(ctx context.Context, filter map[string]string) ([]*types.DfGetTask, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
In the go version, we introduce a peerID field which identifies a peer node and use cid identifies a downloading task. The relationship between them is as follows:

+ a cid one-to-one the combination of peerID and taskID
+ a peerID one-to-one the combination of cID and taskID

And this PR is submitted in order to get a unique cid via peerID and taskID.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

### Ⅳ. Describe how to verify it
None.

### Ⅴ. Special notes for reviews


