### PR TITLE
cleanup some unused dfget config fields

### DIFF
--- a/cmd/dfget/app/root_test.go
+++ b/cmd/dfget/app/root_test.go
@@ -45,11 +45,9 @@ func (suit *dfgetSuit) Test_initFlagsNoArguments() {
 	suit.Equal(cfg.TotalLimit, 0)
 	suit.Equal(cfg.Notbs, false)
 	suit.Equal(cfg.DFDaemon, false)
-	suit.Equal(cfg.Version, false)
 	suit.Equal(cfg.ShowBar, false)
 	suit.Equal(cfg.Console, false)
 	suit.Equal(cfg.Verbose, false)
-	suit.Equal(cfg.Help, false)
 	suit.Equal(cfg.URL, "")
 }
 

--- a/dfget/config/config.go
+++ b/dfget/config/config.go
@@ -191,9 +191,6 @@ type Config struct {
 	// Insecure indicates whether skip secure verify when supernode interact with the source.
 	Insecure bool `json:"insecure,omitempty"`
 
-	// Version show version.
-	Version bool `json:"version,omitempty"`
-
 	// ShowBar show progress bar, it's conflict with `--console`.
 	ShowBar bool `json:"showBar,omitempty"`
 
@@ -203,9 +200,6 @@ type Config struct {
 	// Verbose indicates whether to be verbose.
 	// If set true, log level will be 'debug'.
 	Verbose bool `json:"verbose,omitempty"`
-
-	// Help show help information.
-	Help bool `json:"help,omitempty"`
 
 	// ClientQueueSize is the size of client queue
 	// which controls the number of pieces that can be processed simultaneously.

--- a/dfget/config/config_test.go
+++ b/dfget/config/config_test.go
@@ -58,9 +58,8 @@ func (suite *ConfigSuite) TestConfig_String(c *check.C) {
 	c.Assert(strings.Contains(cfg.String(), expected), check.Equals, true)
 	cfg.LocalLimit = 20971520
 	cfg.Pattern = "p2p"
-	cfg.Version = true
 	expected = "\"url\":\"\",\"output\":\"\",\"localLimit\":20971520," +
-		"\"pattern\":\"p2p\",\"version\":true"
+		"\"pattern\":\"p2p\""
 	c.Assert(strings.Contains(cfg.String(), expected), check.Equals, true)
 }
 


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Dfget config field `help` and `version` is unused now, so remove them.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


