### PR TITLE
fix: BackDownloader only download file when response is less than 400

### DIFF
--- a/dfget/core/downloader/back_downloader/back_downloader.go
+++ b/dfget/core/downloader/back_downloader/back_downloader.go
@@ -103,6 +103,10 @@ func (bd *BackDownloader) Run() error {
 	}
 	defer resp.Body.Close()
 
+	if !bd.isSuccessStatus(resp.StatusCode) {
+		return fmt.Errorf("failed to download from source, response code:%d", resp.StatusCode)
+	}
+
 	buf := make([]byte, 512*1024)
 	reader := cutil.NewLimitReader(resp.Body, bd.cfg.LocalLimit, bd.Md5 != "")
 	if _, err = io.CopyBuffer(f, reader, buf); err != nil {
@@ -128,4 +132,8 @@ func (bd *BackDownloader) Cleanup() {
 		cutil.DeleteFile(bd.tempFileName)
 	}
 	bd.cleaned = true
+}
+
+func (bd *BackDownloader) isSuccessStatus(code int) bool {
+	return code < 400
 }

--- a/dfget/core/downloader/back_downloader/back_downloader_test.go
+++ b/dfget/core/downloader/back_downloader/back_downloader_test.go
@@ -100,3 +100,18 @@ func (s *BackDownloaderTestSuite) TestBackDownloader_Run(c *check.C) {
 	bd.Md5 = testFileMd5
 	c.Assert(bd.Run(), check.IsNil)
 }
+
+func (s *BackDownloaderTestSuite) TestBackDownloader_Run_NotExist(c *check.C) {
+	dst := path.Join(s.workHome, "back.test")
+
+	cfg := helper.CreateConfig(nil, s.workHome)
+	bd := &BackDownloader{
+		cfg:    cfg,
+		URL:    "http://" + s.host + "/download1.test",
+		Target: dst,
+	}
+
+	err := bd.Run()
+	c.Check(err, check.NotNil)
+	c.Check(err, check.ErrorMatches, ".*404")
+}


### PR DESCRIPTION
Signed-off-by: lowzj <zj3142063@gmail.com>

### Ⅰ. Describe what this PR did

When the response code is greater or equals 400, it means that there's something wrong, so `BackDownloader` shouldn't download the file.

merge to branch `master` and `0.3.x`.

### Ⅱ. Does this pull request fix one issue?

fixes: #544 