### PR TITLE
dfget --node flag can specify the port of supernodes.

### DIFF
--- a/cmd/dfget/app/root.go
+++ b/cmd/dfget/app/root.go
@@ -205,7 +205,7 @@ func initFlags() {
 	flagSet.StringSliceVar(&cfg.Header, "header", nil,
 		"http header, eg: --header='Accept: *' --header='Host: abc'")
 	flagSet.StringSliceVarP(&cfg.Node, "node", "n", nil,
-		"specify the addresses(IP:port) of supernodes")
+		"specify the addresses(IP or IP:port) of supernodes")
 	flagSet.BoolVar(&cfg.Notbs, "notbs", false,
 		"disable back source downloading for requested file when p2p fails to download it")
 	flagSet.BoolVar(&cfg.DFDaemon, "dfdaemon", false,

--- a/dfget/core/api/supernode_api.go
+++ b/dfget/core/api/supernode_api.go
@@ -64,7 +64,6 @@ var _ SupernodeAPI = &supernodeAPI{}
 
 //dfget --node ends with ":port" or not
 func (api *supernodeAPI) nodeToIPAndPort(node string) (ip string, port int) {
-
 	strs := strings.Split(node, ":")
 	switch len(strs) {
 	case 0:
@@ -78,7 +77,6 @@ func (api *supernodeAPI) nodeToIPAndPort(node string) (ip string, port int) {
 		}
 		return strs[0], p
 	}
-
 }
 
 // Register sends a request to the supernode to register itself as a peer
@@ -109,7 +107,6 @@ func (api *supernodeAPI) PullPieceTask(node string, req *types.PullPieceTaskRequ
 	resp *types.PullPieceTaskResponse, e error) {
 
 	ip, port := api.nodeToIPAndPort(node)
-
 	url := fmt.Sprintf("%s://%s:%d%s?%s",
 		api.Scheme, ip, port, peerPullPieceTaskPath, util.ParseQuery(req))
 

--- a/dfget/core/api/supernode_api.go
+++ b/dfget/core/api/supernode_api.go
@@ -19,6 +19,8 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/dragonflyoss/Dragonfly/common/util"
@@ -45,10 +47,10 @@ func NewSupernodeAPI() SupernodeAPI {
 
 // SupernodeAPI defines the communication methods between supernode and dfget.
 type SupernodeAPI interface {
-	Register(ip string, req *types.RegisterRequest) (resp *types.RegisterResponse, e error)
-	PullPieceTask(ip string, req *types.PullPieceTaskRequest) (resp *types.PullPieceTaskResponse, e error)
-	ReportPiece(ip string, req *types.ReportPieceRequest) (resp *types.BaseResponse, e error)
-	ServiceDown(ip string, taskID string, cid string) (resp *types.BaseResponse, e error)
+	Register(node string, req *types.RegisterRequest) (resp *types.RegisterResponse, e error)
+	PullPieceTask(node string, req *types.PullPieceTaskRequest) (resp *types.PullPieceTaskResponse, e error)
+	ReportPiece(node string, req *types.ReportPieceRequest) (resp *types.BaseResponse, e error)
+	ServiceDown(node string, taskID string, cid string) (resp *types.BaseResponse, e error)
 }
 
 type supernodeAPI struct {
@@ -60,16 +62,36 @@ type supernodeAPI struct {
 
 var _ SupernodeAPI = &supernodeAPI{}
 
+//dfget --node ends with ":port" or not
+func (api *supernodeAPI) nodeToIPAndPort(node string) (ip string, port int) {
+
+	strs := strings.Split(node, ":")
+	switch len(strs) {
+	case 0:
+		return node, api.ServicePort
+	case 1:
+		return strs[0], api.ServicePort
+	default:
+		p, err := strconv.Atoi(strs[1])
+		if err != nil {
+			return strs[0], api.ServicePort
+		}
+		return strs[0], p
+	}
+
+}
+
 // Register sends a request to the supernode to register itself as a peer
 // and create downloading task.
-func (api *supernodeAPI) Register(ip string, req *types.RegisterRequest) (
+func (api *supernodeAPI) Register(node string, req *types.RegisterRequest) (
 	resp *types.RegisterResponse, e error) {
 	var (
 		code int
 		body []byte
 	)
+	ip, port := api.nodeToIPAndPort(node)
 	url := fmt.Sprintf("%s://%s:%d%s",
-		api.Scheme, ip, api.ServicePort, peerRegisterPath)
+		api.Scheme, ip, port, peerRegisterPath)
 	if code, body, e = api.HTTPClient.PostJSON(url, req, api.Timeout); e != nil {
 		return nil, e
 	}
@@ -83,11 +105,13 @@ func (api *supernodeAPI) Register(ip string, req *types.RegisterRequest) (
 
 // PullPieceTask pull a piece downloading task from supernode, and get a
 // response that describes from which peer to download.
-func (api *supernodeAPI) PullPieceTask(ip string, req *types.PullPieceTaskRequest) (
+func (api *supernodeAPI) PullPieceTask(node string, req *types.PullPieceTaskRequest) (
 	resp *types.PullPieceTaskResponse, e error) {
 
+	ip, port := api.nodeToIPAndPort(node)
+
 	url := fmt.Sprintf("%s://%s:%d%s?%s",
-		api.Scheme, ip, api.ServicePort, peerPullPieceTaskPath, util.ParseQuery(req))
+		api.Scheme, ip, port, peerPullPieceTaskPath, util.ParseQuery(req))
 
 	resp = new(types.PullPieceTaskResponse)
 	e = api.get(url, resp)
@@ -95,11 +119,12 @@ func (api *supernodeAPI) PullPieceTask(ip string, req *types.PullPieceTaskReques
 }
 
 // ReportPiece reports the status of piece downloading task to supernode.
-func (api *supernodeAPI) ReportPiece(ip string, req *types.ReportPieceRequest) (
+func (api *supernodeAPI) ReportPiece(node string, req *types.ReportPieceRequest) (
 	resp *types.BaseResponse, e error) {
 
+	ip, port := api.nodeToIPAndPort(node)
 	url := fmt.Sprintf("%s://%s:%d%s?%s",
-		api.Scheme, ip, api.ServicePort, peerReportPiecePath, util.ParseQuery(req))
+		api.Scheme, ip, port, peerReportPiecePath, util.ParseQuery(req))
 
 	resp = new(types.BaseResponse)
 	e = api.get(url, resp)
@@ -107,11 +132,12 @@ func (api *supernodeAPI) ReportPiece(ip string, req *types.ReportPieceRequest) (
 }
 
 // ServiceDown reports the status of the local peer to supernode.
-func (api *supernodeAPI) ServiceDown(ip string, taskID string, cid string) (
+func (api *supernodeAPI) ServiceDown(node string, taskID string, cid string) (
 	resp *types.BaseResponse, e error) {
 
+	ip, port := api.nodeToIPAndPort(node)
 	url := fmt.Sprintf("%s://%s:%d%s?taskId=%s&cid=%s",
-		api.Scheme, ip, api.ServicePort, peerServiceDownPath, taskID, cid)
+		api.Scheme, ip, port, peerServiceDownPath, taskID, cid)
 
 	resp = new(types.BaseResponse)
 	e = api.get(url, resp)

--- a/dfget/core/api/supernode_api_test.go
+++ b/dfget/core/api/supernode_api_test.go
@@ -157,3 +157,22 @@ func createRegisterRequest() (req *types.RegisterRequest) {
 	req = &types.RegisterRequest{}
 	return req
 }
+
+func (s *SupernodeAPITestSuite) TestSupernodeAPI_nodeToIPAndPort(c *check.C) {
+	node1 := "10.47.231.22"
+	node2 := "10.47.231.25:8005"
+	node3 := "10.47.231.25:abcd"
+
+	ip, port := s.api.(*supernodeAPI).nodeToIPAndPort(node1)
+	c.Assert(ip, check.Equals, "10.47.231.22")
+	c.Assert(port, check.Equals, s.api.(*supernodeAPI).ServicePort)
+
+	ip, port = s.api.(*supernodeAPI).nodeToIPAndPort(node2)
+	c.Assert(ip, check.Equals, "10.47.231.25")
+	c.Assert(port, check.Equals, int(8005))
+
+	ip, port = s.api.(*supernodeAPI).nodeToIPAndPort(node3)
+	c.Assert(ip, check.Equals, "10.47.231.25")
+	c.Assert(port, check.Equals, int(8002))
+
+}

--- a/dfget/core/api/supernode_api_test.go
+++ b/dfget/core/api/supernode_api_test.go
@@ -174,5 +174,4 @@ func (s *SupernodeAPITestSuite) TestSupernodeAPI_nodeToIPAndPort(c *check.C) {
 	ip, port = s.api.(*supernodeAPI).nodeToIPAndPort(node3)
 	c.Assert(ip, check.Equals, "10.47.231.25")
 	c.Assert(port, check.Equals, int(8002))
-
 }


### PR DESCRIPTION
<!-- 
### Ⅰ. Describe what this PR did
The --node flag of dfget only can specify the ip of supernodes, but sometimes wo need to change the port 8002 which supernodes listen on. We add ip:port syntax to the --node flag, but the old ip syntax can also be supported.

### Ⅱ. Does this pull request fix one issue?
The following commands have been tested:
dfget -u xxx -n ip1,ip2
dfget -u xxx -n ip1:port1,ip2
dfget -u xxx -n ip1:port1,ip2:port
They works.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
Yes, I have add unit test function.

### Ⅳ. Describe how to verify it
Modify the nginx listen port 8002 to 8005 at supernode, restart nginx.
Use dfget -n IP or dfget -n IP:8005 to specify the port of supernode.

### Ⅴ. Special notes for reviews


