### PR TITLE
Dfclient set InsecureSkipVerify for https proxy

### DIFF
--- a/dfdaemon/proxy/proxy.go
+++ b/dfdaemon/proxy/proxy.go
@@ -123,7 +123,7 @@ func NewFromConfig(c config.Properties) (*Proxy, error) {
 			if r.UseHTTPS {
 				scheme = "and force https"
 			}
-			logrus.Infof("[%d] proxy %s %s%s", i+1, r.Regx, method, scheme)
+			logrus.Infof("[%d] proxy %s %s %s", i+1, r.Regx, method, scheme)
 		}
 	}
 
@@ -176,7 +176,7 @@ func (proxy *Proxy) mirrorRegistry(w http.ResponseWriter, r *http.Request) {
 func (proxy *Proxy) remoteConfig(host string) *tls.Config {
 	for _, h := range proxy.httpsHosts {
 		if h.Regx.MatchString(host) {
-			config := &tls.Config{}
+			config := &tls.Config{InsecureSkipVerify: h.Insecure}
 			if h.Certs != nil {
 				config.RootCAs = h.Certs.CertPool
 			}

--- a/docs/user_guide/proxy.md
+++ b/docs/user_guide/proxy.md
@@ -37,12 +37,11 @@ proxies:
 ```
 
 Set HTTP_PROXY for docker daemon in `/etc/systemd/system/docker.service.d/http-proxy.conf`.
-`65002` is the default proxy port for dfdaemon. This can be configured with the
-`--proxyPort` cli parameter of dfdaemon.
+`65001` is the default proxy port for dfdaemon.
 
 ```
 [Service]
-Environment="HTTP_PROXY=http://127.0.0.1:65002"
+Environment="HTTP_PROXY=http://127.0.0.1:65001"
 ```
 
 Set your registry as insecure in `/etc/docker/daemon.json`
@@ -77,7 +76,7 @@ requests that match the proxy rules. This works for any program that
 respects the `HTTP_PROXY` environment variable.
 
 ```
-HTTP_PROXY=http://127.0.0.1:65002 curl http://github.com
+HTTP_PROXY=http://127.0.0.1:65001 curl http://github.com
 ```
 
 HTTPS requests and requests that are not matched, will be proxied directly,


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

- dfclient set InsecureSkipVerify for https proxy.
- update docs for deprecated 65002 port

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


