### PR TITLE
feature: return supernode ip according to the value specified by peer

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -859,6 +859,10 @@ definitions:
         description: |
           PeerID is used to uniquely identifies a peer which will be used to create a dfgetTask.
           The value must be the value in the response after registering a peer.
+      supernodeIP:
+        type: "string"
+        description: "IP address of supernode which the peer connects to"
+        
 
   TaskCreateResponse:
     type: "object"
@@ -1162,6 +1166,9 @@ definitions:
           PeerID uniquely identifies a peer, and the cID uniquely identifies a 
           download task belonging to a peer. One peer can initiate multiple download tasks, 
           which means that one peer corresponds to multiple cIDs.
+      supernodeIP:
+        type: "string"
+        description: "IP address of supernode which the peer connects to"
  
   ErrorResponse:
     type: "object"

--- a/apis/types/df_get_task.go
+++ b/apis/types/df_get_task.go
@@ -50,6 +50,9 @@ type DfGetTask struct {
 	// Enum: [WAITING RUNNING FAILED SUCCESS]
 	Status string `json:"status,omitempty"`
 
+	// IP address of supernode which the peer connects to
+	SupernodeIP string `json:"supernodeIP,omitempty"`
+
 	// task Id
 	TaskID string `json:"taskId,omitempty"`
 }

--- a/apis/types/task_create_request.go
+++ b/apis/types/task_create_request.go
@@ -83,6 +83,9 @@ type TaskCreateRequest struct {
 	//
 	RawURL string `json:"rawURL,omitempty"`
 
+	// IP address of supernode which the peer connects to
+	SupernodeIP string `json:"supernodeIP,omitempty"`
+
 	// taskURL is generated from rawURL. rawURL may contains some queries or parameter, dfget will filter some queries via
 	// --filter parameter of dfget. The usage of it is that different rawURL may generate the same taskID.
 	//

--- a/supernode/daemon/mgr/task/manager_util.go
+++ b/supernode/daemon/mgr/task/manager_util.go
@@ -154,12 +154,13 @@ func (tm *Manager) updateTask(taskID string, updateTaskInfo *types.TaskInfo) err
 
 func (tm *Manager) addDfgetTask(ctx context.Context, req *types.TaskCreateRequest, task *types.TaskInfo) (*types.DfGetTask, error) {
 	dfgetTask := &types.DfGetTask{
-		CID:       req.CID,
-		Path:      req.Path,
-		PieceSize: task.PieceSize,
-		Status:    types.DfGetTaskStatusWAITING,
-		TaskID:    task.ID,
-		PeerID:    req.PeerID,
+		CID:         req.CID,
+		Path:        req.Path,
+		PieceSize:   task.PieceSize,
+		Status:      types.DfGetTaskStatusWAITING,
+		TaskID:      task.ID,
+		PeerID:      req.PeerID,
+		SupernodeIP: req.SupernodeIP,
 	}
 
 	if err := tm.dfgetTaskMgr.Add(ctx, dfgetTask); err != nil {
@@ -299,6 +300,11 @@ func (tm *Manager) parseAvailablePeers(ctx context.Context, clientID string, tas
 		pieceInfo, err := tm.pieceResultToPieceInfo(ctx, v, task.PieceSize)
 		if err != nil {
 			return false, nil, err
+		}
+
+		// get supernode IP according to the cid dynamically
+		if tm.cfg.IsSuperPID(pieceInfo.PID) {
+			pieceInfo.PeerIP = dfgetTask.SupernodeIP
 		}
 
 		pieceInfos = append(pieceInfos, pieceInfo)

--- a/supernode/server/0.3_bridge.go
+++ b/supernode/server/0.3_bridge.go
@@ -76,15 +76,16 @@ func (s *Server) registry(ctx context.Context, rw http.ResponseWriter, req *http
 
 	peerID := peerCreateResponse.ID
 	taskCreateRequest := &types.TaskCreateRequest{
-		CID:        request.CID,
-		Dfdaemon:   request.Dfdaemon,
-		Headers:    cutil.ConvertHeaders(request.Headers),
-		Identifier: request.Identifier,
-		Md5:        request.Md5,
-		Path:       request.Path,
-		PeerID:     peerID,
-		RawURL:     request.RawURL,
-		TaskURL:    request.TaskURL,
+		CID:         request.CID,
+		Dfdaemon:    request.Dfdaemon,
+		Headers:     cutil.ConvertHeaders(request.Headers),
+		Identifier:  request.Identifier,
+		Md5:         request.Md5,
+		Path:        request.Path,
+		PeerID:      peerID,
+		RawURL:      request.RawURL,
+		TaskURL:     request.TaskURL,
+		SupernodeIP: request.SuperNodeIP.String(),
 	}
 	resp, err := s.TaskMgr.Register(ctx, taskCreateRequest)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
We must specify the supernode IP which can be connected by the peer node when we use dfget to download a file. However, the different peers have different network environments. And they will use different addresses to connect to the same supernode.  And for now, supernode will always return the IP address that will not change according to the peer node. That's not reasonable. 

So this PR will store the supernode IP which carried by dfget. When a peer download something from supernode, and the supernode will return the IP address that it specifies.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
None.


### Ⅳ. Describe how to verify it
```
# build & install Dragonfly
make build && make install

# start supernode
supernode 

# start nginx server
https://github.com/dragonflyoss/Dragonfly/blob/master/docs/user_guide/install_server_go.md#procedure---when-deploying-with-physical-machines

# use dfget to download a file 
dfget -u https://www.taobao.com --node 127.0.0.1
```

And then checkout the dfclient log (`~/.small-dragonfly/logs/dfclient.log`) to validate the result

```
2019-07-22 07:19:45.639 INFO sign:6251-1563779985.294 : start to download piece from 127.0.0.1:8001 with taskID(9627226867cf6d8496944de44f554b8d0d2e743c991da21ad3e05336f01e5ba9)
```

### Ⅴ. Special notes for reviews


