### PR TITLE
bugfix: initProperties after trans the param

### DIFF
--- a/cmd/dfget/app/root.go
+++ b/cmd/dfget/app/root.go
@@ -76,13 +76,14 @@ func runDfget() error {
 		return err
 	}
 
-	// get config from property files
-	initProperties()
-
 	if err := transParams(); err != nil {
 		util.Printer.Println(err.Error())
 		return err
 	}
+
+	// get config from property files
+	initProperties()
+
 	if err := handleNodes(); err != nil {
 		util.Printer.Println(err.Error())
 		return err

--- a/dfget/core/core.go
+++ b/dfget/core/core.go
@@ -262,6 +262,10 @@ func checkConnectSupernode(nodes []string) (localIP string) {
 
 func calculateTimeout(fileLength int64, defaultTimeoutSecond int, minRate int) time.Duration {
 	timeout := 5 * 60
+	// avoid trigger panic when minRate equals zero
+	if minRate <= 0 {
+		minRate = config.DefaultMinRate
+	}
 
 	if defaultTimeoutSecond > 0 {
 		timeout = defaultTimeoutSecond


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

NOTE: The `rate-related-params` below means the  params `localLimit`, `minRate`,`totalLimit` and so on.

At present, we can configure `rate-related-params`  by cmd or config files. And we should try to trans the param value firstly which from cmd. If not, try to imagine a scene.

If you not specify the `rate-related-params` values , and then they will get the default values when init config. Immediately after that, we will try to parse the `rate-related-params` values specified by cmd. And then you will use the empty value to override the default value.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


