### PR TITLE
bugfix: calculate realHTTPFileLength which is different realFileLength

### DIFF
--- a/supernode/daemon/mgr/cdn/super_writer_test.go
+++ b/supernode/daemon/mgr/cdn/super_writer_test.go
@@ -73,9 +73,9 @@ func (s *SuperWriterTestSuite) TestStartWriter(c *check.C) {
 	pieceCount := (httpFileLen + int64(pieceContSize-1)) / int64(pieceContSize)
 	expectedSize := httpFileLen + pieceCount*int64(config.PieceWrapSize)
 
-	realFileLength, err := s.writer.startWriter(context.TODO(), nil, f, task, 0, httpFileLen, pieceContSize)
+	downloadMetadata, err := s.writer.startWriter(context.TODO(), nil, f, task, 0, httpFileLen, pieceContSize)
 	c.Check(err, check.IsNil)
-	c.Check(realFileLength, check.Equals, expectedSize)
+	c.Check(downloadMetadata.realFileLength, check.Equals, expectedSize)
 	checkFileSize(s.writer.cdnStore, task.ID, expectedSize, c)
 }
 

--- a/supernode/daemon/mgr/progress/progress_util.go
+++ b/supernode/daemon/mgr/progress/progress_util.go
@@ -74,7 +74,10 @@ func updateRunningPiece(dstPIDMap *cutil.SyncMap, srcCID, dstPID string, pieceNu
 		return dstPIDMap.Add(pieceNumString, dstPID)
 	}
 
-	if _, err := dstPIDMap.Get(pieceNumString); err != nil && errorType.IsDataNotFound(err) {
+	if _, err := dstPIDMap.Get(pieceNumString); err != nil {
+		if errorType.IsDataNotFound(err) {
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Now the writer will calculate the file Length dynamically which includes the piece header and piece tailer. However, we will use httpFileLength which is the length of the file contents to check whether file length matches the expected.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

None.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


