### PR TITLE
bugfix: the dfget will always receive fail result when change supernode

### DIFF
--- a/supernode/server/0.3_bridge.go
+++ b/supernode/server/0.3_bridge.go
@@ -121,9 +121,11 @@ func (s *Server) pullPieceTask(ctx context.Context, rw http.ResponseWriter, req 
 	if !cutil.IsEmptyStr(dstCID) {
 		dstDfgetTask, err := s.DfgetTaskMgr.Get(ctx, dstCID, taskID)
 		if err != nil {
-			return err
+			logrus.Warnf("failed to get dfget task by dstCID(%s) and taskID(%s), and the srcCID is %s, err: %v",
+				dstCID, taskID, srcCID, err)
+		} else {
+			request.DstPID = dstDfgetTask.PeerID
 		}
-		request.DstPID = dstDfgetTask.PeerID
 	}
 
 	isFinished, data, err := s.TaskMgr.GetPieces(ctx, taskID, srcCID, request)


### PR DESCRIPTION
Signed-off-by: wybzju <552044481@qq.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
1 there have two supernode A and B
2 dfget registers to A and download some piece from A
3 suddenly, the A down
4 dfget will get error when pull piece task from A, then dfget register to node B
5 it will pull piece task again, but the item has dstCID. However, B doesn't have the task, and can't get dfgettask by dstCID and taskID. Then B will return err. Finally, dfget will receive error again

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


