### PR TITLE
feature:make cli better

### DIFF
--- a/cmd/dfget/app/root.go
+++ b/cmd/dfget/app/root.go
@@ -166,7 +166,7 @@ func initFlags() {
 	// url & output
 	flagSet.StringVarP(&cfg.URL, "url", "u", "", "URL of user requested downloading file(only HTTP/HTTPs supported)")
 	flagSet.StringVarP(&cfg.Output, "output", "o", "",
-		"Destination path which is used to store the requested downloading file. It must contain detailed directory and specific filename, for example, '/tmp/file.mp4'")
+		"destination path which is used to store the requested downloading file. It must contain detailed directory and specific filename, for example, '/tmp/file.mp4'")
 
 	// localLimit & minRate & totalLimit & timeout
 	flagSet.VarP(&cfg.LocalLimit, "locallimit", "s",
@@ -176,18 +176,17 @@ func initFlags() {
 	flagSet.Var(&cfg.TotalLimit, "totallimit",
 		"network bandwidth rate limit for the whole host, in format of G(B)/g/M(B)/m/K(B)/k/B, pure number will also be parsed as Byte")
 	flagSet.DurationVarP(&cfg.Timeout, "timeout", "e", 0,
-		"Timeout set for file downloading task. If dfget has not finished downloading all pieces of file before --timeout, the dfget will throw an error and exit")
+		"timeout set for file downloading task. If dfget has not finished downloading all pieces of file before --timeout, the dfget will throw an error and exit")
 
 	// md5 & identifier
 	flagSet.StringVarP(&cfg.Md5, "md5", "m", "",
 		"md5 value input from user for the requested downloading file to enhance security")
 	flagSet.StringVarP(&cfg.Identifier, "identifier", "i", "",
-		"The usage of identifier is making different downloading tasks generate different downloading task IDs even if they have the same URLs. conflict with --md5.")
-
+		"the usage of identifier is making different downloading tasks generate different downloading task IDs even if they have the same URLs. conflict with --md5.")
 	flagSet.StringVar(&cfg.CallSystem, "callsystem", "",
-		"The name of dfget caller which is for debugging. Once set, it will be passed to all components around the request to make debugging easy")
+		"the name of dfget caller which is for debugging. Once set, it will be passed to all components around the request to make debugging easy")
 	flagSet.StringSliceVar(&cfg.Cacerts, "cacerts", nil,
-		"The cacert file which is used to verify remote server when supernode interact with the source.")
+		"the cacert file which is used to verify remote server when supernode interact with the source.")
 	flagSet.StringVarP(&cfg.Pattern, "pattern", "p", "p2p",
 		"download pattern, must be p2p/cdn/source, cdn and source do not support flag --totallimit")
 	flagSet.StringVarP(&filter, "filter", "f", "",
@@ -223,7 +222,7 @@ func initFlags() {
 	flagSet.DurationVar(&cfg.RV.DataExpireTime, "expiretime", config.DataExpireTime,
 		"caching duration for which cached file keeps no accessed by any process, after this period cache file will be deleted")
 	flagSet.DurationVar(&cfg.RV.ServerAliveTime, "alivetime", config.ServerAliveTime,
-		"Alive duration for which uploader keeps no accessing by any uploading requests, after this period uploader will automatically exit")
+		"alive duration for which uploader keeps no accessing by any uploading requests, after this period uploader will automatically exit")
 
 	flagSet.MarkDeprecated("exceed", "please use '--timeout' or '-e' instead")
 }

--- a/cmd/dfget/app/server.go
+++ b/cmd/dfget/app/server.go
@@ -58,7 +58,7 @@ func initServerFlags() {
 	flagSet.DurationVar(&cfg.RV.DataExpireTime, "expiretime", config.DataExpireTime,
 		"caching duration for which cached file keeps no accessed by any process, after this period cache file will be deleted")
 	flagSet.DurationVar(&cfg.RV.ServerAliveTime, "alivetime", config.ServerAliveTime,
-		"Alive duration for which uploader keeps no accessing by any uploading requests, after this period uploader will automatically exit")
+		"alive duration for which uploader keeps no accessing by any uploading requests, after this period uploader will automatically exit")
 
 	flagSet.BoolVar(&cfg.Verbose, "verbose", false,
 		"be verbose")

--- a/cmd/supernode/app/root.go
+++ b/cmd/supernode/app/root.go
@@ -69,31 +69,31 @@ func setupFlags(cmd *cobra.Command, opt *Options) {
 		"the path of supernode's configuration file")
 
 	flagSet.IntVar(&opt.ListenPort, "port", opt.ListenPort,
-		"ListenPort is the port supernode server listens on")
+		"listenPort is the port that supernode server listens on")
 
 	flagSet.IntVar(&opt.DownloadPort, "download-port", opt.DownloadPort,
-		"DownloadPort is the port for download files from supernode")
+		"downloadPort is the port for download files from supernode")
 
 	flagSet.StringVar(&opt.HomeDir, "home-dir", opt.HomeDir,
-		"HomeDir is working directory of supernode")
+		"homeDir is the working directory of supernode")
 
 	flagSet.StringVar(&opt.DownloadPath, "download-path", opt.DownloadPath,
-		"specifies the path where to store downloaded filed from source address")
+		"download path specifies the path where to store downloaded filed from source address")
 
 	flagSet.Var(&opt.SystemReservedBandwidth, "system-bandwidth",
-		"Network rate reserved for system")
+		"network rate reserved for system")
 
 	flagSet.Var(&opt.MaxBandwidth, "max-bandwidth",
 		"network rate that supernode can use")
 
 	flagSet.IntVar(&opt.SchedulerCorePoolSize, "pool-size", opt.SchedulerCorePoolSize,
-		"the core pool size of ScheduledExecutorService")
+		"pool size is the core pool size of ScheduledExecutorService")
 
 	flagSet.BoolVar(&opt.EnableProfiler, "profiler", opt.EnableProfiler,
-		"Set if supernode HTTP server setup profiler")
+		"profiler sets whether supernode HTTP server setups profiler")
 
 	flagSet.BoolVarP(&opt.Debug, "debug", "D", opt.Debug,
-		"Switch daemon log level to DEBUG mode")
+		"switch daemon log level to DEBUG mode")
 
 	flagSet.IntVar(&opt.PeerUpLimit, "up-limit", opt.PeerUpLimit,
 		"upload limit for a peer to serve download tasks")
@@ -102,22 +102,22 @@ func setupFlags(cmd *cobra.Command, opt *Options) {
 		"download limit for supernode to serve download tasks")
 
 	flagSet.StringVar(&opt.AdvertiseIP, "advertise-ip", "",
-		"the supernode ip that we advertise to other peer in the p2p-network")
+		"the supernode ip is the ip we advertise to other peers in the p2p-network")
 
 	flagSet.DurationVar(&opt.FailAccessInterval, "fail-access-interval", opt.FailAccessInterval,
-		"FailAccessInterval is the interval time after failed to access the URL")
+		"fail access interval is the interval time after failed to access the URL")
 
 	flagSet.DurationVar(&opt.GCInitialDelay, "gc-initial-delay", opt.GCInitialDelay,
-		"GCInitialDelay is the delay time from the start to the first GC execution")
+		"gc initial delay is the delay time from the start to the first GC execution")
 
 	flagSet.DurationVar(&opt.GCMetaInterval, "gc-meta-interval", opt.GCMetaInterval,
-		"GCMetaInterval is the interval time to execute the GC meta")
+		"gc meta interval is the interval time to execute the GC meta")
 
 	flagSet.DurationVar(&opt.TaskExpireTime, "task-expire-time", opt.TaskExpireTime,
-		"TaskExpireTime when a task is not accessed within the taskExpireTime,and it will be treated to be expired")
+		"task expire time is the time that a task is treated expired if the task is not accessed within the time")
 
 	flagSet.DurationVar(&opt.PeerGCDelay, "peer-gc-delay", opt.PeerGCDelay,
-		"PeerGCDelay is the delay time to execute the GC after the peer has reported the offline")
+		"peer gc delay is the delay time to execute the GC after the peer has reported the offline")
 
 }
 

--- a/cmd/supernode/app/root_test.go
+++ b/cmd/supernode/app/root_test.go
@@ -23,9 +23,9 @@ import (
 	"path"
 	"testing"
 
-	"github.com/go-check/check"
-
 	"github.com/dragonflyoss/Dragonfly/supernode/config"
+
+	"github.com/go-check/check"
 )
 
 func Test(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: yunfeiyangbuaa <yunfeiyang@buaa.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #908 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it
supernode:
```
yunfeiyang@buaa:~/go/src/github.com/dragonflyoss/Dragonfly/cmd/supernode$ sudo go run main.go -h
Usage:
  Dragonfly Supernode [flags]
  Dragonfly [command]

Available Commands:
  help        Help about any command
  version     Show the current version of supernode

Flags:
      --advertise-ip string             the supernode ip is the ip we advertise to other peers in the p2p-network
      --config string                   the path of supernode's configuration file (default "/etc/dragonfly/supernode.yml")
  -D, --debug                           switch daemon log level to DEBUG mode
      --down-limit int                  download limit for supernode to serve download tasks (default 5)
      --download-path string            download path specifies the path where to store downloaded filed from source address (default "/home/admin/supernode/repo/download")
      --download-port int               downloadPort is the port for download files from supernode (default 8001)
      --fail-access-interval duration   fail access interval is the interval time after failed to access the URL (default 3m0s)
      --gc-initial-delay duration       gc initial delay is the delay time from the start to the first GC execution (default 6s)
      --gc-meta-interval duration       gc meta interval is the interval time to execute the GC meta (default 2m0s)
  -h, --help                            help for Dragonfly
      --home-dir string                 homeDir is the working directory of supernode (default "/home/admin/supernode")
      --max-bandwidth int               max bandwidth is the max network rate that supernode can use (unit: MB/s) (default 200)
      --peer-gc-delay duration          peer gc delay is the delay time to execute the GC after the peer has reported the offline (default 3m0s)
      --pool-size int                   pool size is the core pool size of ScheduledExecutorService (default 10)
      --port int                        listenPort is the port that supernode server listens on (default 8002)
      --profiler                        profiler sets whether supernode HTTP server setups profiler
      --system-bandwidth int            system bandwidth is the network rate reserved for system (unit: MB/s) (default 20)
      --task-expire-time duration       task expire time is the time that a task is treated expired if the task is not accessed within the time (default 3m0s)
      --up-limit int                    upload limit for a peer to serve download tasks (default 5)

Use "Dragonfly [command] --help" for more information about a command.

```


dfget:
```
yunfeiyang@buaa:~/go/src/github.com/dragonflyoss/Dragonfly/cmd/dfget$ sudo go run main.go -h
dfget is the client of Dragonfly which takes a role of peer in a P2P network.
When user triggers a file downloading task, dfget will download the pieces of
file from other peers. Meanwhile, it will act as an uploader to support other
peers to download pieces from it if it owns them. In addition, dfget has the
abilities to provide more advanced functionality, such as network bandwidth
limit, transmission encryption and so on.

Usage:
  dfget [flags]
  dfget [command]

Examples:

$ dfget -u https://www.taobao.com -o /tmp/test/b.test --notbs --expiretime 20s
--2019-02-02 18:56:34--  https://www.taobao.com
dfget version:0.3.0
workspace:/root/.small-dragonfly
sign:96414-1549104994.143
client:127.0.0.1 connected to node:127.0.0.1
start download by dragonfly...
download SUCCESS cost:0.026s length:141898 reason:0


Available Commands:
  gen-doc     Generate Document for dfget command line tool with MarkDown format
  help        Help about any command
  server      Launch a peer server for uploading files.
  version     Show the current version of dfget



Flags:
      --alivetime duration    alive duration for which uploader keeps no accessing by any uploading requests, after this period uploader will automatically exit (default 5m0s)
      --cacerts strings       the cacert file which is used to verify remote server when supernode interact with the source.
      --callsystem string     the name of dfget caller which is for debugging. Once set, it will be passed to all components around the request to make debugging easy
      --clientqueue int       specify the size of client queue which controls the number of pieces that can be processed simultaneously (default 6)
      --console               show log on console, it's conflict with '--showbar'
      --dfdaemon              identify whether the request is from dfdaemon
      --expiretime duration   caching duration for which cached file keeps no accessed by any process, after this period cache file will be deleted (default 3m0s)
  -f, --filter string         filter some query params of URL, use char '&' to separate different params
                              eg: -f 'key&sign' will filter 'key' and 'sign' query param
                              in this way, different but actually the same URLs can reuse the same downloading task
      --header strings        http header, eg: --header='Accept: *' --header='Host: abc'
  -h, --help                  help for dfget
  -i, --identifier string     the usage of identifier is making different downloading tasks generate different downloading task IDs even if they have the same URLs. conflict with --md5.
      --insecure              identify whether supernode should skip secure verify when interact with the source.
      --ip string             ip address that server will listen on
  -s, --locallimit string     network bandwidth rate limit for single download task, in format of 20M/m/K/k
  -m, --md5 string            md5 value input from user for the requested downloading file to enhance security
      --minrate string        minimal network bandwidth rate for downloading a file, in format of 20M/m/K/k
  -n, --node strings          specify the addresses(host:port) of supernodes
      --notbs                 disable back source downloading for requested file when p2p fails to download it
  -o, --output string         destination path which is used to store the requested downloading file. It must contain detailed directory and specific filename, for example, '/tmp/file.mp4'
  -p, --pattern string        download pattern, must be p2p/cdn/source, cdn and source do not support flag --totallimit (default "p2p")
      --port int              port number that server will listen on
  -b, --showbar               show progress bar, it is conflict with '--console'
  -e, --timeout int           timeout set for file downloading task. If dfget has not finished downloading all pieces of file before --timeout, the dfget will throw an error and exit
      --totallimit string     network bandwidth rate limit for the whole host, in format of 20M/m/K/k
  -u, --url string            url of user requested downloading file(only HTTP/HTTPs supported)
      --verbose               be verbose

Use "dfget [command] --help" for more information about a command.
yunfeiyang@buaa:~/go/src/github.com/dragonflyoss/Dragonfly/cmd/dfget$ 

```
### Ⅴ. Special notes for reviews


