### PR TITLE
fix typo 'deisgn' -> 'design'

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,7 @@ Develop Guide helps (potential) developers/contributors to understand the thoery
 
 ### Design Doc
 
-[Design Doc](./design) is content all about deisgn of Dragonfly. It includes all things taken into consideration at the very beginning, the architecture designed for all components in Dragonfly, the interactive workflow between components, all APIs in Dragonfly and some technical things else.
+[Design Doc](./design) is content all about design of Dragonfly. It includes all things taken into consideration at the very beginning, the architecture designed for all components in Dragonfly, the interactive workflow between components, all APIs in Dragonfly and some technical things else.
 
 ### Test Guide
 


### PR DESCRIPTION
fix typo 'deisgn' -> 'design'

Signed-off-by: alan <zg.zhu@daocloud.io>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
fix typo 'deisgn' -> 'design'

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

