### PR TITLE
feature: add supernode piece downloaded size metrics

### DIFF
--- a/docs/user_guide/metrics.md
+++ b/docs/user_guide/metrics.md
@@ -21,6 +21,7 @@ This doc contains all the metrics that Dragonfly components currently support. N
 - dragonfly_supernode_cdn_cache_hit_total{} - total times of hitting cdn cache. counter type.
 - dragonfly_supernode_cdn_download_total{} - total times of cdn downloading. counter type.
 - dragonfly_supernode_cdn_download_failed_total{} - total failure times of cdn downloading. counter type.
+- dragonfly_supernode_pieces_downloaded_size_bytes{} - total size of pieces downloaded from supernode in bytes. counter type.
 
 ## Dfdaemon
 

--- a/supernode/server/0.3_bridge.go
+++ b/supernode/server/0.3_bridge.go
@@ -209,6 +209,11 @@ func (s *Server) reportPiece(ctx context.Context, rw http.ResponseWriter, req *h
 		return err
 	}
 
+	// If piece is downloaded from supernode, add metrics.
+	if s.Config.IsSuperCID(dstCID) {
+		m.pieceDownloadedBytes.WithLabelValues().Add(float64(sutil.CalculatePieceSize(pieceRange)))
+	}
+
 	request := &types.PieceUpdateRequest{
 		ClientID:    srcCID,
 		DstPID:      dstDfgetTask.PeerID,

--- a/supernode/server/metrics.go
+++ b/supernode/server/metrics.go
@@ -28,10 +28,11 @@ import (
 
 // metrics defines some prometheus metrics for monitoring supernode
 type metrics struct {
-	requestCounter  *prometheus.CounterVec
-	requestDuration *prometheus.HistogramVec
-	requestSize     *prometheus.HistogramVec
-	responseSize    *prometheus.HistogramVec
+	requestCounter       *prometheus.CounterVec
+	requestDuration      *prometheus.HistogramVec
+	requestSize          *prometheus.HistogramVec
+	responseSize         *prometheus.HistogramVec
+	pieceDownloadedBytes *prometheus.CounterVec
 }
 
 func newMetrics(register prometheus.Registerer) *metrics {
@@ -50,6 +51,9 @@ func newMetrics(register prometheus.Registerer) *metrics {
 		responseSize: metricsutils.NewHistogram(config.SubsystemSupernode, "http_response_size_bytes",
 			"Histogram of response size for HTTP requests.", []string{"handler"},
 			prometheus.ExponentialBuckets(100, 10, 8), register,
+		),
+		pieceDownloadedBytes: metricsutils.NewCounter(config.SubsystemSupernode, "pieces_downloaded_size_bytes",
+			"total bytes of pieces downloaded from supernode", []string{}, register,
 		),
 	}
 }

--- a/supernode/util/range_util.go
+++ b/supernode/util/range_util.go
@@ -26,6 +26,30 @@ const (
 	separator = "-"
 )
 
+// CalculatePieceSize calculates the size of piece
+// according to the parameter range.
+func CalculatePieceSize(rangeStr string) int64 {
+	ranges := strings.Split(rangeStr, separator)
+	if len(ranges) != 2 {
+		return 0
+	}
+
+	startIndex, err := strconv.ParseInt(ranges[0], 10, 64)
+	if err != nil {
+		return 0
+	}
+	endIndex, err := strconv.ParseInt(ranges[1], 10, 64)
+	if err != nil {
+		return 0
+	}
+	if endIndex < startIndex {
+		return 0
+	}
+
+	pieceSize := endIndex - startIndex + 1
+	return pieceSize
+}
+
 // CalculatePieceNum calculates the number of piece
 // according to the parameter range.
 func CalculatePieceNum(rangeStr string) int {
@@ -47,7 +71,6 @@ func CalculatePieceNum(rangeStr string) int {
 	}
 
 	pieceSize := endIndex - startIndex + 1
-
 	return int(startIndex / pieceSize)
 }
 

--- a/supernode/util/range_util_test.go
+++ b/supernode/util/range_util_test.go
@@ -32,6 +32,47 @@ func init() {
 	check.Suite(&RangeUtilSuite{})
 }
 
+func (suite *RangeUtilSuite) TestCalculatePieceSize(c *check.C) {
+	var cases = []struct {
+		rangeStr string
+		expected int64
+	}{
+		{
+			rangeStr: "foo",
+			expected: 0,
+		},
+		{
+			rangeStr: "aaa-bbb",
+			expected: 0,
+		},
+		{
+			rangeStr: "3-2",
+			expected: 0,
+		},
+		{
+			rangeStr: "1 -3",
+			expected: 0,
+		},
+		{
+			rangeStr: "0-0",
+			expected: 1,
+		},
+		{
+			rangeStr: "6-8",
+			expected: 3,
+		},
+		{
+			rangeStr: "0-40000",
+			expected: 40001,
+		},
+	}
+
+	for _, v := range cases {
+		result := CalculatePieceSize(v.rangeStr)
+		c.Assert(result, check.Equals, v.expected)
+	}
+}
+
 func (suite *RangeUtilSuite) TestCalculatePieceNum(c *check.C) {
 	var cases = []struct {
 		rangeStr string


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Add a counter type metric to count total size of pieces downloaded from supernode by dfget.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


