### PR TITLE
feature: enable uploader server ip and port to be specified

### DIFF
--- a/cmd/dfget/app/root.go
+++ b/cmd/dfget/app/root.go
@@ -236,7 +236,11 @@ func initFlags() {
 	flagSet.BoolVar(&cfg.Verbose, "verbose", false,
 		"be verbose")
 
-	// pass to server
+	// pass to peer server which as a uploader server
+	flagSet.StringVar(&cfg.RV.LocalIP, "ip", "",
+		"IP address that server will listen on")
+	flagSet.IntVar(&cfg.RV.PeerPort, "port", 0,
+		"port number that server will listen on")
 	flagSet.DurationVar(&cfg.RV.DataExpireTime, "expiretime", config.DataExpireTime,
 		"caching duration for which cached file keeps no accessed by any process, after this period cache file will be deleted")
 	flagSet.DurationVar(&cfg.RV.ServerAliveTime, "alivetime", config.ServerAliveTime,

--- a/dfget/core/core.go
+++ b/dfget/core/core.go
@@ -103,7 +103,9 @@ func prepare(cfg *config.Config) (err error) {
 	rv.DataDir = cfg.RV.SystemDataDir
 
 	cfg.Node = adjustSupernodeList(cfg.Node)
-	rv.LocalIP = checkConnectSupernode(cfg.Node)
+	if cutil.IsEmptyStr(rv.LocalIP) {
+		rv.LocalIP = checkConnectSupernode(cfg.Node)
+	}
 	rv.Cid = getCid(rv.LocalIP, cfg.Sign)
 	rv.TaskFileName = getTaskFileName(rv.RealTarget, cfg.Sign)
 	rv.TaskURL = cutil.FilterURLParam(cfg.URL, cfg.Filter)

--- a/dfget/core/uploader/peer_server_executor.go
+++ b/dfget/core/uploader/peer_server_executor.go
@@ -75,6 +75,7 @@ func (pe *peerServerExecutor) StartPeerServerProcess(cfg *config.Config) (port i
 
 	cmd := exec.Command(os.Args[0], "server",
 		"--ip", cfg.RV.LocalIP,
+		"--port", strconv.Itoa(cfg.RV.PeerPort),
 		"--meta", cfg.RV.MetaPath,
 		"--data", cfg.RV.SystemDataDir,
 		"--expiretime", cfg.RV.DataExpireTime.String(),


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

At present, we can specify the uploader server port with command `dfget server --port`. However, you have to run `dfget server` to start a uploader server before using `dfget` to download. If you don't want to do that, and this PR will help you.

In the meantime, you can't specify the IP address of the uploader server as a peer and `dfget` will use the IP address which can success to connect to `supernode`  automatically before this PR. In fact, the address that can be connected to a supernode is not necessarily the address that can be accessed by other peer nodes.

And now, you can use command as follows to specify the ip and port of uploader server when you want to download a file with `dfget`:
`dfget -u  https://www.taobao.com --ip 192.168.33.21 --port 55555`.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
None.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

Don't merge it until 0.4.1 release has been published.
