### PR TITLE
dfget --node flag can specify the port of supernodes

### DIFF
--- a/cmd/dfget/app/root.go
+++ b/cmd/dfget/app/root.go
@@ -205,7 +205,7 @@ func initFlags() {
 	flagSet.StringSliceVar(&cfg.Header, "header", nil,
 		"http header, eg: --header='Accept: *' --header='Host: abc'")
 	flagSet.StringSliceVarP(&cfg.Node, "node", "n", nil,
-		"specify the addresses(IP:port) of supernodes")
+		"specify the addresses(IP or IP:port) of supernodes")
 	flagSet.BoolVar(&cfg.Notbs, "notbs", false,
 		"disable back source downloading for requested file when p2p fails to download it")
 	flagSet.BoolVar(&cfg.DFDaemon, "dfdaemon", false,

--- a/dfget/core/api/supernode_api.go
+++ b/dfget/core/api/supernode_api.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/dragonflyoss/Dragonfly/common/util"
 	"github.com/dragonflyoss/Dragonfly/dfget/types"
-	"strings"
 	"strconv"
+	"strings"
 )
 
 /* the url paths of supernode APIs*/

--- a/dfget/core/api/supernode_api_test.go
+++ b/dfget/core/api/supernode_api_test.go
@@ -157,3 +157,24 @@ func createRegisterRequest() (req *types.RegisterRequest) {
 	req = &types.RegisterRequest{}
 	return req
 }
+
+
+
+func (s *SupernodeAPITestSuite) TestSupernodeAPI_nodeToIPAndPort(c *check.C) {
+	node1 := "10.47.231.22"
+	node2 := "10.47.231.25:8005"
+	node3 := "10.47.231.25:abcd"
+
+	ip,port := s.api.(*supernodeAPI).nodeToIPAndPort(node1)
+	c.Assert( ip, check.Equals, "10.47.231.22")
+	c.Assert( port, check.Equals, s.api.(*supernodeAPI).ServicePort)
+
+	ip,port = s.api.(*supernodeAPI).nodeToIPAndPort(node2)
+	c.Assert( ip, check.Equals, "10.47.231.25")
+	c.Assert( port, check.Equals, int(8005))
+
+	ip,port = s.api.(*supernodeAPI).nodeToIPAndPort(node3)
+	c.Assert( ip, check.Equals, "10.47.231.25")
+	c.Assert( port, check.Equals, int(8002))
+
+}

--- a/dfget/core/api/supernode_api_test.go
+++ b/dfget/core/api/supernode_api_test.go
@@ -158,8 +158,6 @@ func createRegisterRequest() (req *types.RegisterRequest) {
 	return req
 }
 
-
-
 func (s *SupernodeAPITestSuite) TestSupernodeAPI_nodeToIPAndPort(c *check.C) {
 	node1 := "10.47.231.22"
 	node2 := "10.47.231.25:8005"


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
The --node flag of dfget only can specify the ip of supernodes, but sometimes wo need to change the port 8002 which supernodes listen on.  We add ip:port syntax to the --node flag, but the old ip syntax can also be supported.

### Ⅱ. Does this pull request fix one issue?
fixes #473 #543


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

The following commands have been tested:
dfget -u xxx -n ip1,ip2 
dfget -u xxx -n ip1:port1,ip2 
dfget -u xxx -n ip1:port1,ip2:port
They works.

