### PR TITLE
fix: send http request with timeout

### DIFF
--- a/dfget/core/api/download_api.go
+++ b/dfget/core/api/download_api.go
@@ -60,5 +60,5 @@ func (d *downloadAPI) Download(ip string, port int, req *DownloadRequest) (*http
 	headers[config.StrUserAgent] = "dfget/" + version.DFGetVersion
 
 	url := fmt.Sprintf("http://%s:%d%s", ip, port, req.Path)
-	return util.HTTPGetWithHeaders(url, headers)
+	return util.HTTPGet(url, headers)
 }

--- a/dfget/core/downloader/back_downloader/back_downloader.go
+++ b/dfget/core/downloader/back_downloader/back_downloader.go
@@ -98,7 +98,7 @@ func (bd *BackDownloader) Run() error {
 	bd.tempFileName = f.Name()
 	defer f.Close()
 
-	if resp, err = cutil.HTTPGetWithHeaders(bd.URL, cutil.ConvertHeaders(bd.cfg.Header)); err != nil {
+	if resp, err = cutil.HTTPGet(bd.URL, cutil.ConvertHeaders(bd.cfg.Header)); err != nil {
 		return err
 	}
 	defer resp.Body.Close()

--- a/supernode/daemon/mgr/cdn/downloader.go
+++ b/supernode/daemon/mgr/cdn/downloader.go
@@ -41,7 +41,7 @@ func (cm *Manager) download(ctx context.Context, taskID, url string, headers map
 
 func getWithURL(url string, headers map[string]string, checkCode int) (*http.Response, error) {
 	// TODO: add timeout
-	resp, err := cutil.HTTPGetWithHeaders(url, headers)
+	resp, err := cutil.HTTPGet(url, headers)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: lowzj <zj3142063@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

* change connection timeout from `30 seconds` to `3 seconds`
* use `GET` method instead of `HEAD` method to get `content-length`, check expiration and whether support range request. It's because that some servers may not support `HEAD` method.
* set the whole operation's timeout as `4 seconds`(including connection timeout)

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


