### PR TITLE
feature: replace gometalinter with golangci-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,11 @@
 # Check https://circleci.com/docs/2.0/language-go/ for more details
 version: 2
 jobs:
-  markdownlint-misspell-shellcheck:
+  linters-check:
     docker:
       # this image is build from Dockerfile
       # https://github.com/pouchcontainer/pouchlinter/blob/master/Dockerfile
-      - image: pouchcontainer/pouchlinter:v0.2.2
+      - image: pouchcontainer/pouchlinter:v0.2.3
     working_directory: /go/src/github.com/dragonflyoss/Dragonfly
     steps:
       - checkout
@@ -32,7 +32,6 @@ jobs:
       - run:
           name: use opensource tool client9/misspell to correct commonly misspelled English words
           command: |
-            go get -u github.com/client9/misspell/cmd/misspell
             find  ./* -name  "*" | xargs misspell -error
       - run:
           name: use ShellCheck (https://github.com/koalaman/shellcheck) to check the validateness of shell scripts in pouch repo
@@ -42,16 +41,6 @@ jobs:
           name: validate go mod files
           command: |
             make check-go-mod
-
-  gocode-check-via-golangci-lint-swagger:
-    docker:
-      - image: pouchcontainer/pouchlinter:v0.2.2
-        environment:
-          GO111MODULE: "on"
-          GOPROXY: "https://goproxy.io"
-    working_directory: /go/src/github.com/dragonflyoss/Dragonfly
-    steps:
-      - checkout
       - run:
           name: validate swagger.yml
           command: |
@@ -59,7 +48,7 @@ jobs:
       - run:
           name: use golangci-lint to check gocode of this project.
           command: |
-            golangci-lint run
+            make golangci-lint
 
   unit-test-golang:
     docker:
@@ -99,7 +88,6 @@ workflows:
   version: 2
   ci:
     jobs:
-      - markdownlint-misspell-shellcheck
+      - linters-check
       - unit-test-golang
-      - gocode-check-via-golangci-lint-swagger
       - api-integration-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     docker:
       # this image is build from Dockerfile
       # https://github.com/pouchcontainer/pouchlinter/blob/master/Dockerfile
-      - image: pouchcontainer/pouchlinter:v0.2.1
+      - image: pouchcontainer/pouchlinter:v0.2.2
     working_directory: /go/src/github.com/dragonflyoss/Dragonfly
     steps:
       - checkout
@@ -32,6 +32,7 @@ jobs:
       - run:
           name: use opensource tool client9/misspell to correct commonly misspelled English words
           command: |
+            go get -u github.com/client9/misspell/cmd/misspell
             find  ./* -name  "*" | xargs misspell -error
       - run:
           name: use ShellCheck (https://github.com/koalaman/shellcheck) to check the validateness of shell scripts in pouch repo
@@ -42,9 +43,12 @@ jobs:
           command: |
             make check-go-mod
 
-  gocode-check-via-gometalinter-swagger:
+  gocode-check-via-golangci-lint-swagger:
     docker:
-      - image: pouchcontainer/pouchlinter:v0.2.1
+      - image: pouchcontainer/pouchlinter:v0.2.2
+        environment:
+          GO111MODULE: "on"
+          GOPROXY: "https://goproxy.io"
     working_directory: /go/src/github.com/dragonflyoss/Dragonfly
     steps:
       - checkout
@@ -53,15 +57,9 @@ jobs:
           command: |
             swagger validate "/go/src/github.com/dragonflyoss/Dragonfly/apis/swagger.yml"
       - run:
-          name: use gometalinter to check gocode of this project.
+          name: use golangci-lint to check gocode of this project.
           command: |
-            make go-mod-vendor
-            gometalinter --disable-all --cyclo-over=20 --skip vendor -E gofmt -E goimports -E golint -E misspell -E vet -E goconst -E gocyclo ./...
-      - run:
-          name: detect deadcode without test folder
-          command: |
-            make go-mod-vendor
-            gometalinter --disable-all --skip vendor --skip test -E deadcode ./...
+            golangci-lint run
 
   unit-test-golang:
     docker:
@@ -103,5 +101,5 @@ workflows:
     jobs:
       - markdownlint-misspell-shellcheck
       - unit-test-golang
-      - gocode-check-via-gometalinter-swagger
+      - gocode-check-via-golangci-lint-swagger
       - api-integration-test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,9 +5,6 @@ run:
 linters-settings:
   gocyclo:
     min-complexity: 20
-  goconst:
-    min-len: 3
-    min-occurrences: 5
 
 linters:
   disable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,28 @@
+run:
+  deadline: 3m
+  modules-download-mode: readonly
+
+linters-settings:
+  gocyclo:
+    min-complexity: 20
+  goconst:
+    min-len: 3
+    min-occurrences: 5
+
+linters:
+  disable-all: true
+  enable:
+    - gofmt
+    - goimports
+    - golint
+    - misspell
+    - govet
+    - goconst
+    - deadcode
+    - gocyclo
+
+# output configuration options
+output:
+  format: colored-line-number
+  print-issued-lines: true
+  print-linter-name: true

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,6 @@ go-mod-tidy:
 	@go mod tidy
 .PHONY: go-mod-tidy
 
-# we need this because currently gometalinter can't work in go mod environment.
 go-mod-vendor:
 	@echo "Begin to vendor go mod dependency"
 	@go mod vendor

--- a/Makefile
+++ b/Makefile
@@ -153,3 +153,7 @@ df.crt: df.key
 	openssl req -new -key df.key -out df.csr
 	openssl x509 -req -sha256 -days 365 -in df.csr -signkey df.key -out df.crt
 	rm df.csr
+
+golangci-lint:
+	./hack/golangci-lint.sh
+.PHONY: golangci-lint

--- a/dfget/core/api/supernode_api.go
+++ b/dfget/core/api/supernode_api.go
@@ -113,7 +113,7 @@ func (api *supernodeAPI) ReportPiece(node string, req *types.ReportPieceRequest)
 		logrus.Errorf("failed to report piece{taskid:%s,range:%s},err: %v", req.TaskID, req.PieceRange, e)
 		return nil, e
 	}
-	if resp != nil && resp.Code != constants.CodeGetPieceReport {
+	if resp.Code != constants.CodeGetPieceReport {
 		logrus.Errorf("failed to report piece{taskid:%s,range:%s} to supernode: api response code is %d not equal to %d", req.TaskID, req.PieceRange, resp.Code, constants.CodeGetPieceReport)
 	}
 	return
@@ -131,7 +131,7 @@ func (api *supernodeAPI) ServiceDown(node string, taskID string, cid string) (
 		logrus.Errorf("failed to send service down,err: %v", e)
 		return nil, e
 	}
-	if resp != nil && resp.Code != constants.CodeGetPeerDown {
+	if resp.Code != constants.CodeGetPeerDown {
 		logrus.Errorf("failed to send service down to supernode: api response code is %d not equal to %d", resp.Code, constants.CodeGetPeerDown)
 	}
 	return

--- a/dfget/core/api/supernode_api_test.go
+++ b/dfget/core/api/supernode_api_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/go-check/check"
 )
 
+const localhost = "127.0.0.1"
+
 func Test(t *testing.T) {
 	check.TestingT(t)
 }
@@ -55,43 +57,39 @@ func init() {
 // unit tests for SupernodeAPI
 
 func (s *SupernodeAPITestSuite) TestSupernodeAPI_Register(c *check.C) {
-	ip := "127.0.0.1"
-
 	s.mock.PostJSONFunc = s.mock.CreatePostJSONFunc(0, nil, nil)
-	r, e := s.api.Register(ip, createRegisterRequest())
+	r, e := s.api.Register(localhost, createRegisterRequest())
 	c.Assert(r, check.IsNil)
 	c.Assert(e.Error(), check.Equals, "0:")
 
 	s.mock.PostJSONFunc = s.mock.CreatePostJSONFunc(0, nil,
 		fmt.Errorf("test"))
-	r, e = s.api.Register(ip, createRegisterRequest())
+	r, e = s.api.Register(localhost, createRegisterRequest())
 	c.Assert(r, check.IsNil)
 	c.Assert(e.Error(), check.Equals, "test")
 
 	res := types.RegisterResponse{BaseResponse: &types.BaseResponse{}}
 	s.mock.PostJSONFunc = s.mock.CreatePostJSONFunc(200, []byte(res.String()), nil)
-	r, e = s.api.Register(ip, createRegisterRequest())
+	r, e = s.api.Register(localhost, createRegisterRequest())
 	c.Assert(r, check.NotNil)
 	c.Assert(r.Code, check.Equals, 0)
 
 	res.Code = constants.Success
 	res.Data = &types.RegisterResponseData{FileLength: int64(32)}
 	s.mock.PostJSONFunc = s.mock.CreatePostJSONFunc(200, []byte(res.String()), nil)
-	r, e = s.api.Register(ip, createRegisterRequest())
+	r, e = s.api.Register(localhost, createRegisterRequest())
 	c.Assert(r, check.NotNil)
 	c.Assert(r.Code, check.Equals, constants.Success)
 	c.Assert(r.Data.FileLength, check.Equals, res.Data.FileLength)
 }
 
 func (s *SupernodeAPITestSuite) TestSupernodeAPI_PullPieceTask(c *check.C) {
-	ip := "127.0.0.1"
-
 	res := &types.PullPieceTaskResponse{BaseResponse: &types.BaseResponse{}}
 	res.Code = constants.CodePeerFinish
 	res.Data = []byte(`{"fileLength":2}`)
 	s.mock.GetFunc = s.mock.CreateGetFunc(200, []byte(res.String()), nil)
 
-	r, e := s.api.PullPieceTask(ip, nil)
+	r, e := s.api.PullPieceTask(localhost, nil)
 
 	c.Assert(e, check.IsNil)
 	c.Assert(r.Code, check.Equals, res.Code)
@@ -99,31 +97,26 @@ func (s *SupernodeAPITestSuite) TestSupernodeAPI_PullPieceTask(c *check.C) {
 }
 
 func (s *SupernodeAPITestSuite) TestSupernodeAPI_ReportPiece(c *check.C) {
-	ip := "127.0.0.1"
 	req := &types.ReportPieceRequest{
 		TaskID:     "sssss",
 		PieceRange: "0-11",
 	}
 	s.mock.GetFunc = s.mock.CreateGetFunc(200, []byte(`{"Code":700}`), nil)
-	r, e := s.api.ReportPiece(ip, req)
+	r, e := s.api.ReportPiece(localhost, req)
 	c.Check(e, check.IsNil)
 	c.Check(r.Code, check.Equals, 700)
 }
 
 func (s *SupernodeAPITestSuite) TestSupernodeAPI_ServiceDown(c *check.C) {
-	ip := "127.0.0.1"
-
 	s.mock.GetFunc = s.mock.CreateGetFunc(200, []byte(`{"Code":200}`), nil)
-	r, e := s.api.ServiceDown(ip, "", "")
+	r, e := s.api.ServiceDown(localhost, "", "")
 	c.Check(e, check.IsNil)
 	c.Check(r.Code, check.Equals, 200)
 }
 
 func (s *SupernodeAPITestSuite) TestSupernodeAPI_ReportClientError(c *check.C) {
-	ip := "127.0.0.1"
-
 	s.mock.GetFunc = s.mock.CreateGetFunc(200, []byte(`{"Code":700}`), nil)
-	r, e := s.api.ReportClientError(ip, nil)
+	r, e := s.api.ReportClientError(localhost, nil)
 	c.Check(e, check.IsNil)
 	c.Check(r.Code, check.Equals, 700)
 }

--- a/dfget/core/downloader/p2p_downloader/p2p_downloader.go
+++ b/dfget/core/downloader/p2p_downloader/p2p_downloader.go
@@ -31,7 +31,6 @@ import (
 	"github.com/dragonflyoss/Dragonfly/dfget/core/regist"
 	"github.com/dragonflyoss/Dragonfly/dfget/types"
 	"github.com/dragonflyoss/Dragonfly/pkg/constants"
-	"github.com/dragonflyoss/Dragonfly/pkg/errortypes"
 	"github.com/dragonflyoss/Dragonfly/pkg/fileutils"
 	"github.com/dragonflyoss/Dragonfly/pkg/httputils"
 	"github.com/dragonflyoss/Dragonfly/pkg/printer"
@@ -258,8 +257,8 @@ func (p2p *P2PDownloader) pullPieceTask(item *Piece) (
 
 	logrus.Errorf("pull piece task fail:%v and will migrate", res)
 	var registerRes *regist.RegisterResult
-	var registerErr *errortypes.DfError
-	if registerRes, registerErr = p2p.Register.Register(p2p.cfg.RV.PeerPort); registerErr != nil {
+	registerRes, registerErr := p2p.Register.Register(p2p.cfg.RV.PeerPort)
+	if registerErr != nil {
 		return nil, registerErr
 	}
 	p2p.pieceSizeHistory[1] = registerRes.PieceSize

--- a/dfget/core/downloader/p2p_downloader/p2p_downloader.go
+++ b/dfget/core/downloader/p2p_downloader/p2p_downloader.go
@@ -31,6 +31,7 @@ import (
 	"github.com/dragonflyoss/Dragonfly/dfget/core/regist"
 	"github.com/dragonflyoss/Dragonfly/dfget/types"
 	"github.com/dragonflyoss/Dragonfly/pkg/constants"
+	"github.com/dragonflyoss/Dragonfly/pkg/errortypes"
 	"github.com/dragonflyoss/Dragonfly/pkg/fileutils"
 	"github.com/dragonflyoss/Dragonfly/pkg/httputils"
 	"github.com/dragonflyoss/Dragonfly/pkg/printer"
@@ -257,8 +258,9 @@ func (p2p *P2PDownloader) pullPieceTask(item *Piece) (
 
 	logrus.Errorf("pull piece task fail:%v and will migrate", res)
 	var registerRes *regist.RegisterResult
-	if registerRes, err = p2p.Register.Register(p2p.cfg.RV.PeerPort); err != nil {
-		return nil, err
+	var registerErr *errortypes.DfError
+	if registerRes, registerErr = p2p.Register.Register(p2p.cfg.RV.PeerPort); registerErr != nil {
+		return nil, registerErr
 	}
 	p2p.pieceSizeHistory[1] = registerRes.PieceSize
 	item.Status = constants.TaskStatusStart

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -63,7 +63,7 @@ build-docker() {
         -e GOARCH="${GOARCH}"                                             \
         -e CGO_ENABLED=0                                                  \
         -e GO111MODULE=on                                                 \
-        -e GOPROXY=https://goproxy.io                                     \
+        -e GOPROXY="${GOPROXY}"                                           \
         -w /go/src/${PKG}                                                 \
         ${BUILD_IMAGE}                                                    \
         go build -o "/go/bin/$1" -ldflags "${LDFLAGS}" ./cmd/"$2" 

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# golangci-lint binary version v1.17.1
+
+PKG=github.com/dragonflyoss/Dragonfly
+LINT_IMAGE=pouchcontainer/pouchlinter:v0.2.3
+USE_DOCKER=${USE_DOCKER:-"0"}
+
+curDir=$(cd "$(dirname "$0")" && pwd)
+cd "${curDir}" || return
+LINT_SOURCE_HOME=$(cd ".." && pwd)
+
+. ./env.sh
+
+golangci-lint-docker() {
+    cd "${LINT_SOURCE_HOME}" || return
+    docker run                                                            \
+        --rm                                                              \
+        -ti                                                               \
+        -v "$(pwd)"/.go/pkg:/go/pkg                                       \
+        -v "$(pwd)":/go/src/${PKG}                                        \
+        -e GO111MODULE=on                                                 \
+        -e GOPROXY="${GOPROXY}"                                           \
+        -w /go/src/${PKG}                                                 \
+        ${LINT_IMAGE}                                                     \
+        golangci-lint run
+}
+
+check-golangci-lint() {
+  has_installed="$(command -v golangci-lint || echo false)"
+  if [[ "${has_installed}" = "false" ]]; then
+    echo false
+    return
+  fi
+  echo true
+}
+
+golangci-lint-local() {
+    has_installed="$(check-golangci-lint)"
+    if [[ "${has_installed}" = "true" ]]; then
+        echo "Detected that golangci-lint has already been installed. Start linting..."
+        cd "${LINT_SOURCE_HOME}" || return
+        golangci-lint run
+        return
+    else
+        echo "Detected that golangci-lint has not been installed. You have to install golangci-lint first."
+        return 1
+    fi
+}
+
+main() {
+    if [[ "1" == "${USE_DOCKER}" ]]
+    then
+        echo "Begin to check gocode with golangci-lint in docker."
+        golangci-lint-docker
+    else
+        echo "Begin to check gocode with golangci-lint locally"
+        golangci-lint-local
+    fi
+    echo "Check gocode with golangci-lint successfully "
+}
+
+main "$@"


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Since gometaliner is deprecated, we need to migrate golangci-lint.
Ref: https://github.com/alecthomas/gometalinter

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


