### PR TITLE
gc bug fix

### DIFF
--- a/supernode/daemon/mgr/gc/gc_peer.go
+++ b/supernode/daemon/mgr/gc/gc_peer.go
@@ -19,6 +19,7 @@ package gc
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/dragonflyoss/Dragonfly/pkg/timeutils"
 	"github.com/dragonflyoss/Dragonfly/supernode/util"
@@ -40,8 +41,16 @@ func (gcm *Manager) gcPeers(ctx context.Context) {
 			continue
 		}
 
+		if peerState.ServiceDownTime == 0 {
+			cIDs, _ := gcm.dfgetTaskMgr.GetCIDAndTaskIDsByPeerID(ctx, peerID)
+			//if related task is not expired
+			if len(cIDs) > 0 {
+				continue
+			}
+		}
+
 		if peerState.ServiceDownTime != 0 &&
-			timeutils.GetCurrentTimeMillis()-peerState.ServiceDownTime < int64(gcm.cfg.PeerGCDelay) {
+			timeutils.GetCurrentTimeMillis()-peerState.ServiceDownTime < int64(gcm.cfg.PeerGCDelay/time.Millisecond) {
 			continue
 		}
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
节点下线时间初始化为0，对于这种情况gc异常
时间戳转换错误：int64(gcm.cfg.PeerGCDelay) 默认返回180000000000，但是这里对比使用的是毫秒
当下载时间过长（比如10g大文件），由于异常gc导致下载失败

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

测试用例不好覆盖

### Ⅳ. Describe how to verify it
1.测试下载dfget较大文件，持续时间超过2分钟

### Ⅴ. Special notes for reviews


