### PR TITLE
feature: add some cdn metrics

### DIFF
--- a/docs/user_guide/metrics.md
+++ b/docs/user_guide/metrics.md
@@ -16,8 +16,11 @@ This doc contains all the metrics that Dragonfly components currently support. N
 - dragonfly_supernode_dfgettasks_registered_total{callsystem} - total times of registering new dfgettasks. counter type.
 - dragonfly_supernode_dfgettasks_failed_total{callsystem} - total times of failed dfgettasks. counter type.
 - dragonfly_supernode_schedule_duration_milliseconds{peer} - duration for task scheduling in milliseconds
-- dragonfly_supernode_trigger_cdn_total{} - total times of triggering cdn.
-- dragonfly_supernode_trigger_cdn_failed_total{} - total failed times of triggering cdn.
+- dragonfly_supernode_cdn_trigger_total{} - total times of triggering cdn. counter type.
+- dragonfly_supernode_cdn_trigger_total{} - total failed times of triggering cdn. counter type.
+- dragonfly_supernode_cdn_cache_hit_total{} - total times of hitting cdn cache. counter type.
+- dragonfly_supernode_cdn_download_total{} - total times of cdn downloading. counter type.
+- dragonfly_supernode_cdn_download_failed_total{} - total failure times of cdn downloading. counter type.
 
 ## Dfdaemon
 

--- a/supernode/daemon/mgr/cdn/downloader_test.go
+++ b/supernode/daemon/mgr/cdn/downloader_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/dragonflyoss/Dragonfly/supernode/httpclient"
 
 	"github.com/go-check/check"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 func Test(t *testing.T) {
@@ -45,7 +46,7 @@ func init() {
 }
 
 func (s *CDNDownloadTestSuite) TestDownload(c *check.C) {
-	cm, _ := NewManager(config.NewConfig(), nil, nil, httpclient.NewOriginClient())
+	cm, _ := NewManager(config.NewConfig(), nil, nil, httpclient.NewOriginClient(), prometheus.DefaultRegisterer)
 	bytes := []byte("hello world")
 	bytesLength := int64(len(bytes))
 

--- a/supernode/daemon/mgr/task/manager.go
+++ b/supernode/daemon/mgr/task/manager.go
@@ -58,10 +58,10 @@ func newMetrics(register prometheus.Registerer) *metrics {
 		tasksRegisterCount: metricsutils.NewCounter(config.SubsystemSupernode, "tasks_registered_total",
 			"Total times of registering tasks", []string{}, register),
 
-		triggerCdnCount: metricsutils.NewCounter(config.SubsystemSupernode, "trigger_cdn_total",
+		triggerCdnCount: metricsutils.NewCounter(config.SubsystemSupernode, "cdn_trigger_total",
 			"Total times of triggering cdn", []string{}, register),
 
-		triggerCdnFailCount: metricsutils.NewCounter(config.SubsystemSupernode, "trigger_cdn_failed_total",
+		triggerCdnFailCount: metricsutils.NewCounter(config.SubsystemSupernode, "cdn_trigger_failed_total",
 			"Total failure times of triggering cdn", []string{}, register),
 
 		scheduleDurationMilliSeconds: metricsutils.NewHistogram(config.SubsystemSupernode, "schedule_duration_milliseconds",

--- a/supernode/server/server.go
+++ b/supernode/server/server.go
@@ -87,7 +87,7 @@ func New(cfg *config.Config, register prometheus.Registerer) (*Server, error) {
 		return nil, err
 	}
 
-	cdnMgr, err := cdn.NewManager(cfg, storeLocal, progressMgr, originClient)
+	cdnMgr, err := cdn.NewManager(cfg, storeLocal, progressMgr, originClient, register)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
We already have a metric call `dragonfly_supernode_trigger_cdn_total` to represent the total times of cdn triggering. However this metric cannot represent the total times of downloading by cdn because supernode cdn has cache. So add three metrics in this PR to represent the downloading process and cache hit times.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


