### PR TITLE
feature: make supernode compatible with the 0.2.x dfget

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/golang/mock v1.3.1
 	github.com/gorilla/context v0.0.0-20181012153548-51ce91d2eadd // indirect
 	github.com/gorilla/mux v1.5.0
+	github.com/gorilla/schema v1.1.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/magiconair/properties v1.8.1 // indirect
 	github.com/mailru/easyjson v0.0.0-20170902151237-2a92e673c9a6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/gorilla/context v0.0.0-20181012153548-51ce91d2eadd h1:bB2XEQHhNsTTpqN
 github.com/gorilla/context v0.0.0-20181012153548-51ce91d2eadd/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.5.0 h1:mq8bRov+5x+pZNR/uAHyUEgovR9gLgYFwDQIeuYi9TM=
 github.com/gorilla/mux v1.5.0/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/schema v1.1.0 h1:CamqUDOFUBqzrvxuz2vEwo8+SUdwsluFh7IlzJh30LY=
+github.com/gorilla/schema v1.1.0/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
We have refactored the dragonfly with golang. And we should make supernode compatible with  every version of dfget to make it possible to seamlessly migrate dragonfly to the latest version.

Recommended migration plan:
1. upgrade your supernode to the latest version
2. upgrade the dfclient constantly and supernode can support both old and new versions of dfclient

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
None.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


