### PR TITLE
feature: add download port flag

### DIFF
--- a/cmd/supernode/app/root.go
+++ b/cmd/supernode/app/root.go
@@ -70,6 +70,9 @@ func setupFlags(cmd *cobra.Command, opt *Options) {
 	flagSet.IntVar(&opt.ListenPort, "port", opt.ListenPort,
 		"ListenPort is the port supernode server listens on")
 
+	flagSet.IntVar(&opt.DownloadPort, "download-port", opt.DownloadPort,
+		"DownloadPort is the port for download files from supernode")
+
 	flagSet.StringVar(&opt.HomeDir, "home-dir", opt.HomeDir,
 		"HomeDir is working directory of supernode")
 

--- a/supernode/config/config.go
+++ b/supernode/config/config.go
@@ -72,6 +72,7 @@ func NewBaseProperties() *BaseProperties {
 	home := filepath.Join(string(filepath.Separator), "home", "admin", "supernode")
 	return &BaseProperties{
 		ListenPort:              8002,
+		DownloadPort:            8001,
 		HomeDir:                 home,
 		SchedulerCorePoolSize:   10,
 		DownloadPath:            filepath.Join(home, "repo", "download"),
@@ -90,8 +91,12 @@ func NewBaseProperties() *BaseProperties {
 // BaseProperties contains all basic properties of supernode.
 type BaseProperties struct {
 	// ListenPort is the port supernode server listens on.
-	// default:
+	// default: 8002
 	ListenPort int `yaml:"listenPort"`
+
+	// DownloadPort is the port for download files from supernode.
+	// default: 8001
+	DownloadPort int `yaml:"downloadPort"`
 
 	// HomeDir is working directory of supernode.
 	// default: /home/admin/supernode

--- a/supernode/daemon/daemon.go
+++ b/supernode/daemon/daemon.go
@@ -50,7 +50,7 @@ func (d *Daemon) RegisterSuperNode() error {
 	req := &types.PeerCreateRequest{
 		IP:       strfmt.IPv4(d.config.AdvertiseIP),
 		HostName: strfmt.Hostname(hostname),
-		Port:     int32(d.config.ListenPort),
+		Port:     int32(d.config.DownloadPort),
 	}
 
 	resp, err := d.server.PeerMgr.Register(context.Background(), req)


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Supernode will listen on two ports:
+ The register port (default: 8002) 
+ The download port (default: 8001)

The register port is used for clients to register their own information into supernode.
The download port is used for clients to download pieces from supernode.

And we currently lack of the download port flag.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
None.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


