### PR TITLE
bug fix dfget client timeout set error when fileLength is 0

### DIFF
--- a/dfget/core/core.go
+++ b/dfget/core/core.go
@@ -179,7 +179,7 @@ func downloadFile(cfg *config.Config, supernodeAPI api.SupernodeAPI,
 
 	timeout := netutils.CalculateTimeout(cfg.RV.FileLength, cfg.MinRate, config.DefaultMinRate, 10*time.Second)
 	if timeout == 0 && cfg.Timeout > 0 {
-		timeout = time.Duration(cfg.Timeout) * time.Second
+		timeout = cfg.Timeout
 	}
 	success := true
 	err := downloader.DoDownloadTimeout(getter, timeout)


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
bug fix dfget client timeout set error when fileLength is 0

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
bug fix dfget client timeout set error when fileLength is 0

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it
use dfget and set timeout

### Ⅴ. Special notes for reviews


