### PR TITLE
bugfix: paas registry mirror tls config into dfget config.

### DIFF
--- a/dfdaemon/config/config.go
+++ b/dfdaemon/config/config.go
@@ -151,6 +151,16 @@ func (p *Properties) DFGetConfig() DFGetConfig {
 	if p.HijackHTTPS != nil {
 		dfgetConfig.HostsConfig = p.HijackHTTPS.Hosts
 	}
+	if p.RegistryMirror != nil {
+		exp, err := NewRegexp(p.RegistryMirror.Remote.Host)
+		if err == nil {
+			dfgetConfig.HostsConfig = append(dfgetConfig.HostsConfig, &HijackHost{
+				Regx:     exp,
+				Insecure: p.RegistryMirror.Insecure,
+				Certs:    p.RegistryMirror.Certs,
+			})
+		}
+	}
 	return dfgetConfig
 }
 


### PR DESCRIPTION
Signed-off-by: zhouchencheng <zhouchencheng@bilibili.com>


### Ⅰ. Describe what this PR did
The tls config in registry_mirror should save to dfget config.Otherwise, it doesn't work.

### Ⅱ. Does this pull request fix one issue?
#928 


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


