### PR TITLE
bugfix: modify two supernode api's bug

### DIFF
--- a/common/constants/dfget_super_code.go
+++ b/common/constants/dfget_super_code.go
@@ -72,6 +72,8 @@ const (
 	CodeNeedAuth        = 608
 	CodeWaitAuth        = 609
 	CodeSourceError     = 610
+	CodeGetPieceReport  = 611
+	CodeGetPeerDown     = 612
 )
 
 /* the code of task result that dfget will report to supernode */

--- a/dfget/core/api/supernode_api_test.go
+++ b/dfget/core/api/supernode_api_test.go
@@ -100,9 +100,12 @@ func (s *SupernodeAPITestSuite) TestSupernodeAPI_PullPieceTask(c *check.C) {
 
 func (s *SupernodeAPITestSuite) TestSupernodeAPI_ReportPiece(c *check.C) {
 	ip := "127.0.0.1"
-
+	req := &types.ReportPieceRequest{
+		TaskID:     "sssss",
+		PieceRange: "0-11",
+	}
 	s.mock.GetFunc = s.mock.CreateGetFunc(200, []byte(`{"Code":700}`), nil)
-	r, e := s.api.ReportPiece(ip, nil)
+	r, e := s.api.ReportPiece(ip, req)
 	c.Check(e, check.IsNil)
 	c.Check(r.Code, check.Equals, 700)
 }

--- a/supernode/server/0.3_bridge.go
+++ b/supernode/server/0.3_bridge.go
@@ -200,8 +200,9 @@ func (s *Server) reportPiece(ctx context.Context, rw http.ResponseWriter, req *h
 		return err
 	}
 
-	rw.WriteHeader(http.StatusOK)
-	return nil
+	return EncodeResponse(rw, http.StatusOK, &types.ResultInfo{
+		Code: constants.CodeGetPieceReport,
+	})
 }
 
 func (s *Server) reportServiceDown(ctx context.Context, rw http.ResponseWriter, req *http.Request) (err error) {
@@ -230,6 +231,7 @@ func (s *Server) reportServiceDown(ctx context.Context, rw http.ResponseWriter, 
 		return err
 	}
 
-	rw.WriteHeader(http.StatusOK)
-	return nil
+	return EncodeResponse(rw, http.StatusOK, &types.ResultInfo{
+		Code: constants.CodeGetPeerDown,
+	})
 }


### PR DESCRIPTION
Signed-off-by: yunfeiyangbuaa <yunfeiyang@buaa.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

- First bug:when supernode send  response to dfget's reportpiece and servicedown request,it will return a nil response.So when the dfget do with the response with `json.Unmarshal(body, resp)` ,it will produce an `err unexpected end of JSON input` err.I add a status code info to the supernode's response to resolve these bugs and do with the err and status code
- Second bug:when dfget send pulltask request to supernode.if the supernode is off,the dfget will crash instead of find another supernode to finish its work.because the pulltask will retuen a `{}` instead of `nil`,the coder use `nil` to check the res,so it will happen `a invalid memory address or nil pointer dereference ` err .i make the return be nil when the supernode is off

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #680

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it
you can add a fmt.println() to the previous code's api return err,it will report an err.and my code won't

### Ⅴ. Special notes for reviews


