### PR TITLE
bugfix:fix the gc time 

### DIFF
--- a/supernode/daemon/mgr/gc/gc_peer.go
+++ b/supernode/daemon/mgr/gc/gc_peer.go
@@ -19,6 +19,7 @@ package gc
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/dragonflyoss/Dragonfly/pkg/timeutils"
 	"github.com/dragonflyoss/Dragonfly/supernode/util"
@@ -41,7 +42,7 @@ func (gcm *Manager) gcPeers(ctx context.Context) {
 		}
 
 		if peerState.ServiceDownTime == 0 ||
-			timeutils.GetCurrentTimeMillis()-peerState.ServiceDownTime < int64(gcm.cfg.PeerGCDelay) {
+			timeutils.GetCurrentTimeMillis()-peerState.ServiceDownTime < int64(gcm.cfg.PeerGCDelay/time.Millisecond) {
 			continue
 		}
 


### PR DESCRIPTION
Signed-off-by: yunfeiyangbuaa <yunfeiyang@buaa.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes:#904
### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it

run supernode and dfget
take some minutes gc over

```
2019-09-14 13:35:55.942 DEBU sign:6860 : start to update progress taskID (9f5a8cf450054274c79a485a0fdc75fbc2ec8bfef743620109c464754ab42660) srcCID (127.0.0.1-7560-1568439354.843) srcPID (buaa-127.0.0.1-1568439354844787684) dstPID (buaa-127.0.0.1-1568439352517033339) pieceNum (2) pieceStatus (-3)
2019-09-14 13:35:55.942 DEBU sign:6860 : success to update ClientProgress taskID(9f5a8cf450054274c79a485a0fdc75fbc2ec8bfef743620109c464754ab42660) srcCID(127.0.0.1-7560-1568439354.843) dstPID(buaa-127.0.0.1-1568439352517033339) pieceNum(2) pieceStatus(-3) with result: false
2019-09-14 13:35:55.942 DEBU sign:6860 : taskID(9f5a8cf450054274c79a485a0fdc75fbc2ec8bfef743620109c464754ab42660) clientID(127.0.0.1-7560-1568439354.843) get successful pieces: [0 1 2 3 4 5]
2019-09-14 13:37:41.056 INFO sign:6860 : gc peers: success to gc peer count(0), remainder count(7)
2019-09-14 13:37:41.056 INFO sign:6860 : gc tasks: success to full gc task count(0), remainder count(1)
2019-09-14 13:39:41.056 INFO sign:6860 : start to gc peer: buaa-127.0.0.1-1568439347673951868
2019-09-14 13:39:41.056 INFO sign:6860 : start to gc task: 9f5a8cf450054274c79a485a0fdc75fbc2ec8bfef743620109c464754ab42660
2019-09-14 13:39:41.056 INFO sign:6860 : start to gc peer: buaa-127.0.0.1-1568439354844787684
2019-09-14 13:39:41.056 INFO sign:6860 : gc tasks: success to full gc task count(1), remainder count(0)
2019-09-14 13:39:41.056 INFO sign:6860 : start to gc peer: buaa-127.0.0.1-1568439345216943045
2019-09-14 13:39:41.056 INFO sign:6860 : start to gc peer: buaa-127.0.0.1-1568439336248161905
2019-09-14 13:39:41.056 INFO sign:6860 : start to gc peer: buaa-127.0.0.1-1568439350228838644
2019-09-14 13:39:41.056 INFO sign:6860 : start to gc peer: buaa-127.0.0.1-1568439352517033339
2019-09-14 13:39:41.056 INFO sign:6860 : gc peers: success to gc peer count(6), remainder count(1)

```
### Ⅴ. Special notes for reviews


