### PR TITLE
bugfix:gc peer failing to server down

### DIFF
--- a/supernode/daemon/mgr/gc/gc_peer.go
+++ b/supernode/daemon/mgr/gc/gc_peer.go
@@ -38,6 +38,7 @@ func (gcm *Manager) gcPeers(ctx context.Context) {
 		peerState, err := gcm.progressMgr.GetPeerStateByPeerID(ctx, peerID)
 		if err != nil {
 			logrus.Warnf("gc peers: failed to get peerState peerID(%s): %v", peerID, err)
+			gcm.gcPeer(ctx, peerID)
 			continue
 		}
 


### PR DESCRIPTION
Signed-off-by: yunfeiyangbuaa <yunfeiyang@buaa.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #886 
### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it
 set  
```
func (s *Server) reportServiceDown(ctx context.Context, rw http.ResponseWriter, req *http.Request) (err error) {
	return nil
	params := req.URL.Query()
	taskID := params.Get("taskId")
	cID := params.Get("cid")

	// get peerID according to the CID and taskID
	dfgetTask, err := s.DfgetTaskMgr.Get(ctx, cID, taskID)
	if err != nil {
		return err
	}
	s.ProgressMgr.UpdatePeerServiceDown(ctx, dfgetTask.PeerID)

	return EncodeResponse(rw, http.StatusOK, &types.ResultInfo{
		Code: constants.CodeGetPeerDown,
	})
}

```
to make server down fail,and start some dfgets.wait some minutes and long  at the supernode log to see gc result
```
dstPID(buaa-127.0.0.1-1568789107329775876) pieceNum(0) pieceStatus(1)
2019-09-18 14:45:23.087 DEBU sign:15332 : success to update ClientProgress taskID(9627226867cf6d8496944de44f554b8d0d2e743c991da21ad3e05336f01e5ba9) srcCID(127.0.0.1-17109-1568789123.075) dstPID(buaa-127.0.0.1-1568789107329775876) pieceNum(0) pieceStatus(-3) with result: false
2019-09-18 14:45:23.087 DEBU sign:15332 : taskID(9627226867cf6d8496944de44f554b8d0d2e743c991da21ad3e05336f01e5ba9) clientID(127.0.0.1-17109-1568789123.075) get successful pieces: [0]
2019-09-18 14:47:02.217 INFO sign:15332 : gc tasks: success to full gc task count(0), remainder count(1)
2019-09-18 14:47:02.217 INFO sign:15332 : gc peers: success to gc peer count(0), remainder count(17)
2019-09-18 14:49:02.217 INFO sign:15332 : start to gc task: 9627226867cf6d8496944de44f554b8d0d2e743c991da21ad3e05336f01e5ba9
2019-09-18 14:49:02.217 INFO sign:15332 : gc peers: success to gc peer count(0), remainder count(17)
2019-09-18 14:49:02.217 INFO sign:15332 : gc tasks: success to full gc task count(1), remainder count(0)
2019-09-18 14:51:02.216 INFO sign:15332 : gc tasks: success to full gc task count(0), remainder count(0)
2019-09-18 14:51:02.216 INFO sign:15332 : gc peers: success to gc peer count(0), remainder count(17)
2019-09-18 14:53:02.217 INFO sign:15332 : gc tasks: success to full gc task count(0), remainder count(0)
2019-09-18 14:53:02.217 INFO sign:15332 : start to gc peer: buaa-127.0.0.1-1568789110215189714
2019-09-18 14:53:02.217 INFO sign:15332 : start to gc peer: buaa-127.0.0.1-1568789111710620517
2019-09-18 14:53:02.217 INFO sign:15332 : start to gc peer: buaa-127.0.0.1-1568789102503455620
2019-09-18 14:53:02.218 INFO sign:15332 : start to gc peer: buaa-127.0.0.1-1568789104356430736
2019-09-18 14:53:02.218 INFO sign:15332 : start to gc peer: buaa-127.0.0.1-1568789121686022462
2019-09-18 14:53:02.218 INFO sign:15332 : start to gc peer: buaa-127.0.0.1-1568789108759479973
2019-09-18 14:53:02.218 INFO sign:15332 : start to gc peer: buaa-127.0.0.1-1568789117378592819
2019-09-18 14:53:02.218 INFO sign:15332 : start to gc peer: buaa-127.0.0.1-1568789105879446327
2019-09-18 14:53:02.218 INFO sign:15332 : start to gc peer: buaa-127.0.0.1-1568789099644459405
2019-09-18 14:53:02.219 INFO sign:15332 : start to gc peer: buaa-127.0.0.1-1568789113174107121
2019-09-18 14:53:02.219 INFO sign:15332 : start to gc peer: buaa-127.0.0.1-1568789114643691712
2019-09-18 14:53:02.219 INFO sign:15332 : start to gc peer: buaa-127.0.0.1-1568789116020640445
2019-09-18 14:53:02.219 INFO sign:15332 : start to gc peer: buaa-127.0.0.1-1568789107329775876
2019-09-18 14:53:02.219 INFO sign:15332 : start to gc peer: buaa-127.0.0.1-1568789118858206450
2019-09-18 14:53:02.219 INFO sign:15332 : start to gc peer: buaa-127.0.0.1-1568789120304483555
2019-09-18 14:53:02.219 INFO sign:15332 : start to gc peer: buaa-127.0.0.1-1568789123076779584
2019-09-18 14:53:02.219 INFO sign:15332 : gc peers: success to gc peer count(16), remainder count(1)
```