### PR TITLE
feature: add gc cli config

### DIFF
--- a/cmd/supernode/app/root.go
+++ b/cmd/supernode/app/root.go
@@ -102,6 +102,22 @@ func setupFlags(cmd *cobra.Command, opt *Options) {
 
 	flagSet.StringVar(&opt.AdvertiseIP, "advertise-ip", "",
 		"the supernode ip that we advertise to other peer in the p2p-network")
+
+	flagSet.DurationVar(&opt.FailAccessInterval, "fail-access-interval", opt.FailAccessInterval,
+		"FailAccessInterval is the interval time after failed to access the URL")
+
+	flagSet.DurationVar(&opt.GCInitialDelay, "gc-initial-delay", opt.GCInitialDelay,
+		"GCInitialDelay is the delay time from the start to the first GC execution")
+
+	flagSet.DurationVar(&opt.GCMetaInterval, "gc-meta-interval", opt.GCMetaInterval,
+		"GCMetaInterval is the interval time to execute the GC meta")
+
+	flagSet.DurationVar(&opt.TaskExpireTime, "task-expire-time", opt.TaskExpireTime,
+		"TaskExpireTime when a task is not accessed within the taskExpireTime,and it will be treated to be expired")
+
+	flagSet.DurationVar(&opt.PeerGCDelay, "peer-gc-delay", opt.PeerGCDelay,
+		"PeerGCDelay is the delay time to execute the GC after the peer has reported the offline")
+
 }
 
 // runSuperNode prepares configs, setups essential details and runs supernode daemon.


### PR DESCRIPTION
Signed-off-by: yunfeiyangbuaa <yunfeiyang@buaa.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
add gc cli config

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #884 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


```
Usage:
  Dragonfly Supernode [flags]
  Dragonfly [command]

Available Commands:
  help        Help about any command
  version     Show the current version of supernode

Flags:
      --advertise-ip string             the supernode ip that we advertise to other peer in the p2p-network
      --config string                   the path of supernode's configuration file (default "/etc/dragonfly/supernode.yml")
  -D, --debug                           Switch daemon log level to DEBUG mode
      --down-limit int                  download limit for supernode to serve download tasks (default 5)
      --download-path string            specifies the path where to store downloaded filed from source address (default "/home/admin/supernode/repo/download")
      --download-port int               DownloadPort is the port for download files from supernode (default 8001)
      --fail-access-interval duration   failAccessInterval is the interval time after failed to access the URL (default 3m0s)
      --gc-initial-delay duration       GCInitialDelay is the delay time from the start to the first GC execution. (default 6s)
      --gc-meta-interval duration       GCMetaInterval is the interval time to execute the GC meta. (default 2m0s)
  -h, --help                            help for Dragonfly
      --home-dir string                 HomeDir is working directory of supernode (default "/home/admin/supernode")
      --max-bandwidth int               network rate that supernode can use (unit: MB/s) (default 200)
      --peer-gc-delay duration          PeerGCDelay is the delay time to execute the GC after the peer has reported the offline. (default 3m0s)
      --pool-size int                   the core pool size of ScheduledExecutorService (default 10)
      --port int                        ListenPort is the port supernode server listens on (default 8002)
      --profiler                        Set if supernode HTTP server setup profiler
      --system-bandwidth int            Network rate reserved for system (unit: MB/s) (default 20)
      --task-expire-time duration       TaskExpireTime when a task is not accessed within the taskExpireTime,and it will be treated to be expired. (default 3m0s)
      --up-limit int                    upload limit for a peer to serve download tasks (default 5)

```
commend  :
`
sudo go run main.go   --fail-access-interval  9m  --home-dir ~/suplog1  -D  --gc-initial-delay 7s  --task-expire-time  8m`
the result is as flows
```
2019-09-06 12:27:09.707 ERRO sign:1482 : failed to init properties: open /etc/dragonfly/supernode.yml: no such file or directory
2019-09-06 12:27:09.708 INFO sign:1482 : success to init local ip of supernode, use ip: 192.168.1.246
2019-09-06 12:27:09.708 DEBU sign:1482 : get supernode config: base:
  listenPort: 8002
  downloadPort: 8001
  homeDir: /home/yunfeiyang/suplog1
  schedulerCorePoolSize: 10
  downloadPath: /home/admin/supernode/repo/download
  peerUpLimit: 5
  peerDownLimit: 5
  eliminationLimit: 5
  failureCountLimit: 5
  linkLimit: 20
  systemReservedBandwidth: 20
  maxBandwidth: 200
  enableProfiler: false
  debug: true
  advertiseIP: 192.168.1.246
  failAccessInterval: 9m0s
  gcInitialDelay: 7s
  gcMetaInterval: 2m0s
  taskExpireTime: 8m0s
  peerGCDelay: 3m0s
plugins: {}
storages: {}

2019-09-06 12:27:09.708 INFO sign:1482 : start to run supernode
2019-09-06 12:27:09.709 DEBU sign:1482 : start the gc job
```
### Ⅴ. Special notes for reviews


