### PR TITLE
feature: handle client error and repair

### DIFF
--- a/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/common/Constants.java
+++ b/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/common/Constants.java
@@ -21,6 +21,7 @@ package com.dragonflyoss.dragonfly.supernode.common;
 public final class Constants {
 
     public static final int PORT = 8001;
+    public static final String CDN_NODE_PREFIX = "cdnnode:";
 
     public static String localIp;
     public static String SUPER_NODE_CID = null;
@@ -80,7 +81,7 @@ public final class Constants {
     //-------------------------------------------------------------------------
 
     private static String getSuperNodeCidPrefix() {
-        return "cdnnode:" + localIp + "~";
+        return CDN_NODE_PREFIX + localIp + "~";
     }
 
     public static void generateNodeCid() {

--- a/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/common/domain/ClientErrorInfo.java
+++ b/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/common/domain/ClientErrorInfo.java
@@ -1,0 +1,20 @@
+package com.dragonflyoss.dragonfly.supernode.common.domain;
+
+import com.dragonflyoss.dragonfly.supernode.common.enumeration.ClientErrorType;
+
+import lombok.Data;
+
+/**
+ * @author lowzj
+ */
+@Data
+public class ClientErrorInfo {
+    private ClientErrorType errorType;
+    private String srcCid;
+    private String dstCid;
+    private String dstIp;
+    private String taskId;
+    private String range;
+    private String realMd5;
+    private String expectedMd5;
+}

--- a/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/common/enumeration/ClientErrorType.java
+++ b/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/common/enumeration/ClientErrorType.java
@@ -1,0 +1,19 @@
+package com.dragonflyoss.dragonfly.supernode.common.enumeration;
+
+/**
+ * ClientErrorType is the error that may happen on client-side when downloading
+ * files. Supernode will handle these errors reported by clients.
+ *
+ * @author lowzj
+ */
+public enum ClientErrorType {
+    /**
+     * the md5 calculated by clients doesn't equal to the md5 calculated by supernode
+     */
+    FILE_MD5_NOT_MATCH,
+
+    /**
+     * the downloading file isn't exist
+     */
+    FILE_NOT_EXIST,
+}

--- a/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/common/util/ExecutorsUtil.java
+++ b/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/common/util/ExecutorsUtil.java
@@ -1,0 +1,26 @@
+package com.dragonflyoss.dragonfly.supernode.common.util;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang3.concurrent.BasicThreadFactory;
+
+/**
+ * @author lowzj
+ */
+public final class ExecutorsUtil {
+        public static ExecutorService newThreadPool(String name, int corePoolSize, int maxPoolSize) {
+            return new ThreadPoolExecutor(corePoolSize, maxPoolSize, 60L, TimeUnit.SECONDS,
+                new LinkedBlockingQueue<Runnable>(), newThreadFactory(name));
+        }
+
+        private static ThreadFactory newThreadFactory(String name) {
+            return new BasicThreadFactory.Builder()
+                .namingPattern(name + "-%d")
+                .daemon(true)
+                .build();
+        }
+}

--- a/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/common/util/RangeParseUtil.java
+++ b/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/common/util/RangeParseUtil.java
@@ -28,16 +28,32 @@ public class RangeParseUtil {
      * @return
      */
     public static int calculatePieceNum(String range) {
+        long[] pieceRange = calculatePieceRange(range);
+        if (pieceRange == null|| pieceRange.length != 2) {
+            return -1;
+        }
+        long start = pieceRange[0];
+        long end = pieceRange[1];
+        return (int)(start / (end - start + 1));
+    }
+
+    /**
+     * @param range the string of range: start-end
+     * @return the array has 2 elements: [start,end], null if any exception happens
+     */
+    public static long[] calculatePieceRange(String range) {
         try {
             String[] rangeArr = range.split(SEPARATOR);
-            long startIndex = Long.parseLong(rangeArr[0]);
-            long endIndex = Long.parseLong(rangeArr[1]);
-            long pieceSize = endIndex - startIndex + 1;
-            return (int)(startIndex / pieceSize);
+            long start = Long.parseLong(rangeArr[0]);
+            long end = Long.parseLong(rangeArr[1]);
+            if (end < start) {
+                return null;
+            }
+            return new long[] {start, end};
         } catch (Exception e) {
-            logger.error("E_caculatePieceNum for range:{}", range, e);
+            logger.error("E_calculatePieceRange for range:{}", range, e);
         }
-        return -1;
+        return null;
     }
 
     /**

--- a/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/service/cdn/util/PathUtil.java
+++ b/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/service/cdn/util/PathUtil.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import com.dragonflyoss.dragonfly.supernode.common.Constants;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,9 +67,7 @@ public class PathUtil {
     }
 
     public static String getHttpPath(String taskId) {
-        StringBuilder sb = new StringBuilder(Constants.HTTP_SUB_PATH);
-        sb.append(taskId.substring(0, 3)).append("/").append(taskId);
-        return sb.toString();
+        return Constants.HTTP_SUB_PATH + taskId.substring(0, 3) + "/" + taskId;
     }
 
     public static void deleteTaskFiles(String taskId, boolean deleteUploadPath) {
@@ -82,7 +81,6 @@ public class PathUtil {
 
             Files.deleteIfExists(getMetaDataPath(taskId));
             Files.deleteIfExists(getMd5DataPath(taskId));
-
         } catch (Exception e) {
             logger.error("delete files error for taskId:{}", taskId, e);
         }

--- a/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/service/impl/PeerRegistryServiceImpl.java
+++ b/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/service/impl/PeerRegistryServiceImpl.java
@@ -93,9 +93,13 @@ public class PeerRegistryServiceImpl implements PeerRegistryService {
                 }
             }
         } catch (TaskIdDuplicateException e) {
-            resultInfo.withCode(ResultCode.TASK_CONFLICT).withMsg(e.getMessage());
+            resultInfo.withCode(ResultCode.TASK_CONFLICT)
+                .withMsg(taskId + " " + e.getMessage());
         } catch (UrlNotReachableException e) {
-            resultInfo.withCode(ResultCode.URL_NOT_REACH).withMsg(e.getMessage());
+            // delete the task after 3 minutes to avoid caching its invalid status always
+            dataGcService.updateAccessTimeIfAbsent(taskId);
+            resultInfo.withCode(ResultCode.URL_NOT_REACH)
+                .withMsg(taskId + " " + e.getMessage());
         } catch (AuthenticationRequiredException e) {
             resultInfo.withCode(ResultCode.NEED_AUTH);
         } catch (AuthenticationWaitedException e) {

--- a/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/service/repair/BaseClientErrorHandler.java
+++ b/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/service/repair/BaseClientErrorHandler.java
@@ -1,0 +1,170 @@
+package com.dragonflyoss.dragonfly.supernode.service.repair;
+
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import com.alibaba.fastjson.JSON;
+
+import com.dragonflyoss.dragonfly.supernode.common.Constants;
+import com.dragonflyoss.dragonfly.supernode.common.domain.ClientErrorInfo;
+import com.dragonflyoss.dragonfly.supernode.common.enumeration.ClientErrorType;
+import com.dragonflyoss.dragonfly.supernode.common.util.ExecutorsUtil;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * The client error will be handled immediately. In the process of handling,
+ * and within 5 seconds after completing handling, the subsequent client errors
+ * with the same taskId and error type will be ignored.
+ *
+ * @author lowzj
+ */
+@Slf4j
+public abstract class BaseClientErrorHandler implements ClientErrorHandler {
+    private static final ExecutorService executor = ExecutorsUtil
+        .newThreadPool("client-error", 5, 100);
+
+    /**
+     * map(taskId, addTime)
+     */
+    private ConcurrentHashMap<String, Integer> running = new ConcurrentHashMap<>();
+
+    private Remover remover = new Remover();
+
+    public BaseClientErrorHandler() {
+        executor.execute(remover);
+    }
+
+    abstract ClientErrorType errorType();
+    abstract void doHandle(final ClientErrorInfo info);
+
+    @Override
+    public boolean isErrorType(ClientErrorType type) {
+        return errorType().equals(type);
+    }
+
+    @Override
+    public void handle(final ClientErrorInfo info) {
+        if (isInvalidInfo(info)) {
+            return;
+        }
+        Integer pre = running.putIfAbsent(info.getTaskId(), currentSeconds());
+        if (pre != null) {
+            return;
+        }
+        try {
+            executor.execute(new HandlerRunner(info));
+        } catch (RejectedExecutionException e) {
+            log.error("reject to execute: {}", JSON.toJSONString(info), e);
+            removeTask(info.getTaskId());
+        }
+    }
+
+    boolean isInvalidInfo(ClientErrorInfo info) {
+        return info == null || !isErrorType(info.getErrorType())
+            || StringUtils.isAnyBlank(info.getTaskId(), info.getDstCid())
+            // ignore the error that isn't caused by downloading from supernode
+            || !info.getDstCid().startsWith(Constants.CDN_NODE_PREFIX);
+    }
+
+    private void removeTask(String taskId) {
+        if (StringUtils.isNoneBlank(taskId)) {
+            remover.add(taskId, true);
+        }
+    }
+
+    private class HandlerRunner implements Runnable {
+        private final ClientErrorInfo info;
+
+        HandlerRunner(ClientErrorInfo info) {
+            this.info = info;
+        }
+
+        @Override
+        public void run() {
+            try {
+                log.info("start to handle client error: {}", JSON.toJSONString(info));
+                doHandle(info);
+            } catch (Exception e) {
+                log.error("failed to handle client error: {}", JSON.toJSONString(info), e);
+            } finally {
+                removeTask(info.getTaskId());
+            }
+        }
+    }
+
+    private class Remover implements Runnable {
+        private static final int EXPIRED = 5;
+        private static final int POLL_INTERVAL = 2;
+        private static final int MAX_SIZE = 100;
+
+        private BlockingDeque<String> queue = new LinkedBlockingDeque<>();
+        private boolean interrupted = false;
+
+        @Override
+        public void run() {
+            while (true) {
+                try {
+                    if (queue.size() >= MAX_SIZE) {
+                        for (int i = 0; i < MAX_SIZE / 2; i++) {
+                            remove(queue.takeFirst(), true);
+                        }
+                    }
+                    String taskId = queue.pollFirst(POLL_INTERVAL, TimeUnit.SECONDS);
+                    if (taskId == null) {
+                        continue;
+                    }
+                    int expires = remove(taskId, false);
+                    if (expires > 0) {
+                        add(taskId, false);
+                        Thread.sleep(expires * 1000);
+                    }
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                    log.warn("remover of {} is interrupted", errorType(), e);
+                    break;
+                }
+            }
+        }
+
+        public void add(String taskId, boolean last) {
+            if (interrupted) {
+                running.remove(taskId);
+                return;
+            }
+            try {
+                if (last) {
+                    queue.addLast(taskId);
+                } else {
+                    queue.addFirst(taskId);
+                }
+            } catch (Throwable t) {
+                running.remove(taskId);
+                log.warn("failed to add into remover, directly remove taskId:{}", taskId, t);
+            }
+        }
+
+        private int remove(String taskId, boolean force) {
+            Integer addTime = running.get(taskId);
+            if (force || addTime == null) {
+                running.remove(taskId);
+                return 0;
+            }
+
+            int expires = addTime + EXPIRED - currentSeconds();
+            if (expires <= 0) {
+                running.remove(taskId);
+            }
+            return expires;
+        }
+    }
+
+    private int currentSeconds() {
+        return (int)(System.currentTimeMillis() / 1000);
+    }
+}

--- a/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/service/repair/ClientErrorHandleService.java
+++ b/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/service/repair/ClientErrorHandleService.java
@@ -1,0 +1,15 @@
+package com.dragonflyoss.dragonfly.supernode.service.repair;
+
+import com.dragonflyoss.dragonfly.supernode.common.domain.ClientErrorInfo;
+
+/**
+ * @author lowzj
+ */
+public interface ClientErrorHandleService {
+    /**
+     * handle the client error
+     *
+     * @param info the information of client error
+     */
+    void handleClientError(ClientErrorInfo info);
+}

--- a/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/service/repair/ClientErrorHandleServiceImpl.java
+++ b/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/service/repair/ClientErrorHandleServiceImpl.java
@@ -1,0 +1,35 @@
+package com.dragonflyoss.dragonfly.supernode.service.repair;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import com.dragonflyoss.dragonfly.supernode.common.domain.ClientErrorInfo;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author lowzj
+ */
+@Service("clientErrorHandleService")
+@Slf4j
+public class ClientErrorHandleServiceImpl implements ClientErrorHandleService {
+
+    @Autowired
+    private List<ClientErrorHandler> handlers = new LinkedList<>();
+
+    @Override
+    public void handleClientError(ClientErrorInfo info) {
+        if (handlers == null || info == null || info.getErrorType() == null) {
+            return;
+        }
+
+        for (ClientErrorHandler handler : handlers) {
+            if (handler != null && handler.isErrorType(info.getErrorType())) {
+                handler.handle(info);
+                break;
+            }
+        }
+    }
+}

--- a/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/service/repair/ClientErrorHandler.java
+++ b/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/service/repair/ClientErrorHandler.java
@@ -1,0 +1,13 @@
+package com.dragonflyoss.dragonfly.supernode.service.repair;
+
+import com.dragonflyoss.dragonfly.supernode.common.domain.ClientErrorInfo;
+import com.dragonflyoss.dragonfly.supernode.common.enumeration.ClientErrorType;
+
+/**
+ * @author lowzj
+ */
+public interface ClientErrorHandler {
+    boolean isErrorType(ClientErrorType type);
+
+    void handle(ClientErrorInfo info);
+}

--- a/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/service/repair/FileMd5NotMatchHandler.java
+++ b/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/service/repair/FileMd5NotMatchHandler.java
@@ -1,0 +1,135 @@
+package com.dragonflyoss.dragonfly.supernode.service.repair;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.List;
+
+import com.dragonflyoss.dragonfly.supernode.common.domain.ClientErrorInfo;
+import com.dragonflyoss.dragonfly.supernode.common.domain.FileMetaData;
+import com.dragonflyoss.dragonfly.supernode.common.enumeration.ClientErrorType;
+import com.dragonflyoss.dragonfly.supernode.common.util.RangeParseUtil;
+import com.dragonflyoss.dragonfly.supernode.service.cdn.FileMetaDataService;
+import com.dragonflyoss.dragonfly.supernode.service.cdn.util.PathUtil;
+import com.dragonflyoss.dragonfly.supernode.service.timer.DataGcService;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * This class only handle the errors that are caused by downloading from supernode.
+ * It checks the piece md5 on local cache, verify it and delete the related task
+ * if the md5 is not expected.
+ *
+ * @author lowzj
+ */
+@Component
+@Slf4j
+public class FileMd5NotMatchHandler extends BaseClientErrorHandler {
+
+    @Autowired
+    private FileMetaDataService fileMetaDataService;
+
+    @Autowired
+    private DataGcService gcService;
+
+    @Override
+    ClientErrorType errorType() {
+        return ClientErrorType.FILE_MD5_NOT_MATCH;
+    }
+
+    @Override
+    void doHandle(final ClientErrorInfo info) {
+        boolean gc = false;
+        String md5FromMeta = getMd5FromMeta(info.getTaskId(), info.getRange());
+        String localMd5 = getMd5(info.getTaskId(), info.getRange());
+        if (StringUtils.isNotBlank(localMd5)) {
+            if (!StringUtils.equals(md5FromMeta, localMd5) // data in supernode is not right
+                && !StringUtils.equals(localMd5, info.getExpectedMd5())) {
+                gcService.gcOneTask(info.getTaskId());
+                gc = true;
+            }
+        }
+        log.info("taskId:{} range:{} realMd5:{} expectedMd5:{} localMd5:{} metaMd5:{} gc:{}",
+            info.getTaskId(), info.getRange(), info.getRealMd5(), info.getExpectedMd5(),
+            localMd5, md5FromMeta, gc);
+    }
+
+    @Override
+    boolean isInvalidInfo(ClientErrorInfo info) {
+        return super.isInvalidInfo(info)
+            || StringUtils.isAnyBlank(
+                info.getDstIp(), info.getRange(), info.getExpectedMd5(), info.getRealMd5());
+    }
+
+    private String getMd5(String taskId, String range) {
+        long[] pieceRange = RangeParseUtil.calculatePieceRange(range);
+        if (pieceRange == null) {
+            return null;
+        }
+
+        Path uploadPath = PathUtil.getUploadPath(taskId);
+        RandomAccessFile raf = null;
+        try {
+            raf = new RandomAccessFile(uploadPath.toFile(), "r");
+            return readMd5(raf, pieceRange[0], pieceRange[1]);
+        } catch (IOException e) {
+            log.error("getMd5 taskId:{} range:{} error:{}", taskId, range, e.getMessage(), e);
+        } finally {
+            closeFile(raf);
+        }
+        return null;
+    }
+
+    private String readMd5(RandomAccessFile raf, long start, long end) throws IOException {
+        final int size = 4 * 1024 * 1024;
+        final byte[] buff = new byte[size];
+
+        MessageDigest pieceMd5 = DigestUtils.getMd5Digest();
+        int remain = (int)(end - start + 1);
+        raf.seek(start);
+        do {
+            int readLen = remain > size ? size : remain;
+            readLen = raf.read(buff, 0, readLen);
+            log.debug("readMd5, remain:{} readLen:{}", remain, readLen);
+            if (readLen > 0) {
+                pieceMd5.update(buff, 0, readLen);
+                remain -= readLen;
+            } else {
+                break;
+            }
+        } while (remain > 0);
+        return Hex.encodeHexString(pieceMd5.digest());
+    }
+
+    private void closeFile(Closeable c) {
+        if (c != null) {
+            try {
+                c.close();
+            } catch (IOException e) {
+                // pass
+            }
+        }
+    }
+
+    private String getMd5FromMeta(String taskId, String range) {
+        int pieceNum = RangeParseUtil.calculatePieceNum(range);
+        if (pieceNum < 0) {
+            return null;
+        }
+
+        FileMetaData meta = fileMetaDataService.readFileMetaData(taskId);
+        if (meta == null) {
+            return null;
+        }
+        List<String> pieceMd5s = fileMetaDataService.readPieceMd5(taskId, meta.getRealMd5());
+
+        return pieceMd5s.size() > pieceNum ? pieceMd5s.get(pieceNum) : null;
+    }
+}

--- a/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/service/repair/FileNotExistHandler.java
+++ b/src/supernode/src/main/java/com/dragonflyoss/dragonfly/supernode/service/repair/FileNotExistHandler.java
@@ -1,0 +1,44 @@
+package com.dragonflyoss.dragonfly.supernode.service.repair;
+
+import java.nio.file.Path;
+
+import com.dragonflyoss.dragonfly.supernode.common.domain.ClientErrorInfo;
+import com.dragonflyoss.dragonfly.supernode.common.enumeration.ClientErrorType;
+import com.dragonflyoss.dragonfly.supernode.common.util.FileUtil;
+import com.dragonflyoss.dragonfly.supernode.service.cdn.util.PathUtil;
+import com.dragonflyoss.dragonfly.supernode.service.timer.DataGcService;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author lowzj
+ */
+@Component
+@Slf4j
+public class FileNotExistHandler extends BaseClientErrorHandler {
+    @Autowired
+    private DataGcService dataGcService;
+
+    @Override
+    ClientErrorType errorType() {
+        return ClientErrorType.FILE_NOT_EXIST;
+    }
+
+    @Override
+    void doHandle(final ClientErrorInfo info) {
+        Path downloadPath = PathUtil.getDownloadPath(info.getTaskId());
+        if (!downloadPath.toFile().exists()) {
+            boolean res = dataGcService.gcOneTask(info.getTaskId());
+            log.info("taskId:{} data file doesn't exist, task gc:{}", info.getTaskId(), res);
+            return;
+        }
+
+        Path uploadPath = PathUtil.getUploadPath(info.getTaskId());
+        if (!uploadPath.toFile().exists()) {
+            boolean res = FileUtil.createSymbolicLink(uploadPath, downloadPath);
+            log.info("taskId:{} upload file doesn't exist, link again:{}", info.getTaskId(), res);
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: lowzj <zj3142063@gmail.com>

### Ⅰ. Describe what this PR did

dfget reports downloading errors to supernode, supernode checks and repairs local data automatically, currently repair these client errors:
* `FILE_NOT_EXIST`
* `FILE_MD5_NOT_MATCH`

add a new api into supernode to delete the task's data manually if any error occurred

```
DELETE /peer/tasks/{taskId}
```

client-side pr: #583 

> merge into branch `master` and `0.3.x`

### Ⅱ. Does this pull request fix one issue?

fixes #545 
fixes #311 
fixes #68 


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


