### PR TITLE
fix typo "caculate" -> "calculate"

### DIFF
--- a/supernode/daemon/mgr/task/manager_util.go
+++ b/supernode/daemon/mgr/task/manager_util.go
@@ -69,7 +69,7 @@ func (tm *Manager) addOrUpdateTask(ctx context.Context, req *types.TaskCreateReq
 		task.Headers = req.Headers
 	}
 
-	// caculate piece size and update the PieceSize and PieceTotal
+	// calculate piece size and update the PieceSize and PieceTotal
 	pieceSize := computePieceSize(fileLength)
 	task.PieceSize = pieceSize
 	task.PieceTotal = int32((fileLength + (int64(pieceSize) - 1)) / int64(pieceSize))


### PR DESCRIPTION
fix typo "caculate" -> "calculate"

Signed-off-by: alan <zg.zhu@daocloud.io>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
fix typo "caculate" -> "calculate"

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE


