### PR TITLE
feature:registry mirror support direct param.

### DIFF
--- a/dfdaemon/config/config.go
+++ b/dfdaemon/config/config.go
@@ -52,6 +52,8 @@ var fs = afero.NewOsFs()
 //       insecure: false
 //       # optional certificates if the remote server uses self-signed certificates
 //       certs: []
+//       # whether to request the remote registry directly
+//       direct: false
 //
 //     proxies:
 //     # proxy all http image layer download requests with dfget
@@ -174,6 +176,9 @@ type RegistryMirror struct {
 
 	// Whether to ignore certificates errors for the registry
 	Insecure bool `yaml:"insecure" json:"insecure"`
+
+	// Request the remote registry directly.
+	Direct bool `yaml:"direct" json:"direct"`
 }
 
 // TLSConfig returns the tls.Config used to communicate with the mirror

--- a/dfdaemon/proxy/proxy.go
+++ b/dfdaemon/proxy/proxy.go
@@ -179,6 +179,7 @@ func (proxy *Proxy) mirrorRegistry(w http.ResponseWriter, r *http.Request) {
 	t, err := transport.New(
 		transport.WithDownloader(proxy.downloadFactory()),
 		transport.WithTLS(proxy.registry.TLSConfig()),
+		transport.WithCondition(proxy.shouldUseDfgetForMirror),
 	)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to get transport: %v", err), http.StatusInternalServerError)
@@ -262,6 +263,12 @@ func (proxy *Proxy) shouldUseDfget(req *http.Request) bool {
 		}
 	}
 	return false
+}
+
+// shouldUseDfgetForMirror returns whether we should use dfget to proxy a request
+// when we use registry mirror.
+func (proxy *Proxy) shouldUseDfgetForMirror(req *http.Request) bool {
+	return proxy.registry != nil && !proxy.registry.Direct && transport.NeedUseGetter(req)
 }
 
 // tunnelHTTPS handles a CONNECT request and proxy an https request through an

--- a/dfdaemon/transport/transport.go
+++ b/dfdaemon/transport/transport.go
@@ -52,7 +52,7 @@ func New(opts ...Option) (*DFRoundTripper, error) {
 	rt := &DFRoundTripper{
 		Round:          defaultHTTPTransport(nil),
 		Round2:         http.NewFileTransport(http.Dir("/")),
-		ShouldUseDfget: needUseGetter,
+		ShouldUseDfget: NeedUseGetter,
 	}
 
 	for _, opt := range opts {
@@ -162,6 +162,6 @@ func (roundTripper *DFRoundTripper) downloadByGetter(url string, header map[stri
 
 // needUseGetter is the default value for ShouldUseDfget, which downloads all
 // images layers with dfget.
-func needUseGetter(req *http.Request) bool {
+func NeedUseGetter(req *http.Request) bool {
 	return req.Method == http.MethodGet && layerReg.MatchString(req.URL.Path)
 }


### PR DESCRIPTION
Signed-off-by: zhouchencheng <zhouchencheng@bilibili.com>

### Ⅰ. Describe what this PR did
I find that there is no config item `direct=true` in `registry_mirror` just like in `proxy`.
It is necessary for us to support this config, because in some cases we want to make some nodes pull image from remote registry directly.

### Ⅱ. Does this pull request fix one issue?


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


