### PR TITLE
feature: delete the repo prefix for download home path

### DIFF
--- a/supernode/config/global_variable.go
+++ b/supernode/config/global_variable.go
@@ -16,22 +16,8 @@
 
 package config
 
-import (
-	"path"
-)
-
 var (
-	// HTTPSubPath is the name of the parent directory where the upload files are stored.
-	HTTPSubPath = "qtdown"
-
-	// DownloadSubPath is the name of the parent directory where the downloaded files are stored.
-	DownloadSubPath = "download"
-
 	// DownloadHome is the parent directory where the downloaded files are stored
 	// which is a relative path.
-	DownloadHome = path.Join("repo", DownloadSubPath)
-
-	// UploadHome is the parent directory where the upload files are stored
-	// which is a relative path.
-	UploadHome = path.Join("repo", HTTPSubPath)
+	DownloadHome = "download"
 )


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
The store mgr set baseDir with prefix “repo” as the baseDir of local storage. In fact, it should be configured by the user. So I delete the prefix "repo". 

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


