### PR TITLE
bugfix: delete the default value for supernodes from dfdaemon

### DIFF
--- a/cmd/dfdaemon/app/root.go
+++ b/cmd/dfdaemon/app/root.go
@@ -95,7 +95,7 @@ func init() {
 	rf.String("localrepo", filepath.Join(os.Getenv("HOME"), ".small-dragonfly/dfdaemon/data/"), "temp output dir of dfdaemon")
 	rf.String("dfpath", defaultDfgetPath, "dfget path")
 	rf.Var(netutils.NetLimit(), "ratelimit", "net speed limit")
-	rf.StringSlice("node", []string{"127.0.0.1:8002"}, "specify the addresses(host:port) of supernodes that will be passed to dfget.")
+	rf.StringSlice("node", nil, "specify the addresses(host:port) of supernodes that will be passed to dfget.")
 
 	exitOnError(bindRootFlags(viper.GetViper()), "bind root command flags")
 }

--- a/cmd/dfdaemon/app/root_test.go
+++ b/cmd/dfdaemon/app/root_test.go
@@ -76,7 +76,7 @@ func (ts *rootTestSuite) TestNodeFlag() {
 		r.Equal([]string{"127.0.0.1:6666"}, cfg.SuperNodes)
 	}
 
-	// flag not set, config file doesn't exist, should use default
+	// flag not set, config file doesn't exist, should be nil
 	{
 		v := viper.New()
 		v.SetFs(fs)
@@ -86,7 +86,7 @@ func (ts *rootTestSuite) TestNodeFlag() {
 		r.NotNil(readConfigFile(v, rootCmd))
 		cfg, err := getConfigFromViper(rootCmd, v)
 		r.Nil(err)
-		r.Equal([]string{"127.0.0.1:8002"}, cfg.SuperNodes)
+		r.EqualValues([]string(nil), cfg.SuperNodes)
 	}
 
 	// when --node flag is set, should always use the flag

--- a/dfdaemon/downloader/dfget/dfget.go
+++ b/dfdaemon/downloader/dfget/dfget.go
@@ -77,7 +77,9 @@ func (dfGetter *DFGetter) getCommand(
 	}
 	add("-s", dfGetter.config.RateLimit)
 	add("--totallimit", dfGetter.config.RateLimit)
-	add("--node", strings.Join(dfGetter.config.SuperNodes, ","))
+	if len(dfGetter.config.SuperNodes) > 0 {
+		add("--node", strings.Join(dfGetter.config.SuperNodes, ","))
+	}
 
 	for key, value := range header {
 		// discard HTTP host header for backing to source successfully


### PR DESCRIPTION
Signed-off-by: Starnop <starnopg@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Somebody will define the dfget configuration by using dfget config file which locates at `/etc/dragonfly/dfget.yml`. And then they will feel confused about why dfget don't use the supernodes that I defined in the dfget config file. In fact, dfdaemon will specify a default value for supernodes and dfdaemon call the dfget by using cmd flags. So the default value defined by dfdaemon will override the dfget config. So I think we should delete the default value for supernode specified by dfdaemon.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
No need.


### Ⅳ. Describe how to verify it
1. config the nodes in the dfget config file and neither define the nodes through the configuration file nor through cli flags for dfdaemon
2. start to pull a file by dfdaemon

### Ⅴ. Special notes for reviews


