### PR TITLE
feature: return updateTaskInfo with cdnStatusFailed when http download gets errors

### DIFF
--- a/supernode/daemon/mgr/cdn/cdn_util.go
+++ b/supernode/daemon/mgr/cdn/cdn_util.go
@@ -2,6 +2,8 @@ package cdn
 
 import (
 	"time"
+
+	"github.com/dragonflyoss/Dragonfly/apis/types"
 )
 
 var getCurrentTimeMillisFunc = getCurrentTimeMillis
@@ -17,4 +19,16 @@ func getContentLengthByHeader(pieceHeader uint32) int32 {
 
 func getPieceHeader(dataSize, pieceSize int32) uint32 {
 	return uint32(dataSize | (pieceSize << 4))
+}
+
+func getUpdateTaskInfoWithStatusOnly(cdnStatus string) *types.TaskInfo {
+	return getUpdateTaskInfo(cdnStatus, "", 0)
+}
+
+func getUpdateTaskInfo(cdnStatus, realMD5 string, fileLength int64) *types.TaskInfo {
+	return &types.TaskInfo{
+		CdnStatus:  cdnStatus,
+		FileLength: fileLength,
+		RealMd5:    realMD5,
+	}
 }

--- a/supernode/daemon/mgr/cdn/manager.go
+++ b/supernode/daemon/mgr/cdn/manager.go
@@ -87,7 +87,7 @@ func (cm *Manager) TriggerCDN(ctx context.Context, task *types.TaskInfo) (*types
 	// start to download the source file
 	resp, err := cm.download(ctx, task.ID, task.TaskURL, task.Headers, startPieceNum, httpFileLength, pieceContSize)
 	if err != nil {
-		return nil, err
+		return getUpdateTaskInfoWithStatusOnly(types.TaskInfoCdnStatusFAILED), err
 	}
 	defer resp.Body.Close()
 
@@ -102,16 +102,10 @@ func (cm *Manager) TriggerCDN(ctx context.Context, task *types.TaskInfo) (*types
 	realMD5 := reader.Md5()
 	success, err := cm.handleCDNResult(ctx, task, realMD5, httpFileLength, downloadMetadata.realHTTPFileLength)
 	if err != nil || success == false {
-		return &types.TaskInfo{
-			CdnStatus: types.TaskInfoCdnStatusFAILED,
-		}, err
+		return getUpdateTaskInfoWithStatusOnly(types.TaskInfoCdnStatusFAILED), err
 	}
 
-	return &types.TaskInfo{
-		CdnStatus:  types.TaskInfoCdnStatusSUCCESS,
-		FileLength: downloadMetadata.realFileLength,
-		RealMd5:    realMD5,
-	}, nil
+	return getUpdateTaskInfo(types.TaskInfoCdnStatusSUCCESS, realMD5, downloadMetadata.realFileLength), nil
 }
 
 // GetHTTPPath returns the http download path of taskID.

--- a/supernode/daemon/mgr/cdn/reporter.go
+++ b/supernode/daemon/mgr/cdn/reporter.go
@@ -83,11 +83,8 @@ func (re *reporter) processCacheByQuick(ctx context.Context, taskID string, meta
 		return false, nil, nil
 	}
 
-	return true, &types.TaskInfo{
-		CdnStatus:  types.TaskInfoCdnStatusSUCCESS,
-		FileLength: metaData.FileLength,
-		RealMd5:    metaData.Md5,
-	}, re.reportPiecesStatus(ctx, taskID, pieceMd5s)
+	return true, getUpdateTaskInfo(types.TaskInfoCdnStatusSUCCESS, metaData.Md5, metaData.FileLength),
+		re.reportPiecesStatus(ctx, taskID, pieceMd5s)
 }
 
 func (re *reporter) processCacheByReadFile(ctx context.Context, taskID string, metaData *fileMetaData, breakNum int) (hash.Hash, *types.TaskInfo, error) {
@@ -134,11 +131,8 @@ func (re *reporter) processCacheByReadFile(ctx context.Context, taskID string, m
 	}
 	logrus.Infof("success to update status and result fileMetaData(%+v) for taskID(%s)", fmd, taskID)
 
-	return nil, &types.TaskInfo{
-		CdnStatus:  types.TaskInfoCdnStatusSUCCESS,
-		FileLength: result.fileLength,
-		RealMd5:    fileMd5Value,
-	}, re.metaDataManager.writePieceMD5s(ctx, taskID, fileMd5Value, result.pieceMd5s)
+	return nil, getUpdateTaskInfo(types.TaskInfoCdnStatusSUCCESS, fileMd5Value, result.fileLength),
+		re.metaDataManager.writePieceMD5s(ctx, taskID, fileMd5Value, result.pieceMd5s)
 }
 
 func (re *reporter) reportPiecesStatus(ctx context.Context, taskID string, pieceMd5s []string) error {


### PR DESCRIPTION

Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

The `cdn_manger` should update the cdn status to failed when it  failed to get resources from url. Otherwise, `supernode` will keep returning peer_wait error until timeout.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


