### PR TITLE
feature: support non-ipv4 format node address for Dragonfly dfclient

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -298,7 +298,7 @@ Name                           | Flag                      | Remark
 ------------------------------ | ------------------------- | ----------
 dfdaemon proxy server port     | dfdaemon --port           | The port should   be in the range of 2000-65535.
 dfget uploader server port     | dfget server --port       | You can use command `dfget server` to start a uploader server before using dfget to download if you don't want to use a random port.
-supernode register port        | supernode --port          | You can use `dfget --node IP:port` to register with the specified supernode register port.
+supernode register port        | supernode --port          | You can use `dfget --node host:port` to register with the specified supernode register port.
 supernode cdn file server port | supernode --download-port | You should prepare a file server firstly and listen on the port that flag `download-port` will use.
 
 **NOTE**: The supernode maintains both Java and Golang versions currently. And the above table is for the Golang version. And you will get a guide [here](https://d7y.io/en-us/docs/userguide/supernode_configuration.html) for Java version.

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -642,8 +642,7 @@ definitions:
         format: "ipv4"
       superNodeIp:
          type: "string"
-         description: "IP address of supernode that the client can connect to"
-         format: "ipv4"
+         description: "The address of supernode that the client can connect to"
       hostName:
         type: "string"
         description: "host name of peer client node."

--- a/apis/types/task_register_request.go
+++ b/apis/types/task_register_request.go
@@ -86,9 +86,8 @@ type TaskRegisterRequest struct {
 	//
 	RawURL string `json:"rawURL,omitempty"`
 
-	// IP address of supernode that the client can connect to
-	// Format: ipv4
-	SuperNodeIP strfmt.IPv4 `json:"superNodeIp,omitempty"`
+	// The address of supernode that the client can connect to
+	SuperNodeIP string `json:"superNodeIp,omitempty"`
 
 	// taskURL is generated from rawURL. rawURL may contains some queries or parameter, dfget will filter some queries via
 	// --filter parameter of dfget. The usage of it is that different rawURL may generate the same taskID.
@@ -116,10 +115,6 @@ func (m *TaskRegisterRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validatePort(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateSuperNodeIP(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -179,19 +174,6 @@ func (m *TaskRegisterRequest) validatePort(formats strfmt.Registry) error {
 	}
 
 	if err := validate.MaximumInt("port", "body", int64(m.Port), 65000, false); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *TaskRegisterRequest) validateSuperNodeIP(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.SuperNodeIP) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("superNodeIp", "body", "ipv4", m.SuperNodeIP.String(), formats); err != nil {
 		return err
 	}
 

--- a/cmd/dfdaemon/app/root.go
+++ b/cmd/dfdaemon/app/root.go
@@ -96,7 +96,7 @@ func init() {
 	rf.String("ratelimit", util.NetLimit(), "net speed limit,format:xxxM/K")
 	rf.String("urlfilter", "Signature&Expires&OSSAccessKeyId", "filter specified url fields")
 	rf.Bool("notbs", true, "not try back source to download if throw exception")
-	rf.StringSlice("node", nil, "specify the addresses(IP:port) of supernodes that will be passed to dfget.")
+	rf.StringSlice("node", nil, "specify the addresses(host:port) of supernodes that will be passed to dfget.")
 
 	exitOnError(bindRootFlags(viper.GetViper()), "bind root command flags")
 }

--- a/cmd/dfget/app/root.go
+++ b/cmd/dfget/app/root.go
@@ -224,7 +224,7 @@ func initFlags() {
 	flagSet.StringSliceVar(&cfg.Header, "header", nil,
 		"http header, eg: --header='Accept: *' --header='Host: abc'")
 	flagSet.StringSliceVarP(&cfg.Node, "node", "n", nil,
-		"specify the addresses(IP:port) of supernodes")
+		"specify the addresses(host:port) of supernodes")
 	flagSet.BoolVar(&cfg.Notbs, "notbs", false,
 		"disable back source downloading for requested file when p2p fails to download it")
 	flagSet.BoolVar(&cfg.DFDaemon, "dfdaemon", false,

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -87,7 +87,7 @@ main() {
     if [[ "1" == "${USE_DOCKER}" ]]
     then
         echo "Begin to build with docker."
-        case "$1" in
+        case "${1-}" in
             dfdaemon)
                 build-dfdaemon-docker
             ;;

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -15,7 +15,7 @@ cd "${curDir}" || return
 . ./env.sh
 
 install() {
-    case "$1" in
+    case "${1-}" in
         dfclient)
             install-client
         ;;
@@ -53,7 +53,7 @@ install-supernode(){
 
 
 uninstall() {
-    case "$1" in
+    case "${1-}" in
         dfclient)
             uninstall-client
         ;;
@@ -101,12 +101,12 @@ createDir() {
 }
 
 main() {
-    case "$1" in
+    case "${1-}" in
         install)
-            install "$2"
+            install "${2-}"
         ;;
         uninstall)
-            uninstall "$2"
+            uninstall "${2-}"
         ;;
         *)
             echo "You must specify the subcommand 'install' or 'uninstall'."

--- a/hack/package.sh
+++ b/hack/package.sh
@@ -33,7 +33,7 @@ main() {
         FPM="fpm"
     fi
 
-    case "$1" in
+    case "${1-}" in
         rpm )
             build_rpm
             ;;

--- a/supernode/server/0.3_bridge.go
+++ b/supernode/server/0.3_bridge.go
@@ -86,7 +86,7 @@ func (s *Server) registry(ctx context.Context, rw http.ResponseWriter, req *http
 		PeerID:      peerID,
 		RawURL:      request.RawURL,
 		TaskURL:     request.TaskURL,
-		SupernodeIP: request.SuperNodeIP.String(),
+		SupernodeIP: request.SuperNodeIP,
 	}
 	resp, err := s.TaskMgr.Register(ctx, taskCreateRequest)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Make it work normally when specifies non-ipv4 format node address for dfclient.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

#679
### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
None.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

BTW. update the shell scripts.
