### PR TITLE
bugfix: use access time to determine whether the file is expired

### DIFF
--- a/dfget/core/downloader/p2p_downloader/p2p_downloader.go
+++ b/dfget/core/downloader/p2p_downloader/p2p_downloader.go
@@ -226,11 +226,11 @@ func (p2p *P2PDownloader) pullPieceTask(item *Piece) (
 
 	for {
 		if res, err = p2p.API.PullPieceTask(item.SuperNode, req); err != nil {
-			logrus.Errorf("pull piece task error: %v", err)
+			logrus.Errorf("pull piece task(%+v) error: %v", item, err)
 		} else if res.Code == constants.CodePeerWait {
 			sleepTime := time.Duration(rand.Intn(1400)+600) * time.Millisecond
-			logrus.Infof("pull piece task result:%s and sleep %.3fs",
-				res, sleepTime.Seconds())
+			logrus.Infof("pull piece task(%+v) result:%s and sleep %.3fs",
+				item, res, sleepTime.Seconds())
 			time.Sleep(sleepTime)
 			continue
 		}

--- a/dfget/core/uploader/peer_server_test.go
+++ b/dfget/core/uploader/peer_server_test.go
@@ -339,9 +339,10 @@ func (s *PeerServerTestSuite) TestDeleteExpiredFile(c *check.C) {
 	}
 	var t = func(f bool) *taskConfig {
 		return &taskConfig{
-			taskID:   fmt.Sprintf("%d", rand.Int63()),
-			finished: f,
-			dataDir:  cfg.RV.SystemDataDir,
+			taskID:     fmt.Sprintf("%d", rand.Int63()),
+			finished:   f,
+			dataDir:    cfg.RV.SystemDataDir,
+			accessTime: time.Now(),
 		}
 	}
 

--- a/dfget/core/uploader/uploader_test.go
+++ b/dfget/core/uploader/uploader_test.go
@@ -220,7 +220,6 @@ func (s *UploaderTestSuite) TestServerGC(c *check.C) {
 		v := &cases[i]
 		expire := time.Duration(v.expire) * time.Minute
 		v.name = createTestFile(p2p, v.store, v.finished, expire)
-
 	}
 
 	time.AfterFunc(500*time.Millisecond, func() {
@@ -276,7 +275,10 @@ func createTestFile(srv *peerServer, store bool, finished bool, expire time.Dura
 	os.Chtimes(taskFile, expireTime, expireTime)
 
 	if store {
-		srv.syncTaskMap.Store(name, &taskConfig{finished: finished})
+		srv.syncTaskMap.Store(name, &taskConfig{
+			finished:   finished,
+			accessTime: expireTime,
+		})
 	}
 	return name
 }

--- a/supernode/daemon/mgr/task/manager_util.go
+++ b/supernode/daemon/mgr/task/manager_util.go
@@ -192,7 +192,7 @@ func (tm *Manager) triggerCdnSyncAction(ctx context.Context, task *types.TaskInf
 	go func() {
 		updateTaskInfo, err := tm.cdnMgr.TriggerCDN(ctx, task)
 		if err != nil {
-			logrus.Errorf("trigger cdn get error: %v", err)
+			logrus.Errorf("taskID(%s) trigger cdn get error: %v", task.ID, err)
 		}
 		tm.updateTask(task.ID, updateTaskInfo)
 		logrus.Infof("success to update task cdn %+v", updateTaskInfo)


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Now we use file.ModTime() to determine whether the file is expired. However, we just read the file when we upload pieces to other files. And the `modTime` has not changed. So the file will be marked expired and will be deleted after expire time even though it is providing the server for the other peers.

So I added a `accessTime` field which should be updated when doing anything with the file.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
None.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


