### PR TITLE
Add support for arm32

### DIFF
--- a/common/util/stat_linux_arm.go
+++ b/common/util/stat_linux_arm.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package util
+
+import (
+	"syscall"
+	"time"
+)
+
+// Atime returns the last access time in time.Time.
+func Atime(stat *syscall.Stat_t) time.Time {
+	return time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec))
+}
+
+// AtimeSec returns the last access time in seconds.
+func AtimeSec(stat *syscall.Stat_t) int64 {
+	return int64(stat.Atim.Sec)
+}
+
+// Ctime returns the create time in time.Time.
+func Ctime(stat *syscall.Stat_t) time.Time {
+	return time.Unix(int64(stat.Ctim.Sec), int64(stat.Ctim.Nsec))
+}
+
+// CtimeSec returns the create time in seconds.
+func CtimeSec(stat *syscall.Stat_t) int64 {
+	return int64(stat.Ctim.Sec)
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Add support for arm32. Recently, we can not build binary for arm32 unless we implement function `Atime`, `Ctime`, `AtimeSec` and `CtimeSec` for arm32.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
No test needed because I only add support for a special architecture.


### Ⅳ. Describe how to verify it
```shell
for i in dfdaemon dfget supernode; do
  cd cmd/$i
  GOOS=linux GOARCH=arm GOARM=7 go build
  cd ../..
done
```
### Ⅴ. Special notes for reviews


