### PR TITLE
delete os.O_SYNC flag when supernode write piece to local

### DIFF
--- a/supernode/store/local_storage.go
+++ b/supernode/store/local_storage.go
@@ -174,7 +174,7 @@ func (ls *localStorage) Put(ctx context.Context, raw *Raw, data io.Reader) error
 	lock(path, raw.Offset, false)
 	defer unLock(path, raw.Offset, false)
 
-	f, err := fileutils.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_SYNC, 0644)
+	f, err := fileutils.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
 		return err
 	}
@@ -210,7 +210,7 @@ func (ls *localStorage) PutBytes(ctx context.Context, raw *Raw, data []byte) err
 	lock(path, raw.Offset, false)
 	defer unLock(path, raw.Offset, false)
 
-	f, err := fileutils.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_SYNC, 0644)
+	f, err := fileutils.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: zhouchencheng <zhouchencheng@bilibili.com>

### Ⅰ. Describe what this PR did
I found that if set OpenFile flag `os.O_SYNC`, supernode writes piece files to local disk with low efficiency.
I removed this flag, then writing process was obviously speed up.
 

### Ⅱ. Does this pull request fix one issue?
None


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it
I download a 300+M size image layer in the same machine,  and compare the efficiency when set and unset 
`os.O_SYNC` flag. 
I filter the critical logs with timestamp as below:
set `os.O_SYNC`
```
2019-09-05 20:24:01.102 DEBU sign:12542 : send the protocolContent taskID: d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3 pieceNum: 0
2019-09-05 20:24:01.226 DEBU sign:12542 : send the protocolContent taskID: d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3 pieceNum: 1
2019-09-05 20:24:01.371 DEBU sign:12542 : send the protocolContent taskID: d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3 pieceNum: 2
2019-09-05 20:24:01.531 DEBU sign:12542 : send the protocolContent taskID: d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3 pieceNum: 3
2019-09-05 20:24:16.228 DEBU sign:12542 : success to report piece status with taskID(d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3) pieceNum(0)
2019-09-05 20:24:16.228 DEBU sign:12542 : success to report piece status with taskID(d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3) pieceNum(1)
2019-09-05 20:24:16.234 DEBU sign:12542 : send the protocolContent taskID: d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3 pieceNum: 4
2019-09-05 20:24:16.297 DEBU sign:12542 : success to report piece status with taskID(d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3) pieceNum(3)
2019-09-05 20:24:16.298 DEBU sign:12542 : success to report piece status with taskID(d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3) pieceNum(2)
.....
2019-09-05 20:26:53.491 DEBU sign:12542 : success to report piece status with taskID(d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3) pieceNum(70)
2019-09-05 20:26:53.491 DEBU sign:12542 : send the protocolContent taskID: d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3 pieceNum: 74
2019-09-05 20:26:54.247 DEBU sign:12542 : success to report piece status with taskID(d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3) pieceNum(71)
2019-09-05 20:26:55.877 DEBU sign:12542 : success to report piece status with taskID(d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3) pieceNum(74)
2019-09-05 20:26:58.211 DEBU sign:12542 : success to report piece status with taskID(d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3) pieceNum(72)
2019-09-05 20:26:58.258 DEBU sign:12542 : success to report piece status with taskID(d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3) pieceNum(73)
```

unset `os.O_SYNC`
```
2019-09-05 20:45:48.944 DEBU sign:15363 : send the protocolContent taskID: d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3 pieceNum: 0
2019-09-05 20:45:48.963 DEBU sign:15363 : success to report piece status with taskID(d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3) pieceNum(0)
2019-09-05 20:45:49.025 DEBU sign:15363 : send the protocolContent taskID: d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3 pieceNum: 1
2019-09-05 20:45:49.046 DEBU sign:15363 : success to report piece status with taskID(d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3) pieceNum(1)
2019-09-05 20:45:49.142 DEBU sign:15363 : send the protocolContent taskID: d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3 pieceNum: 2
2019-09-05 20:45:49.162 DEBU sign:15363 : success to report piece status with taskID(d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3) pieceNum(2)
2019-09-05 20:45:49.249 DEBU sign:15363 : send the protocolContent taskID: d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3 pieceNum: 3
2019-09-05 20:45:49.272 DEBU sign:15363 : success to report piece status with taskID(d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3) pieceNum(3)
2019-09-05 20:45:49.346 DEBU sign:15363 : send the protocolContent taskID: d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3 pieceNum: 4
2019-09-05 20:45:49.372 DEBU sign:15363 : success to report piece status with taskID(d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3) pieceNum(4)
2019-09-05 20:45:49.427 DEBU sign:15363 : send the protocolContent taskID: d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3 pieceNum: 5
.....
2019-09-05 20:45:55.582 DEBU sign:15363 : send the protocolContent taskID: d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3 pieceNum: 71
2019-09-05 20:45:55.604 DEBU sign:15363 : success to report piece status with taskID(d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3) pieceNum(71)
2019-09-05 20:45:55.677 DEBU sign:15363 : send the protocolContent taskID: d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3 pieceNum: 72
2019-09-05 20:45:55.703 DEBU sign:15363 : success to report piece status with taskID(d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3) pieceNum(72)
2019-09-05 20:45:55.766 DEBU sign:15363 : send the protocolContent taskID: d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3 pieceNum: 73
2019-09-05 20:45:55.790 DEBU sign:15363 : success to report piece status with taskID(d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3) pieceNum(73)
2019-09-05 20:45:55.843 DEBU sign:15363 : send the protocolContent taskID: d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3 pieceNum: 74
2019-09-05 20:45:55.855 DEBU sign:15363 : success to report piece status with taskID(d577b0c6f739dabcf101dd6733a16916126f1cef89418f0b72c10b48c18dcdf3) pieceNum(74)
```
### Ⅴ. Special notes for reviews


