### PR TITLE
feature: use constant value to replace literals in supernode config.

### DIFF
--- a/supernode/config/config.go
+++ b/supernode/config/config.go
@@ -57,7 +57,7 @@ func (c *Config) String() string {
 // SetCIDPrefix sets a string as the prefix for supernode CID
 // which used to distinguish from the other peer nodes.
 func (c *Config) SetCIDPrefix(ip string) {
-	c.cIDPrefix = fmt.Sprintf("cdnnode:%s~", ip)
+	c.cIDPrefix = fmt.Sprintf("%s%s~", SuperNodeCIdPrefix, ip)
 }
 
 // GetSuperCID returns the cid string for taskID.
@@ -89,18 +89,18 @@ func (c *Config) IsSuperPID(peerID string) bool {
 func NewBaseProperties() *BaseProperties {
 	home := filepath.Join(string(filepath.Separator), "home", "admin", "supernode")
 	return &BaseProperties{
-		ListenPort:              8002,
-		DownloadPort:            8001,
+		ListenPort:              DefaultListenPort,
+		DownloadPort:            DefaultDownloadPort,
 		HomeDir:                 home,
-		SchedulerCorePoolSize:   10,
+		SchedulerCorePoolSize:   DefaultSchedulerCorePoolSize,
 		DownloadPath:            filepath.Join(home, "repo", "download"),
-		PeerUpLimit:             5,
-		PeerDownLimit:           5,
-		EliminationLimit:        5,
-		FailureCountLimit:       5,
-		LinkLimit:               20 * rate.MB,
-		SystemReservedBandwidth: 20 * rate.MB,
-		MaxBandwidth:            200 * rate.MB,
+		PeerUpLimit:             DefaultPeerUpLimit,
+		PeerDownLimit:           DefaultPeerDownLimit,
+		EliminationLimit:        DefaultEliminationLimit,
+		FailureCountLimit:       DefaultFailureCountLimit,
+		LinkLimit:               DefaultLinkLimit * rate.MB,
+		SystemReservedBandwidth: DefaultSystemReservedBandwidth * rate.MB,
+		MaxBandwidth:            DefaultMaxBandwidth * rate.MB,
 		EnableProfiler:          false,
 		Debug:                   false,
 		FailAccessInterval:      DefaultFailAccessInterval,

--- a/supernode/config/constants.go
+++ b/supernode/config/constants.go
@@ -18,6 +18,17 @@ package config
 
 import (
 	"time"
+
+	"github.com/dragonflyoss/Dragonfly/pkg/rate"
+)
+
+const (
+	// DefaultListenPort is the default port supernode server listens on.
+	DefaultListenPort = 8002
+	// DefaultDownloadPort is the default port for download files from supernode.
+	DefaultDownloadPort = 8001
+	// DefaultSchedulerCorePoolSize is the default core pool size of ScheduledExecutorService.
+	DefaultSchedulerCorePoolSize = 10
 )
 
 const (
@@ -38,17 +49,17 @@ const (
 )
 
 const (
-	// FailCountLimit indicates the limit of fail count as a client.
-	FailCountLimit = 5
+	// DefaultFailCountLimit indicates the default limit of failure count as a client.
+	DefaultFailureCountLimit = 5
 
-	// EliminationLimit indicates limit of fail count as a server.
-	EliminationLimit = 5
+	// DefaultEliminationLimit indicates the default limit of failure count as a server.
+	DefaultEliminationLimit = 5
 
-	// PeerUpLimit indicates the limit of the load count as a server.
-	PeerUpLimit = 5
+	// DefaultPeerUpLimit indicates the default limit of the load count as a server.
+	DefaultPeerUpLimit = 5
 
-	// PeerDownLimit indicates the limit of the download task count as a client.
-	PeerDownLimit = 4
+	// DefaultPeerDownLimit indicates the default limit of the download task count as a client.
+	DefaultPeerDownLimit = 4
 )
 
 const (
@@ -100,11 +111,14 @@ const (
 )
 
 const (
+	// DefaultLinkLimit is the default network speed limit for each piece.
+	// unit: MB/s
+	DefaultLinkLimit = 20 * rate.MB
 	// DefaultSystemReservedBandwidth is the default network bandwidth reserved for system software.
 	// unit: MB/s
-	DefaultSystemReservedBandwidth = 20
+	DefaultSystemReservedBandwidth = 20 * rate.MB
 
 	// DefaultMaxBandwidth is the default network bandwidth that supernode can use.
 	// unit: MB/s
-	DefaultMaxBandwidth = 200
+	DefaultMaxBandwidth = 200 * rate.MB
 )

--- a/supernode/daemon/mgr/scheduler/manager.go
+++ b/supernode/daemon/mgr/scheduler/manager.go
@@ -147,9 +147,9 @@ func (sm *Manager) getPieceResults(ctx context.Context, taskID, clientID, srcPID
 	if err != nil {
 		return nil, err
 	}
-	if srcPeerState.ClientErrorCount.Get() > config.FailCountLimit {
+	if srcPeerState.ClientErrorCount.Get() > int32(sm.cfg.FailureCountLimit) {
 		logrus.Warnf("scheduler: peerID: %s got errors for %d times which reaches error limit: %d for taskID(%s)",
-			srcPID, srcPeerState.ClientErrorCount.Get(), config.FailCountLimit, taskID)
+			srcPID, srcPeerState.ClientErrorCount.Get(), sm.cfg.FailureCountLimit, taskID)
 		useSupernode = true
 	}
 


### PR DESCRIPTION
Signed-off-by: zhouchencheng <zhouchencheng@bilibili.com>

### Ⅰ. Describe what this PR did
Replace literal values when initial supernode's base properties.

### Ⅱ. Does this pull request fix one issue?
`FailureCountLimit` config item does not work now, fix it in this pr.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

### Ⅳ. Describe how to verify it

### Ⅴ. Special notes for reviews


