### PR TITLE
feature: not return error directly when failed to get http file Length

### DIFF
--- a/supernode/daemon/mgr/task/manager_util.go
+++ b/supernode/daemon/mgr/task/manager_util.go
@@ -84,11 +84,15 @@ func (tm *Manager) addOrUpdateTask(ctx context.Context, req *types.TaskCreateReq
 	// get fileLength with req.Headers
 	fileLength, err := getHTTPFileLength(taskID, task.RawURL, req.Headers)
 	if err != nil {
+		logrus.Errorf("failed to get file length from http client for taskID(%s): %v", taskID, err)
+
 		if errortypes.IsURLNotReachable(err) {
 			tm.taskURLUnReachableStore.Add(taskID, time.Now())
+			return nil, err
 		}
-		logrus.Errorf("failed to get file length from http client for taskID(%s): %v", taskID, err)
-		return nil, err
+		if errortypes.IsAuthenticationRequired(err) {
+			return nil, err
+		}
 	}
 	task.HTTPFileLength = fileLength
 	logrus.Infof("get file length %d from http client for taskID(%s)", fileLength, taskID)


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

When supernode failed to get file length from source which is slow to be accessed due to `context deadline exceeded`, we should not return error directly and tell the client failed to register the task.  Instead, we should make it success unless something goes wrong with 404, 401,407, etc.
 
### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

None.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


