### PR TITLE
bugfix:fix debug mod and homedir config in yaml

### DIFF
--- a/cmd/supernode/app/root.go
+++ b/cmd/supernode/app/root.go
@@ -51,6 +51,17 @@ var rootCmd = &cobra.Command{
 	Args:         cobra.NoArgs,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// load config file.
+		if err := readConfigFile(supernodeViper, cmd); err != nil {
+			return errors.Wrap(err, "read config file")
+		}
+
+		// get config from viper.
+		cfg, err := getConfigFromViper(supernodeViper)
+		if err != nil {
+			return errors.Wrap(err, "get config from viper")
+		}
+
 		// create home dir
 		if err := fileutils.CreateDirectory(supernodeViper.GetString("base.homeDir")); err != nil {
 			return fmt.Errorf("failed to create home dir %s: %v", supernodeViper.GetString("base.homeDir"), err)
@@ -65,17 +76,6 @@ var rootCmd = &cobra.Command{
 		dfgetLogger := logrus.New()
 		if err := initLog(dfgetLogger, "dfget.log"); err != nil {
 			return err
-		}
-
-		// load config file
-		if err := readConfigFile(supernodeViper, cmd); err != nil {
-			return errors.Wrap(err, "read config file")
-		}
-
-		// get config from viper
-		cfg, err := getConfigFromViper(supernodeViper)
-		if err != nil {
-			return errors.Wrap(err, "get config from viper")
 		}
 
 		// set supernode advertise ip


### PR DESCRIPTION
Signed-off-by: yunfeiyangbuaa <yunfeiyang@buaa.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
we can't config debug mod and homedir in yaml file because init config after init log and use option to config the log instead of cfg

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it
the yaml file is 

```
base:
  listenPort: 9002
  downloadPort: 9001
  advertiseIP: 102.168.50.156
  failAccessInterval: 2m0s
  gcInitialDelay: 3s
  gcMetaInterval: 10m0s
  taskExpireTime: 2m0s
  peerGCDelay: 100m0s
  gcDiskInterval: 120s
  debug: true
```
the command is 

`sudo go run main.go  --config  /home/yunfeiyang/yml/supernode.yml  --port  8090  --advertise-ip 127.0.0.2`
 the config result is 

```
2019-10-10 15:35:44.417 DEBU sign:16151 : get supernode config: base:
  listenPort: 8090
  downloadPort: 9001
  homeDir: /home/admin/supernode
  schedulerCorePoolSize: 10
  downloadPath: /home/admin/supernode/repo/download
  peerUpLimit: 5
  peerDownLimit: 4
  eliminationLimit: 5
  failureCountLimit: 5
  linkLimit: 20480GB
  systemReservedBandwidth: 20480GB
  maxBandwidth: 204800GB
  enableProfiler: false
  debug: true
  advertiseIP: 127.0.0.2
  failAccessInterval: 2m0s
  gcInitialDelay: 3s
  gcMetaInterval: 10m0s
  taskExpireTime: 2m0s
  peerGCDelay: 1h40m0s
  gcDiskInterval: 2m0s
  youngGCThreshold: 100GB
  fullGCThreshold: 5GB
  IntervalThreshold: 2h0m0s
  cleanratio: 1
plugins: {}
storages: {}

```

### Ⅴ. Special notes for reviews


