### PR TITLE
bugfix: set GO111MODULE to on when use docker build

### DIFF
--- a/cmd/supernode/app/root.go
+++ b/cmd/supernode/app/root.go
@@ -16,7 +16,6 @@
 
 package app
 
-import "C"
 import (
 	"fmt"
 	"os"

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -18,10 +18,6 @@ USE_DOCKER=${USE_DOCKER:-"0"}
 
 create-dirs() {
     cd "${BUILD_SOURCE_HOME}" || return
-    if [ "${GOOS}" == "darwin" ] && [ "1" == "${USE_DOCKER}" ]
-    then
-        BUILD_PATH=bin
-    fi
     mkdir -p .go/src/${PKG} .go/bin .cache
     mkdir -p "${BUILD_PATH}"
 }
@@ -58,11 +54,13 @@ build-docker() {
         -v "$(pwd)"/.cache:/.cache                                        \
         -e GOOS="${GOOS}"                                                 \
         -e GOARCH="${GOARCH}"                                             \
-        -e CGO_ENABLED=1                                                  \
+        -e CGO_ENABLED=0                                                  \
+        -e GO111MODULE=on                                                 \
+        -e GOPROXY=https://goproxy.io                                     \
         -w /go/src/${PKG}                                                 \
         ${BUILD_IMAGE}                                                    \
-        go install -v -pkgdir /go/pkg -ldflags "${LDFLAGS}" ./cmd/"$2"
-    echo "BUILD: dfget in ${BUILD_SOURCE_HOME}/${BUILD_PATH}/$1"
+        go build -o "/go/bin/$1" -ldflags "${LDFLAGS}" ./cmd/"$2" 
+    echo "BUILD: $1 in ${BUILD_SOURCE_HOME}/${BUILD_PATH}/$1"
 }
 
 build-dfdaemon-docker(){


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
We have updated the go version to 1.12.6 and use go mod to manage the dependency. So we should set the `GO111MODULE` env to `on` when building with docker. Otherwise we would get errors like this：

```
apis/types/df_get_task.go:11:2: cannot find package "github.com/go-openapi/errors" in any of:
	/usr/local/go/src/github.com/go-openapi/errors (from $GOROOT)
	/go/src/github.com/go-openapi/errors (from $GOPATH)
apis/types/df_get_task.go:12:2: cannot find package "github.com/go-openapi/strfmt" in any of:
	/usr/local/go/src/github.com/go-openapi/strfmt (from $GOROOT)
	/go/src/github.com/go-openapi/strfmt (from $GOPATH)
apis/types/df_get_task.go:13:2: cannot find package "github.com/go-openapi/swag" in any of:
	/usr/local/go/src/github.com/go-openapi/swag (from $GOROOT)
	/go/src/github.com/go-openapi/swag (from $GOPATH)
......
```

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

None.
### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
None.


### Ⅳ. Describe how to verify it
Use command `docker build USE_DOCKER=1` and it can be executed successfully

### Ⅴ. Special notes for reviews


