### PR TITLE
Configure InsecureSkipVerify for proxied https host

### DIFF
--- a/dfdaemon/config/config.go
+++ b/dfdaemon/config/config.go
@@ -55,7 +55,7 @@ func NewProperties() *Properties {
 //
 //     proxies:
 //     # proxy all http image layer download requests with dfget
-//     - regx: blob/sha256/.*
+//     - regx: blobs/sha256:.*
 //     # change http requests to some-registry to https and proxy them with dfget
 //     - regx: some-registry/
 //       use_https: true
@@ -64,12 +64,13 @@ func NewProperties() *Properties {
 //       direct: true
 //
 //     hijack_https:
-//	 # key pair used to hijack https requests
+//     # key pair used to hijack https requests
 //       cert: df.crt
 //       key: df.key
-//	 hosts:
+//       hosts:
 //       - regx: mirror.aliyuncs.com:443
-//	   certs:
+//         insecure: true
+//         certs:
 type Properties struct {
 	// Registries the more front the position, the higher priority.
 	// You could add an empty Registry at the end to proxy all other requests
@@ -95,8 +96,9 @@ type HijackConfig struct {
 
 // HijackHost is a hijack rule for the hosts that matches Regx
 type HijackHost struct {
-	Regx  *Regexp   `yaml:"regx"`
-	Certs *CertPool `yaml:"certs"`
+	Regx     *Regexp   `yaml:"regx"`
+	Insecure bool      `yaml:"insecure"`
+	Certs    *CertPool `yaml:"certs"`
 }
 
 // CertPool is a wrapper around x509.CertPool, which can be unmarshalled and

--- a/dfdaemon/proxy/proxy.go
+++ b/dfdaemon/proxy/proxy.go
@@ -86,6 +86,10 @@ func (proxy *TransparentProxy) remoteConfig(host string) *tls.Config {
 			if h.Certs != nil {
 				config.RootCAs = h.Certs.CertPool
 			}
+
+			if h.Insecure {
+				config.InsecureSkipVerify = true
+			}
 			return config
 		}
 	}

--- a/docs/user_guide/proxy.md
+++ b/docs/user_guide/proxy.md
@@ -20,7 +20,7 @@ proxies:
 - regx: no-proxy-reg
   direct: true
 # proxy all http image layer download requests with dfget
-- regx: blob/sha256/.*
+- regx: blobs/sha256:.*
 # change http requests to some-registry to https, and proxy them with dfget
 - regx: some-registry/
   use_https: true
@@ -33,7 +33,7 @@ Add the following content to `/etc/dragonfly/dfdaemon.yml`.
 ```yaml
 proxies:
 # proxy all http image layer download requests with dfget
-- regx: blob/sha256/.*
+- regx: blobs/sha256:.*
 ```
 
 Set HTTP_PROXY for docker daemon in `/etc/systemd/system/docker.service.d/http-proxy.conf`.


### PR DESCRIPTION
Signed-off-by: cd1989 <chende@caicloud.io>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

- InsecureSkipVerify when no certs configured for HTTPS proxied host
- Update docs for example regex `blob/sha256/.*` --> `blobs/sha256:.*`

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


