### PR TITLE
feature: add golbal dfget params to the dfdaemon config

### DIFF
--- a/cmd/dfdaemon/app/root.go
+++ b/cmd/dfdaemon/app/root.go
@@ -91,11 +91,8 @@ func init() {
 
 	// dfget download config
 	rf.String("localrepo", filepath.Join(os.Getenv("HOME"), ".small-dragonfly/dfdaemon/data/"), "temp output dir of dfdaemon")
-	rf.String("callsystem", "com_ops_dragonfly", "caller name")
 	rf.String("dfpath", defaultDfgetPath, "dfget path")
 	rf.String("ratelimit", netutils.NetLimit(), "net speed limit,format:xxxM/K")
-	rf.String("urlfilter", "Signature&Expires&OSSAccessKeyId", "filter specified url fields")
-	rf.Bool("notbs", true, "not try back source to download if throw exception")
 	rf.StringSlice("node", nil, "specify the addresses(host:port) of supernodes that will be passed to dfget.")
 
 	exitOnError(bindRootFlags(viper.GetViper()), "bind root command flags")

--- a/dfdaemon/config/config_test.go
+++ b/dfdaemon/config/config_test.go
@@ -266,19 +266,6 @@ func (ts *configTestSuite) TestProxyMatch() {
 
 }
 
-func (ts *configTestSuite) TestDFGetConfig() {
-	r := ts.Require()
-	cfg := defaultConfig()
-	dfgetCfg := cfg.DFGetConfig()
-	r.Equal(cfg.SuperNodes, dfgetCfg.SuperNodes)
-	r.Equal(cfg.DFRepo, dfgetCfg.DFRepo)
-	r.Equal(cfg.DFPath, dfgetCfg.DFPath)
-	r.Equal(cfg.RateLimit, dfgetCfg.RateLimit)
-	r.Equal(cfg.URLFilter, dfgetCfg.URLFilter)
-	r.Equal(cfg.CallSystem, dfgetCfg.CallSystem)
-	r.Equal(cfg.Notbs, dfgetCfg.Notbs)
-}
-
 func (ts *configTestSuite) TestMirrorTLSConfig() {
 	r := ts.Require()
 

--- a/dfdaemon/downloader/dfget/dfget.go
+++ b/dfdaemon/downloader/dfget/dfget.go
@@ -64,27 +64,16 @@ func (dfGetter *DFGetter) getCommand(
 	url string, header map[string][]string, output string,
 ) (cmd *exec.Cmd) {
 	args := []string{
-		"--dfdaemon",
 		"-u", url,
 		"-o", output,
 	}
-
-	if dfGetter.config.Notbs {
-		args = append(args, "--notbs")
-	}
-
-	if dfGetter.config.Verbose {
-		args = append(args, "--verbose")
-	}
+	args = append(args, dfGetter.config.DfgetFlags...)
 
 	add := func(key, value string) {
 		if v := strings.TrimSpace(value); v != "" {
 			args = append(args, key, v)
 		}
 	}
-
-	add("--callsystem", dfGetter.config.CallSystem)
-	add("-f", dfGetter.config.URLFilter)
 	add("-s", dfGetter.config.RateLimit)
 	add("--totallimit", dfGetter.config.RateLimit)
 	add("--node", strings.Join(dfGetter.config.SuperNodes, ","))


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes part of #687

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

TODO.

### Ⅳ. Describe how to verify it
```
cat /etc/dragonfly/dfdaemon.yml
# node is the supernode address
# ip should be the ip address that the other nodes in the p2p network can access.
# port is the port that peer server will listen on
global_dfget_params: ["--node","192.168.33.21","--verbose","--ip","192.168.33.22","--port","15001","--alivetime","0s","--expiretime","5m0s"]
......
```

### Ⅴ. Special notes for reviews

In my opition,  I think it's not a good way to use CLI args to pass values to the dfget compared to the config file. So I have not added a flag for dfget params. @lowzj @yeya24 WDYT?

In this PR, I only add a `globalDfgetParams` through the dfdaemon config file firstly. And we can add a `dfgetParam` for every proxy later.

 In addition, there is one more thing we need to pay attention to: how should we verify the correctness of the dfget params? Do you have any good ideas? 