### PR TITLE
fix: markdown-link-check ignore twitter.com

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,10 @@ jobs:
           name: use markdown-link-check(https://github.com/tcort/markdown-link-check) to check links in markdown files
           command: |
             set +e
+            curl -OfsSL https://raw.githubusercontent.com/dragonflyoss/dragonfly-scripts/master/config/markdown-link-check-scripts.json
             for name in $(find . -name \*.md | grep -v CHANGELOG); do
               if [ -f $name ]; then
-                markdown-link-check -q $name;
+                markdown-link-check -q -v -c ./markdown-link-check-scripts.json $name;
                 if [ $? -ne 0 ]; then
                   code=1
                 fi


### PR DESCRIPTION
Signed-off-by: lowzj <zj3142063@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?

```bash
FILE: README.md
[✖] https://twitter.com/dragonfly_oss → Status: 0 Error: Exceeded maxRedirects. Probably stuck in a redirect loop https://twitter.com/dragonfly_oss

ERROR: dead links found!
```
The failure is caused by some reason that we don't known(maybe a bug of `markdown-link-check`), but we can confirm that this link is ok and can be accessed successfully. So we ignore checking the urls of `twitter.com`.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


