### PR TITLE
Init peer server from environment variables

### DIFF
--- a/cmd/dfget/app/server.go
+++ b/cmd/dfget/app/server.go
@@ -18,6 +18,7 @@ package app
 
 import (
 	"fmt"
+	"os"
 	"path"
 
 	"github.com/dragonflyoss/Dragonfly/common/dflog"
@@ -63,8 +64,16 @@ func initServerFlags() {
 		"be verbose")
 }
 
+func initCfgFromEnvs() {
+	if ip := os.Getenv(config.EnvPeerServerIP); len(ip) > 0 {
+		cfg.RV.LocalIP = ip
+	}
+}
+
 func runServer() error {
 	initServerLog()
+	initCfgFromEnvs()
+
 	// launch a peer server as a uploader server
 	port, err := uploader.LaunchPeerServer(cfg)
 	if err != nil {

--- a/dfget/config/constants.go
+++ b/dfget/config/constants.go
@@ -53,6 +53,11 @@ const (
 	DefaultClientQueueSize = 6
 )
 
+/* environment variables */
+const (
+	EnvPeerServerIP = "LOCAL_IP"
+)
+
 /* http headers */
 const (
 	StrRange         = "Range"

--- a/dfget/core/uploader/uploader.go
+++ b/dfget/core/uploader/uploader.go
@@ -68,7 +68,7 @@ func LaunchPeerServer(cfg *config.Config) (int, error) {
 	var p2pPtr unsafe.Pointer
 
 	logrus.Infof("********************")
-	logrus.Infof("start peer server...")
+	logrus.Infof("start peer server on %s:%d ...", cfg.RV.LocalIP, cfg.RV.PeerPort)
 
 	res := make(chan error)
 	go func() {

--- a/docs/cli_reference/dfget_server.md
+++ b/docs/cli_reference/dfget_server.md
@@ -24,6 +24,12 @@ dfget server [flags]
       --verbose               be verbose
 ```
 
+### Environments
+
+In addition to the command line arguments, peer server will also take configs from environment variables. Following environment variables are used:
+
+* **LOCAL_IP** IP address that server will listen on, it will override value provided by command argument `ip`.
+
 ### SEE ALSO
 
 * [dfget](dfget.md)	 - client of Dragonfly used to download and upload files


### PR DESCRIPTION
Signed-off-by: cd1989 <chende@caicloud.io>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Support init peer servers from environment variables, for example `host IP`.

This is necessary when deploy dfclient (with peer servers) in k8s as DaemonSet. In this case, we can't set ip via command args statically.

But we can use `Downward API` to inject host IP to pod containers as environment variables:

```
        env:
          - name: LOCAL_IP
            valueFrom:
              fieldRef:
                fieldPath: status.hostIP
```

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


