### PR TITLE
bugfix: the dfget will wait forever when the final piece failed

### DIFF
--- a/dfget/core/downloader/p2p_downloader/p2p_downloader.go
+++ b/dfget/core/downloader/p2p_downloader/p2p_downloader.go
@@ -178,6 +178,8 @@ func (p2p *P2PDownloader) Run() error {
 			} else if code == constants.CodePeerFinish {
 				p2p.finishTask(response, clientWriter)
 				return nil
+			} else if code == constants.CodePeerWait {
+				continue
 			}
 
 			logrus.Warnf("request piece result:%v", response)
@@ -233,6 +235,9 @@ func (p2p *P2PDownloader) pullPieceTask(item *Piece) (
 		if res.Code != constants.CodePeerWait {
 			break
 		}
+		if p2p.queue.Len() > 0 {
+			break
+		}
 		sleepTime := time.Duration(rand.Intn(1400)+600) * time.Millisecond
 		logrus.Infof("pull piece task(%+v) result:%s and sleep %.3fs", item, res, sleepTime.Seconds())
 		time.Sleep(sleepTime)
@@ -242,7 +247,8 @@ func (p2p *P2PDownloader) pullPieceTask(item *Piece) (
 	if res != nil && !(res.Code != constants.CodePeerContinue &&
 		res.Code != constants.CodePeerFinish &&
 		res.Code != constants.CodePeerLimited &&
-		res.Code != constants.Success) {
+		res.Code != constants.Success &&
+		res.Code != constants.CodePeerWait) {
 		return res, err
 	}
 


### PR DESCRIPTION
Signed-off-by: wybzju <552044481@qq.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
the case is:
1 the dfget pull piece task from supernode(for example, the total piece is two, pieceA, pieceB)
2 the dfget get two pieces and start to run download tasks
3 pieceB download successfully and put it into queue. pieceA is running 
4 so the function p2p.getItem can get one Item. Then try to pull task again
5 because the supernode have sent all pieces to dfget， dfget will receive waiting code, then sleep a moment and try to pull task again.
6 the pieceA download failed, and put it into queue, but it will never be dealt. And the step5 will run forever until timeout.

so if dfget receive the code waiting, it should judge the length of the queue. If the length is large than 0, it should break the cycle. Then the failed piece in the queue can be dealt.
### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


