### PR TITLE
bugfix: dfdaemon's config supernodes as an alias do not work.

### DIFF
--- a/cmd/dfdaemon/app/root.go
+++ b/cmd/dfdaemon/app/root.go
@@ -100,7 +100,6 @@ func init() {
 
 // bindRootFlags binds flags on rootCmd to the given viper instance
 func bindRootFlags(v *viper.Viper) error {
-	v.RegisterAlias("supernodes", "node")
 	if err := v.BindPFlags(rootCmd.Flags()); err != nil {
 		return err
 	}
@@ -121,6 +120,7 @@ func readConfigFile(v *viper.Viper, cmd *cobra.Command) error {
 		}
 		return err
 	}
+	v.RegisterAlias("supernodes", "node")
 
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: zhouchencheng <zhouchencheng@bilibili.com>


### Ⅰ. Describe what this PR did
I config `supernodes` in /etc/dragonfly/dfdaemon.yml , but it does not work.
```
supernodes: 
- "172.16.38.93:8002"
```
I use `node` instead of `supernodes` , and it works.

In fact, `RegisterAlias` after reading config from file may solve this problem?

### Ⅱ. Does this pull request fix one issue?
None


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


