### PR TITLE
bugfix: reduce error logs when download home dir not exist

### DIFF
--- a/supernode/daemon/mgr/cdn/cache_detector.go
+++ b/supernode/daemon/mgr/cdn/cache_detector.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dragonflyoss/Dragonfly/supernode/httpclient"
 	"github.com/dragonflyoss/Dragonfly/supernode/store"
 
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -59,7 +60,7 @@ func (cd *cacheDetector) detectCache(ctx context.Context, task *types.TaskInfo) 
 
 	if breakNum == 0 {
 		if metaData, err = cd.resetRepo(ctx, task); err != nil {
-			return 0, nil, err
+			return 0, nil, errors.Wrapf(err, "failed to reset repo")
 		}
 	} else {
 		logrus.Debugf("start to update access time with taskID(%s)", task.ID)
@@ -120,7 +121,7 @@ func (cd *cacheDetector) parseBreakNumByCheckFile(ctx context.Context, taskID st
 func (cd *cacheDetector) resetRepo(ctx context.Context, task *types.TaskInfo) (*fileMetaData, error) {
 	logrus.Infof("reset repo for taskID: %s", task.ID)
 	if err := deleteTaskFiles(ctx, cd.cacheStore, task.ID); err != nil {
-		return nil, err
+		logrus.Errorf("reset repo: failed to delete task(%s) files: %v", task.ID, err)
 	}
 
 	return cd.metaDataManager.writeFileMetaDataByTask(ctx, task)

--- a/supernode/daemon/mgr/cdn/cdn_gc.go
+++ b/supernode/daemon/mgr/cdn/cdn_gc.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/emirpasic/gods/maps/treemap"
 	godsutils "github.com/emirpasic/gods/utils"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -41,7 +42,10 @@ func (cm *Manager) GetGCTaskIDs(ctx context.Context, taskMgr mgr.TaskMgr) ([]str
 
 	freeDisk, err := cm.cacheStore.GetAvailSpace(ctx, getHomeRawFunc())
 	if err != nil {
-		return nil, err
+		if store.IsKeyNotFound(err) {
+			return nil, nil
+		}
+		return nil, errors.Wrapf(err, "failed to get avail space")
 	}
 	if freeDisk > cm.cfg.YoungGCThreshold {
 		return nil, nil

--- a/supernode/store/local_storage.go
+++ b/supernode/store/local_storage.go
@@ -309,7 +309,7 @@ func (ls *localStorage) statPath(bucket, key string) (string, os.FileInfo, error
 	f, err := os.Stat(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return "", nil, errors.Wrapf(ErrKeyNotFound, "key: %s", key)
+			return "", nil, errors.Wrapf(ErrKeyNotFound, "bucket(%s) key(%s)", bucket, key)
 		}
 		return "", nil, err
 	}


### PR DESCRIPTION
…me dir not exist

Signed-off-by: Starnop <starnopg@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

At present, gc disk will produce error logs continuously when download home dir not exist. And in this case, there is no need to do the gc job. So just return  directly in this PR.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


