### PR TITLE
feature: support init from environment variables for dfdaemon and supernode

### DIFF
--- a/cmd/dfdaemon/app/root.go
+++ b/cmd/dfdaemon/app/root.go
@@ -39,6 +39,12 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const (
+	// DFDaemonEnvPrefix is the default environment prefix for Viper.
+	// Both BindEnv and AutomaticEnv will use this prefix.
+	DFDaemonEnvPrefix = "dfdaemon"
+)
+
 var rootCmd = &cobra.Command{
 	Use:               "dfdaemon",
 	Short:             "The dfdaemon is a proxy that intercepts image download requests.",
@@ -106,7 +112,13 @@ func bindRootFlags(v *viper.Viper) error {
 	if err := v.BindPFlags(rootCmd.Flags()); err != nil {
 		return err
 	}
-	return v.BindPFlag("registry_mirror.remote", rootCmd.Flag("registry"))
+	if err := v.BindPFlag("registry_mirror.remote", rootCmd.Flag("registry")); err != nil {
+		return err
+	}
+	v.SetEnvPrefix(DFDaemonEnvPrefix)
+	v.AutomaticEnv()
+
+	return nil
 }
 
 // readConfigFile reads config file into the given viper instance. If we're

--- a/cmd/dfdaemon/app/root_test.go
+++ b/cmd/dfdaemon/app/root_test.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -134,6 +135,28 @@ func (ts *rootTestSuite) TestBindRootFlags() {
 	v := viper.New()
 	r.Nil(bindRootFlags(v))
 	r.Equal(v.GetString("registry"), v.GetString("registry_mirror.remote"))
+}
+
+func (ts *rootTestSuite) TestAutomaticEnv() {
+	r := ts.Require()
+	v := viper.New()
+	r.Nil(bindRootFlags(v))
+
+	maxprocsEnvKey := strings.ToUpper(DFDaemonEnvPrefix + "_maxprocs")
+	workHomeEnvKey := strings.ToUpper(DFDaemonEnvPrefix + "_workHome")
+	registryEnvKey := strings.ToUpper(DFDaemonEnvPrefix + "_registry_mirror.remote")
+
+	os.Setenv(maxprocsEnvKey, "17")
+	os.Setenv(workHomeEnvKey, "/dragonfly/home")
+	os.Setenv(registryEnvKey, "https://dragonfly.io")
+
+	r.Equal(17, v.GetInt("maxprocs"))
+	r.Equal("/dragonfly/home", v.GetString("workHome"))
+	r.Equal("https://dragonfly.io", v.GetString("registry_mirror.remote"))
+
+	os.Unsetenv(maxprocsEnvKey)
+	os.Unsetenv(workHomeEnvKey)
+	os.Unsetenv(registryEnvKey)
 }
 
 var testCrt = `-----BEGIN CERTIFICATE-----

--- a/cmd/supernode/app/root.go
+++ b/cmd/supernode/app/root.go
@@ -41,6 +41,12 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const (
+	// SupernodeEnvPrefix is the default environment prefix for Viper.
+	// Both BindEnv and AutomaticEnv will use this prefix.
+	SupernodeEnvPrefix = "supernode"
+)
+
 var (
 	supernodeViper = viper.GetViper()
 )
@@ -259,6 +265,10 @@ func bindRootFlags(v *viper.Viper) error {
 			return err
 		}
 	}
+
+	v.SetEnvPrefix(SupernodeEnvPrefix)
+	v.AutomaticEnv()
+
 	return nil
 }
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
feature: support init from environment variables for dfdaemon and supernode

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
Ref:  #959

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


/cc @Starnop 