### PR TITLE
chore: remove trailing spaces in dfget example

### DIFF
--- a/cmd/dfget/app/root.go
+++ b/cmd/dfget/app/root.go
@@ -321,7 +321,7 @@ func dfgetExample() string {
 $ dfget -u https://www.taobao.com -o /tmp/test/b.test --notbs --expiretime 20s
 --2019-02-02 18:56:34--  https://www.taobao.com
 dfget version:0.3.0
-workspace:/root/.small-dragonfly 
+workspace:/root/.small-dragonfly
 sign:96414-1549104994.143
 client:127.0.0.1 connected to node:127.0.0.1
 start download by dragonfly...


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
See PR https://github.com/dragonflyoss/Dragonfly/pull/859 and its ci https://circleci.com/gh/dragonflyoss/Dragonfly/10456?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link failed because of the example has trailing space here. So remove it.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


