### PR TITLE
feature: prohibit the IPv6 to communicate with supernode

### DIFF
--- a/pkg/httputils/http_util.go
+++ b/pkg/httputils/http_util.go
@@ -312,7 +312,9 @@ func CheckConnect(ip string, port int, timeout int) (localIP string, e error) {
 
 	var conn net.Conn
 	addr := fmt.Sprintf("%s:%d", ip, port)
-	if conn, e = net.DialTimeout("tcp", addr, t); e == nil {
+	// Just temporarily limit users can only use IP addr for IPv4 format.
+	// In the near future, if we want to support IPv6, we can revise logic as below.
+	if conn, e = net.DialTimeout("tcp4", addr, t); e == nil {
 		localIP = conn.LocalAddr().String()
 		conn.Close()
 		if idx := strings.LastIndexByte(localIP, ':'); idx >= 0 {

--- a/pkg/httputils/http_util_test.go
+++ b/pkg/httputils/http_util_test.go
@@ -118,6 +118,10 @@ func (s *HTTPUtilTestSuite) TestCheckConnect(c *check.C) {
 	ip, e := CheckConnect("127.0.0.1", s.port, 0)
 	c.Assert(e, check.IsNil)
 	c.Assert(ip, check.Equals, "127.0.0.1")
+
+	// Test IPv6
+	_, e = CheckConnect("[::1]", s.port, 0)
+	c.Assert(e, check.NotNil)
 }
 
 func (s *HTTPUtilTestSuite) TestGetRangeSE(c *check.C) {


### PR DESCRIPTION
Signed-off-by: fengzixu <hnustphoenix@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

For prohibiting the IPv6, we have two methods

1. validate the IP addr which was passed by parameters in dfclient side
2. validate the IP addr in supernode side

Both methods will throw an error when users use the IPv6 address as the IP of dfget.
Before we support the IPv6 in Dragonfly, we can prohibit using IPv6 in dfclient.
### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


