### PR TITLE
improve config print output in logs

### DIFF
--- a/cmd/dfget/app/root_test.go
+++ b/cmd/dfget/app/root_test.go
@@ -45,7 +45,6 @@ func (suit *dfgetSuit) Test_initFlagsNoArguments() {
 	suit.Equal(cfg.TotalLimit, 0)
 	suit.Equal(cfg.Notbs, false)
 	suit.Equal(cfg.DFDaemon, false)
-	suit.Equal(cfg.Version, false)
 	suit.Equal(cfg.ShowBar, false)
 	suit.Equal(cfg.Console, false)
 	suit.Equal(cfg.Verbose, false)

--- a/dfget/config/config.go
+++ b/dfget/config/config.go
@@ -185,9 +185,6 @@ type Config struct {
 	// DFDaemon indicates whether the caller is from dfdaemon
 	DFDaemon bool `json:"dfdaemon,omitempty"`
 
-	// Version show version.
-	Version bool `json:"version,omitempty"`
-
 	// ShowBar show progress bar, it's conflict with `--console`.
 	ShowBar bool `json:"showBar,omitempty"`
 
@@ -236,7 +233,36 @@ type Config struct {
 }
 
 func (cfg *Config) String() string {
-	js, _ := json.Marshal(cfg)
+	var baseConfig = struct {
+		URL             string    `json:"url"`
+		Output          string    `json:"output"`
+		LocalLimit      int       `json:"localLimit,omitempty"`
+		MinRate         int       `json:"minRate,omitempty"`
+		TotalLimit      int       `json:"totalLimit,omitempty"`
+		Timeout         int       `json:"timeout,omitempty"`
+		Md5             string    `json:"md5,omitempty"`
+		Identifier      string    `json:"identifier,omitempty"`
+		CallSystem      string    `json:"callSystem,omitempty"`
+		Pattern         string    `json:"pattern,omitempty"`
+		Filter          []string  `json:"filter,omitempty"`
+		Node            []string  `json:"node,omitempty"`
+		Notbs           bool      `json:"notbs,omitempty"`
+		DFDaemon        bool      `json:"dfdaemon,omitempty"`
+		ClientQueueSize int       `json:"clientQueueSize,omitempty"`
+		StartTime       time.Time `json:"startTime"`
+		Sign            string    `json:"sign"`
+		User            string    `json:"user"`
+		WorkHome        string    `json:"workHome"`
+		ConfigFiles     []string  `json:"configFile"`
+	}{
+		cfg.URL, cfg.Output, cfg.LocalLimit, cfg.MinRate,
+		cfg.TotalLimit, cfg.Timeout, cfg.Md5, cfg.Identifier,
+		cfg.CallSystem, cfg.Pattern, cfg.Filter, cfg.Node,
+		cfg.Notbs, cfg.DFDaemon, cfg.ClientQueueSize,
+		cfg.StartTime, cfg.Sign, cfg.User, cfg.WorkHome,
+		cfg.ConfigFiles,
+	}
+	js, _ := json.Marshal(baseConfig)
 	return string(js)
 }
 

--- a/dfget/config/config_test.go
+++ b/dfget/config/config_test.go
@@ -58,9 +58,8 @@ func (suite *ConfigSuite) TestConfig_String(c *check.C) {
 	c.Assert(strings.Contains(cfg.String(), expected), check.Equals, true)
 	cfg.LocalLimit = 20971520
 	cfg.Pattern = "p2p"
-	cfg.Version = true
 	expected = "\"url\":\"\",\"output\":\"\",\"localLimit\":20971520," +
-		"\"pattern\":\"p2p\",\"version\":true"
+		"\"pattern\":\"p2p\""
 	c.Assert(strings.Contains(cfg.String(), expected), check.Equals, true)
 }
 


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
From https://github.com/dragonflyoss/Dragonfly/pull/774#discussion_r310101729, remove some useless fields when printing dfget config.

Removed fields:
``` bash
Header
ShowBar
Console
Verbose
Help
```

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it
tail -f dfclient.log

### Ⅴ. Special notes for reviews


