### PR TITLE
feature: add supernode Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,15 @@ RUN apk --no-cache add bash make gcc libc-dev git
 
 COPY . /go/src/github.com/dragonflyoss/Dragonfly
 
-# go build dfdaemon and dfget.
-# write the resulting executable to the dir /dfclient.
-RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -o /dfclient/dfdaemon cmd/dfdaemon/main.go
-RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -o /dfclient/dfget cmd/dfget/main.go
+# make build dfdaemon and dfget.
+# write the resulting executable to the dir /opt/dragonfly/df-client.
+RUN make build-client && make install-client
 
 FROM alpine:3.8
 
 RUN apk --no-cache add ca-certificates bash
 
-COPY --from=builder /dfclient /dfclient
+COPY --from=builder /opt/dragonfly/df-client /opt/dragonfly/df-client
 
 # dfdaemon will listen 65001 in default.
 EXPOSE 65001
@@ -22,4 +21,4 @@ EXPOSE 65001
 # use the https://index.docker.io as default registry.
 CMD [ "--registry", "https://index.docker.io" ]
 
-ENTRYPOINT [ "/dfclient/dfdaemon" ]
+ENTRYPOINT [ "/opt/dragonfly/df-client/dfdaemon" ]

--- a/Dockerfile.supernode
+++ b/Dockerfile.supernode
@@ -1,0 +1,22 @@
+FROM golang:1.10.4-alpine as builder
+
+WORKDIR /go/src/github.com/dragonflyoss/Dragonfly
+RUN apk --no-cache add bash make gcc libc-dev git
+
+COPY . /go/src/github.com/dragonflyoss/Dragonfly
+
+# go build supernode.
+# write the resulting executable to the dir /opt/dragonfly/df-supernode.
+RUN make build-supernode && make install-supernode
+
+FROM nginx:1.16-alpine
+
+RUN apk --no-cache add ca-certificates bash
+
+COPY --from=builder /go/src/github.com/dragonflyoss/Dragonfly/hack/supernode-nginx.conf /etc/nginx/nginx.conf
+COPY --from=builder /opt/dragonfly/df-supernode/supernode /opt/dragonfly/df-supernode/supernode
+
+# supernode will listen 8001,8002 in default.
+EXPOSE 8001 8002
+
+ENTRYPOINT [ "sh", "-c", "nginx && /opt/dragonfly/df-supernode/supernode" ]

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@
 # with docker.
 USE_DOCKER?=0 # Default: build components in the local environment.
 
+# Assign the Dragonfly version to DF_VERSION as the image tag.
+DF_VERSION?=latest # Default: use latest as the image tag which built by docker.
+
 clean:
 	@echo "Begin to clean redundant files."
 	@rm -rf ./bin
@@ -57,10 +60,45 @@ install:
 	./hack/install.sh install
 .PHONY: install
 
+install-client:
+	@echo "Begin to install dfget and dfdaemon."
+	./hack/install.sh install dfclient
+.PHONY: install-client
+
+install-supernode:
+	@echo "Begin to install supernode."
+	./hack/install.sh install supernode
+.PHONY: install-supernode
+
 uninstall:
 	@echo "Begin to uninstall dfget and dfdaemon and supernode."
 	./hack/install.sh uninstall
 .PHONY: uninstall
+
+uninstall-client:
+	@echo "Begin to uninstall dfget and dfdaemon."
+	./hack/install.sh uninstall-dfclient
+.PHONY: uninstall-client
+
+uninstall-supernode:
+	@echo "Begin to uninstall supernode."
+	./hack/install.sh uninstall-supernode
+.PHONY: uninstall-supernode
+
+docker-build:
+	@echo "Begin to use docker build dfcient and supernode images."
+	./hack/docker-build.sh
+.PHONY: docker-build
+
+docker-build-client:
+	@echo "Begin to use docker build dfcient image."
+	./hack/docker-build.sh dfclient 
+.PHONY: docker-build-client
+
+docker-build-supernode:
+	@echo "Begin to use docker build supernode image."
+	./hack/docker-build.sh supernode
+.PHONY: docker-build-supernode
 
 unit-test: build-dirs
 	./hack/unit-test.sh

--- a/hack/docker-build.sh
+++ b/hack/docker-build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DF_VERSION=${DF_VERSION:-"latest"}
+curDir=$(cd "$(dirname "$0")" && pwd)
+cd "${curDir}/../" || return
+
+docker-build::build-dfclient(){
+    docker build -t dfclient:"${DF_VERSION}" -f Dockerfile .
+}
+
+docker-build::build-supernode(){
+    docker build -t supernode:"${DF_VERSION}" -f Dockerfile.supernode .
+}
+
+main() {
+    case "$1" in
+        dfclient)
+            docker-build::build-dfclient 
+        ;;
+        supernode)
+            docker-build::build-supernode 
+        ;;
+        *)
+            docker-build::build-dfclient
+            docker-build::build-supernode
+        ;;
+    esac
+}
+
+main "$@"

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -10,28 +10,72 @@ cd "${curDir}" || return
 . ./env.sh
 
 install() {
-    installClientDir="${INSTALL_HOME}/${INSTALL_CLIENT_PATH}"
-    installSuperDir="${INSTALL_HOME}/${INSTALL_SUPERNODE_PATH}"
-    echo "install: ${INSTALL_HOME}"
+    case "$1" in
+        dfclient)
+            install-client
+        ;;
+        supernode)
+            install-supernode
+        ;;
+        *)
+            install-client
+            install-supernode
+        ;;
+    esac
+}
+
+install-client(){
+    local installClientDir="${INSTALL_HOME}/${INSTALL_CLIENT_PATH}"
+    echo "install: ${installClientDir}"
     createDir "${installClientDir}"
-    createDir "${installSuperDir}"
 
     cp "${BIN_DIR}/${GOOS}_${GOARCH}/${DFDAEMON_BINARY_NAME}"   "${installClientDir}"
     cp "${BIN_DIR}/${GOOS}_${GOARCH}/${DFGET_BINARY_NAME}"      "${installClientDir}"
-    cp "${BIN_DIR}/${GOOS}_${GOARCH}/${SUPERNODE_BINARY_NAME}"  "${installSuperDir}"
 
     createLink "${installClientDir}/${DFDAEMON_BINARY_NAME}" /usr/local/bin/dfdaemon
     createLink "${installClientDir}/${DFGET_BINARY_NAME}" /usr/local/bin/dfget
+}
+
+install-supernode(){
+    local installSuperDir="${INSTALL_HOME}/${INSTALL_SUPERNODE_PATH}"
+    echo "install: ${installSuperDir}"
+    createDir "${installSuperDir}"
+
+    cp "${BIN_DIR}/${GOOS}_${GOARCH}/${SUPERNODE_BINARY_NAME}"  "${installSuperDir}"
+
     createLink "${installSuperDir}/${SUPERNODE_BINARY_NAME}" /usr/local/bin/supernode
 }
 
+
 uninstall() {
+    case "$1" in
+        dfclient)
+            uninstall-client
+        ;;
+        supernode)
+            uninstall-supernode
+        ;;
+        *)
+            uninstall-all
+        ;;
+    esac
+}
+
+uninstall-client() {
     echo "unlink /usr/local/bin/dfdaemon"
     test -e /usr/local/bin/dfdaemon && unlink /usr/local/bin/dfdaemon
     echo "unlink /usr/local/bin/dfget"
     test -e /usr/local/bin/dfget && unlink /usr/local/bin/dfget
+}
+
+uninstall-supernode() {
     echo "unlink /usr/local/bin/supernode"
     test -e /usr/local/bin/supernode && unlink /usr/local/bin/supernode
+}
+
+uninstall-all(){
+    uninstall-client
+    uninstall-supernode
 
     echo "uninstall dragonfly: ${INSTALL_HOME}"
     test -d "${INSTALL_HOME}" && rm -rf "${INSTALL_HOME}"
@@ -54,10 +98,10 @@ createDir() {
 main() {
     case "$1" in
         install)
-            install
+            install "$2"
         ;;
         uninstall)
-            uninstall
+            uninstall "$2"
         ;;
         *)
             echo "You must specify the subcommand 'install' or 'uninstall'."

--- a/hack/supernode-nginx.conf
+++ b/hack/supernode-nginx.conf
@@ -1,0 +1,51 @@
+worker_rlimit_nofile        100000;
+
+events {
+    use                     epoll;
+    worker_connections      20480;
+}
+
+http {
+    include                 mime.types;
+    default_type            application/octet-stream;
+    root                    /home/admin/cai/htdocs;
+    sendfile                on;
+    tcp_nopush              on;
+
+    server_tokens           off;
+    keepalive_timeout       5;
+
+    client_header_timeout   1m;
+    send_timeout            1m;
+    client_max_body_size    3m;
+
+    index                   index.html index.htm;
+    access_log              off;
+    log_not_found           off;
+
+    gzip                    on;
+    gzip_http_version       1.0;
+    gzip_comp_level         6;
+    gzip_min_length         1024;
+    gzip_proxied            any;
+    gzip_vary               on;
+    gzip_disable            msie6;
+    gzip_buffers            96 8k;
+    gzip_types              text/xml text/plain text/css application/javascript application/x-javascript application/rss+xml application/json;
+
+    proxy_set_header        Host $host;
+    proxy_set_header        X-Real-IP $remote_addr;
+    proxy_set_header        Web-Server-Type nginx;
+    proxy_set_header        WL-Proxy-Client-IP $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_redirect          off;
+    proxy_buffers           128 8k;
+    proxy_intercept_errors  on;
+
+    server {
+        listen              8001;
+        location / {
+            root /home/admin/supernode/repo;
+        }
+    }
+}

--- a/supernode/server/0.3_bridge.go
+++ b/supernode/server/0.3_bridge.go
@@ -125,7 +125,6 @@ func (s *Server) pullPieceTask(ctx context.Context, rw http.ResponseWriter, req 
 	}
 
 	isFinished, data, err := s.TaskMgr.GetPieces(ctx, taskID, srcCID, request)
-	logrus.Infof("get pieces data:%+v", data)
 	if err != nil {
 		logrus.Errorf("failed to get pieces %+v: %v", request, err)
 		resultInfo := NewResultInfoWithError(err)


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Add Dockerfile for supernode and use `make build && make install` instead of `go build` for either dfclient and supernode.

Update the `Makefile` and add a shell `docker-build.sh` , and then you can
+ use `make docker-build-dfclient DF_VERSION=$tag` to get a dfclient image
+ use `make docker-build-supernode DF_VERSION=$tag` to get a supernode image 
+ use `make docker-build DF_VERSION=$tag` to get them all

After you get a supernode image, then you can use docker run to start your supernode server
```
make docker-build-supernode DF_VERSION=0.4

docker run -d --name dfsupernode -p 8001:8001 -p 8002:8002 -v /home/admin/supernode:/home/admin/supernode supernode:0.4 --advertise-ip=127.0.0.1 --download-port=8001
```
### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes part of #206

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


