### PR TITLE
bugfix: fix overflow for rate limit

### DIFF
--- a/common/util/assert.go
+++ b/common/util/assert.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Max returns the larger of x or y.
-func Max(x, y int32) int32 {
+func Max(x, y int64) int64 {
 	if x > y {
 		return x
 	}
@@ -34,7 +34,7 @@ func Max(x, y int32) int32 {
 }
 
 // Min returns the smaller of x or y.
-func Min(x, y int32) int32 {
+func Min(x, y int64) int64 {
 	if x < y {
 		return x
 	}

--- a/common/util/assert_test.go
+++ b/common/util/assert_test.go
@@ -34,16 +34,16 @@ func init() {
 
 func (suite *AssertSuite) TestMax(c *check.C) {
 	c.Assert(Max(1, 2), check.Not(check.Equals), 2)
-	c.Assert(Max(1, 2), check.Equals, int32(2))
-	c.Assert(Max(1, 1), check.Equals, int32(1))
-	c.Assert(Max(3, 2), check.Equals, int32(3))
+	c.Assert(Max(1, 2), check.Equals, int64(2))
+	c.Assert(Max(1, 1), check.Equals, int64(1))
+	c.Assert(Max(3, 2), check.Equals, int64(3))
 }
 
 func (suite *AssertSuite) TestMin(c *check.C) {
 	c.Assert(Min(1, 2), check.Not(check.Equals), 1)
-	c.Assert(Min(1, 2), check.Equals, int32(1))
-	c.Assert(Min(1, 1), check.Equals, int32(1))
-	c.Assert(Min(3, 2), check.Equals, int32(2))
+	c.Assert(Min(1, 2), check.Equals, int64(1))
+	c.Assert(Min(1, 1), check.Equals, int64(1))
+	c.Assert(Min(3, 2), check.Equals, int64(2))
 }
 
 func (suite *AssertSuite) TestIsEmptyStr(c *check.C) {

--- a/common/util/limit_reader.go
+++ b/common/util/limit_reader.go
@@ -83,7 +83,7 @@ func (lr *LimitReader) Read(p []byte) (n int, err error) {
 		if lr.md5sum != nil {
 			lr.md5sum.Write(p[:n])
 		}
-		lr.Limiter.AcquireBlocking(int32(n))
+		lr.Limiter.AcquireBlocking(int64(n))
 	}
 	return n, e
 }

--- a/common/util/rate_limiter.go
+++ b/common/util/rate_limiter.go
@@ -23,10 +23,10 @@ import (
 
 // RateLimiter is used for limiting the rate of transporting.
 type RateLimiter struct {
-	capacity      int32
-	bucket        int32
-	rate          int32
-	ratePerWindow int32
+	capacity      int64
+	bucket        int64
+	rate          int64
+	ratePerWindow int64
 	window        int64
 	last          int64
 
@@ -37,7 +37,7 @@ type RateLimiter struct {
 // rate: how many tokens are generated per second. 0 represents that don't limit the rate.
 // window: generating tokens interval (millisecond, [1,1000]).
 // The production of rate and window should be division by 1000.
-func NewRateLimiter(rate int32, window int64) *RateLimiter {
+func NewRateLimiter(rate int64, window int64) *RateLimiter {
 	rl := new(RateLimiter)
 	rl.capacity = rate
 	rl.bucket = 0
@@ -50,18 +50,18 @@ func NewRateLimiter(rate int32, window int64) *RateLimiter {
 
 // AcquireBlocking acquires tokens. It will be blocking unit the bucket has enough required
 // number of tokens.
-func (rl *RateLimiter) AcquireBlocking(token int32) int32 {
+func (rl *RateLimiter) AcquireBlocking(token int64) int64 {
 	return rl.acquire(token, true)
 }
 
 // AcquireNonBlocking acquires tokens. It will return -1 immediately when there is no enough
 // number of tokens.
-func (rl *RateLimiter) AcquireNonBlocking(token int32) int32 {
+func (rl *RateLimiter) AcquireNonBlocking(token int64) int64 {
 	return rl.acquire(token, false)
 }
 
 // SetRate sets rate of RateLimiter.
-func (rl *RateLimiter) SetRate(rate int32) {
+func (rl *RateLimiter) SetRate(rate int64) {
 	if rl.rate != rate {
 		rl.capacity = rate
 		rl.rate = rate
@@ -69,14 +69,14 @@ func (rl *RateLimiter) SetRate(rate int32) {
 	}
 }
 
-func (rl *RateLimiter) acquire(token int32, blocking bool) int32 {
+func (rl *RateLimiter) acquire(token int64, blocking bool) int64 {
 	if rl.capacity <= 0 || token < 1 {
 		return token
 	}
 	tmpCapacity := Max(rl.capacity, token)
 
-	var process func() int32
-	process = func() int32 {
+	var process func() int64
+	process = func() int64 {
 		now := time.Now().UnixNano()
 
 		newTokens := rl.createTokens(now)
@@ -113,7 +113,7 @@ func (rl *RateLimiter) computeRatePerWindow() {
 	if rl.rate <= 0 {
 		return
 	}
-	ratePerWindow := int32(int64(rl.rate) * int64(rl.window) / 1000)
+	ratePerWindow := int64(rl.rate) * int64(rl.window) / 1000
 	if ratePerWindow > 0 {
 		rl.ratePerWindow = ratePerWindow
 		return
@@ -122,15 +122,15 @@ func (rl *RateLimiter) computeRatePerWindow() {
 	rl.setWindow(int64(rl.ratePerWindow * 1000 / rl.rate))
 }
 
-func (rl *RateLimiter) createTokens(timeNano int64) int32 {
+func (rl *RateLimiter) createTokens(timeNano int64) int64 {
 	diff := timeNano - rl.last
 	if diff < time.Millisecond.Nanoseconds() {
 		return 0
 	}
-	return int32(diff/(rl.window*time.Millisecond.Nanoseconds())) * rl.ratePerWindow
+	return diff / (rl.window * time.Millisecond.Nanoseconds()) * rl.ratePerWindow
 }
 
-func (rl *RateLimiter) blocking(requiredToken int32) {
+func (rl *RateLimiter) blocking(requiredToken int64) {
 	if requiredToken <= 0 {
 		return
 	}
@@ -140,10 +140,10 @@ func (rl *RateLimiter) blocking(requiredToken int32) {
 
 // TransRate trans the rate to multiples of 1000
 // For NewRateLimiter, the production of rate should be division by 1000.
-func TransRate(rate int) int32 {
+func TransRate(rate int) int64 {
 	if rate <= 0 {
 		rate = 10 * 1024 * 1024
 	}
 	rate = (rate/1000 + 1) * 1000
-	return int32(rate)
+	return int64(rate)
 }

--- a/common/util/rate_limiter_test.go
+++ b/common/util/rate_limiter_test.go
@@ -30,7 +30,7 @@ func init() {
 
 func (suite *RateLimiterSuite) TestNewRateLimiter(c *check.C) {
 	var cases = []struct {
-		r int32
+		r int64
 		w int64
 		e *RateLimiter
 	}{
@@ -44,7 +44,7 @@ func (suite *RateLimiterSuite) TestNewRateLimiter(c *check.C) {
 	for _, cc := range cases {
 		rl := NewRateLimiter(cc.r, cc.w)
 		c.Assert(rl.capacity, check.Equals, cc.e.rate)
-		c.Assert(rl.bucket, check.Equals, int32(0))
+		c.Assert(rl.bucket, check.Equals, int64(0))
 		c.Assert(rl.rate, check.Equals, cc.e.rate)
 		c.Assert(rl.window, check.Equals, cc.e.window)
 		c.Assert(rl.ratePerWindow, check.Equals, cc.e.ratePerWindow)
@@ -53,9 +53,9 @@ func (suite *RateLimiterSuite) TestNewRateLimiter(c *check.C) {
 
 func (suite *RateLimiterSuite) TestRateLimiter_SetRate(c *check.C) {
 	var cases = []struct {
-		r  int32
+		r  int64
 		w  int64
-		nr int32
+		nr int64
 		e  *RateLimiter
 	}{
 		{0, 1, 500, &RateLimiter{rate: 500, window: 2, ratePerWindow: 1}},
@@ -78,9 +78,9 @@ func (suite *RateLimiterSuite) TestRateLimiter_SetRate(c *check.C) {
 
 func (suite *RateLimiterSuite) TestRateLimiter_AcquireBlocking(c *check.C) {
 	var cases = []struct {
-		r     int32
+		r     int64
 		w     int64
-		t     int32
+		t     int64
 		count int
 		e     int64
 	}{
@@ -106,7 +106,7 @@ func (suite *RateLimiterSuite) TestRateLimiter_AcquireBlocking(c *check.C) {
 
 func (suite *RateLimiterSuite) TestRateLimiter_AcquireNonBlocking(c *check.C) {
 	rl := NewRateLimiter(1000, 1)
-	c.Assert(rl.AcquireNonBlocking(1000), check.Equals, int32(-1))
+	c.Assert(rl.AcquireNonBlocking(1000), check.Equals, int64(-1))
 	rl.blocking(1000)
-	c.Assert(rl.AcquireNonBlocking(1000), check.Equals, int32(1000))
+	c.Assert(rl.AcquireNonBlocking(1000), check.Equals, int64(1000))
 }

--- a/dfget/core/downloader/p2p_downloader/p2p_downloader.go
+++ b/dfget/core/downloader/p2p_downloader/p2p_downloader.go
@@ -134,7 +134,7 @@ func (p2p *P2PDownloader) init() {
 
 	p2p.pieceSet = make(map[string]bool)
 
-	p2p.rateLimiter = cutil.NewRateLimiter(int32(p2p.cfg.LocalLimit), 2)
+	p2p.rateLimiter = cutil.NewRateLimiter(int64(p2p.cfg.LocalLimit), 2)
 	p2p.pullRateTime = time.Now().Add(-3 * time.Second)
 }
 

--- a/dfget/core/downloader/p2p_downloader/power_client_test.go
+++ b/dfget/core/downloader/p2p_downloader/power_client_test.go
@@ -162,7 +162,7 @@ func (s *PowerClientTestSuite) reset() {
 	s.powerClient = &PowerClient{
 		cfg:         &config.Config{RV: config.RuntimeVariable{Cid: ""}},
 		node:        "127.0.0.1",
-		rateLimiter: util.NewRateLimiter(int32(5), 2),
+		rateLimiter: util.NewRateLimiter(int64(5), 2),
 		downloadAPI: NewMockDownloadAPI(),
 		pieceTask: &types.PullPieceTaskResponseContinueData{
 			PieceMd5: "",

--- a/dfget/core/uploader/peer_server.go
+++ b/dfget/core/uploader/peer_server.go
@@ -209,7 +209,7 @@ func (ps *peerServer) checkHandler(w http.ResponseWriter, r *http.Request) {
 	totalLimit, err := strconv.Atoi(r.Header.Get(config.StrTotalLimit))
 	if err == nil && totalLimit > 0 {
 		if ps.rateLimiter == nil {
-			ps.rateLimiter = util.NewRateLimiter(int32(totalLimit), 2)
+			ps.rateLimiter = util.NewRateLimiter(int64(totalLimit), 2)
 		} else {
 			ps.rateLimiter.SetRate(util.TransRate(totalLimit))
 		}

--- a/dfget/core/uploader/uploader_helper_test.go
+++ b/dfget/core/uploader/uploader_helper_test.go
@@ -57,7 +57,7 @@ func newTestPeerServer(workHome string) (srv *peerServer) {
 	cfg := helper.CreateConfig(nil, workHome)
 	srv = newPeerServer(cfg, 0)
 	srv.totalLimitRate = 1000
-	srv.rateLimiter = util.NewRateLimiter(int32(defaultRateLimit), 2)
+	srv.rateLimiter = util.NewRateLimiter(int64(defaultRateLimit), 2)
 	return srv
 }
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
fix the overflow for rate limit
when use the function `createTokens` it may return negative number because of the overflow
The problem code is here `diff/(rl.window*time.Millisecond.Nanoseconds()) * rl.ratePerWindow`.
When `createTokens` return negative number it may cause sleep and it will make p2p download failed.
use int64 instead of int32 can solve this problem

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


