### PR TITLE
Using path/filepath instead of path for file operations

### DIFF
--- a/cmd/dfget/app/root.go
+++ b/cmd/dfget/app/root.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"os"
 	"os/user"
-	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -169,11 +169,11 @@ func initProperties() ([]*propertiesResult, error) {
 	if cfg.WorkHome == "" {
 		cfg.WorkHome = properties.WorkHome
 		if cfg.WorkHome == "" {
-			cfg.WorkHome = path.Join(currentUser.HomeDir, ".small-dragonfly")
+			cfg.WorkHome = filepath.Join(currentUser.HomeDir, ".small-dragonfly")
 		}
 	}
-	cfg.RV.MetaPath = path.Join(cfg.WorkHome, "meta", "host.meta")
-	cfg.RV.SystemDataDir = path.Join(cfg.WorkHome, "data")
+	cfg.RV.MetaPath = filepath.Join(cfg.WorkHome, "meta", "host.meta")
+	cfg.RV.SystemDataDir = filepath.Join(cfg.WorkHome, "data")
 	cfg.RV.FileLength = -1
 
 	return results, nil
@@ -185,7 +185,7 @@ func initProperties() ([]*propertiesResult, error) {
 // while console log will output the dfget client's log in console/terminal for
 // debugging usage.
 func initClientLog() error {
-	logFilePath := path.Join(cfg.WorkHome, "logs", "dfclient.log")
+	logFilePath := filepath.Join(cfg.WorkHome, "logs", "dfclient.log")
 
 	opts := []dflog.Option{
 		dflog.WithLogFile(logFilePath),

--- a/cmd/dfget/app/server.go
+++ b/cmd/dfget/app/server.go
@@ -17,7 +17,7 @@
 package app
 
 import (
-	"path"
+	"path/filepath"
 
 	"github.com/dragonflyoss/Dragonfly/dfget/config"
 	"github.com/dragonflyoss/Dragonfly/dfget/core/uploader"
@@ -82,7 +82,7 @@ func runServer() error {
 }
 
 func initServerLog() error {
-	logFilePath := path.Join(cfg.WorkHome, "logs", "dfserver.log")
+	logFilePath := filepath.Join(cfg.WorkHome, "logs", "dfserver.log")
 
 	opts := []dflog.Option{
 		dflog.WithLogFile(logFilePath),

--- a/cmd/supernode/app/root.go
+++ b/cmd/supernode/app/root.go
@@ -19,7 +19,6 @@ package app
 import (
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"reflect"
 	"time"
@@ -318,7 +317,7 @@ func decodeWithYAML(types ...reflect.Type) mapstructure.DecodeHookFunc {
 
 // initLog initializes log Level and log format.
 func initLog(logger *logrus.Logger, logPath string) error {
-	logFilePath := path.Join(supernodeViper.GetString("base.homeDir"), "logs", logPath)
+	logFilePath := filepath.Join(supernodeViper.GetString("base.homeDir"), "logs", logPath)
 
 	opts := []dflog.Option{
 		dflog.WithLogFile(logFilePath),

--- a/dfget/config/config_test.go
+++ b/dfget/config/config_test.go
@@ -23,7 +23,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/user"
-	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -84,7 +83,7 @@ func (suite *ConfigSuite) TestNewConfig(c *check.C) {
 
 	if curUser, err := user.Current(); err != nil {
 		c.Assert(cfg.User, check.Equals, curUser.Username)
-		c.Assert(cfg.WorkHome, check.Equals, path.Join(curUser.HomeDir, ".small-dragonfly"))
+		c.Assert(cfg.WorkHome, check.Equals, filepath.Join(curUser.HomeDir, ".small-dragonfly"))
 	}
 }
 

--- a/dfget/core/core.go
+++ b/dfget/core/core.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -89,7 +88,7 @@ func prepare(cfg *config.Config) (err error) {
 	rv := &cfg.RV
 
 	rv.RealTarget = cfg.Output
-	rv.TargetDir = path.Dir(rv.RealTarget)
+	rv.TargetDir = filepath.Dir(rv.RealTarget)
 	if err = fileutils.CreateDirectory(rv.TargetDir); err != nil {
 		return err
 	}
@@ -98,7 +97,7 @@ func prepare(cfg *config.Config) (err error) {
 		return err
 	}
 
-	if err = fileutils.CreateDirectory(path.Dir(rv.MetaPath)); err != nil {
+	if err = fileutils.CreateDirectory(filepath.Dir(rv.MetaPath)); err != nil {
 		return err
 	}
 	if err = fileutils.CreateDirectory(cfg.WorkHome); err != nil {
@@ -238,7 +237,7 @@ func createTempTargetFile(targetDir string, sign string) (name string, e error) 
 		return f.Name(), e
 	}
 
-	f, e = os.OpenFile(path.Join(targetDir, fmt.Sprintf("%s%d", prefix, rand.Uint64())),
+	f, e = os.OpenFile(filepath.Join(targetDir, fmt.Sprintf("%s%d", prefix, rand.Uint64())),
 		os.O_CREATE|os.O_EXCL, 0755)
 	if e == nil {
 		return f.Name(), e

--- a/dfget/core/core_test.go
+++ b/dfget/core/core_test.go
@@ -24,7 +24,7 @@ import (
 	"math/rand"
 	"net"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -65,7 +65,7 @@ func (s *CoreTestSuite) TearDownSuite(c *check.C) {
 func (s *CoreTestSuite) TestPrepare(c *check.C) {
 	buf := &bytes.Buffer{}
 	cfg := s.createConfig(buf)
-	cfg.Output = path.Join(s.workHome, "test.output")
+	cfg.Output = filepath.Join(s.workHome, "test.output")
 
 	err := prepare(cfg)
 	fmt.Printf("%s\nerror:%v", buf.String(), err)

--- a/dfget/core/downloader/back_downloader/back_downloader.go
+++ b/dfget/core/downloader/back_downloader/back_downloader.go
@@ -22,7 +22,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/dragonflyoss/Dragonfly/dfget/config"
 	"github.com/dragonflyoss/Dragonfly/dfget/core/downloader"
@@ -90,13 +90,13 @@ func (bd *BackDownloader) Run() error {
 		return err
 	}
 
-	printer.Printf("start download %s from the source station", path.Base(bd.Target))
-	logrus.Infof("start download %s from the source station", path.Base(bd.Target))
+	printer.Printf("start download %s from the source station", filepath.Base(bd.Target))
+	logrus.Infof("start download %s from the source station", filepath.Base(bd.Target))
 
 	defer bd.Cleanup()
 
 	prefix := "backsource." + bd.cfg.Sign + "."
-	if f, err = ioutil.TempFile(path.Dir(bd.Target), prefix); err != nil {
+	if f, err = ioutil.TempFile(filepath.Dir(bd.Target), prefix); err != nil {
 		return err
 	}
 	bd.tempFileName = f.Name()

--- a/dfget/core/downloader/back_downloader/back_downloader_test.go
+++ b/dfget/core/downloader/back_downloader/back_downloader_test.go
@@ -23,7 +23,7 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/dragonflyoss/Dragonfly/dfget/config"
@@ -64,8 +64,8 @@ func (s *BackDownloaderTestSuite) TearDownSuite(c *check.C) {
 }
 
 func (s *BackDownloaderTestSuite) TestBackDownloader_Run(c *check.C) {
-	testFileMd5 := helper.CreateTestFileWithMD5(path.Join(s.workHome, "download.test"), "test downloader")
-	dst := path.Join(s.workHome, "back.test")
+	testFileMd5 := helper.CreateTestFileWithMD5(filepath.Join(s.workHome, "download.test"), "test downloader")
+	dst := filepath.Join(s.workHome, "back.test")
 
 	cfg := helper.CreateConfig(nil, s.workHome)
 	bd := &BackDownloader{
@@ -102,7 +102,7 @@ func (s *BackDownloaderTestSuite) TestBackDownloader_Run(c *check.C) {
 }
 
 func (s *BackDownloaderTestSuite) TestBackDownloader_Run_NotExist(c *check.C) {
-	dst := path.Join(s.workHome, "back.test")
+	dst := filepath.Join(s.workHome, "back.test")
 
 	cfg := helper.CreateConfig(nil, s.workHome)
 	bd := &BackDownloader{

--- a/dfget/core/downloader/downloader_test.go
+++ b/dfget/core/downloader/downloader_test.go
@@ -19,7 +19,7 @@ package downloader
 import (
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -56,8 +56,8 @@ func (s *DownloaderTestSuite) TestMoveFile(c *check.C) {
 	tmp, _ := ioutil.TempDir("/tmp", "dfget-TestMoveFile-")
 	defer os.RemoveAll(tmp)
 
-	src := path.Join(tmp, "a")
-	dst := path.Join(tmp, "b")
+	src := filepath.Join(tmp, "a")
+	dst := filepath.Join(tmp, "b")
 	md5str := helper.CreateTestFileWithMD5(src, "hello")
 
 	err := MoveFile(src, dst, "x")

--- a/dfget/core/downloader/p2p_downloader/client_writer_test.go
+++ b/dfget/core/downloader/p2p_downloader/client_writer_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/dragonflyoss/Dragonfly/pkg/fileutils"
 
@@ -39,7 +39,7 @@ func init() {
 
 func (s *ClientWriterTestSuite) SetUpSuite(c *check.C) {
 	s.workHome, _ = ioutil.TempDir("/tmp", "dfget-ClientWriterTestSuite-")
-	serviceFilePath := path.Join(s.workHome, "cwtest.service")
+	serviceFilePath := filepath.Join(s.workHome, "cwtest.service")
 	s.serviceFile, _ = fileutils.OpenFile(serviceFilePath, os.O_RDWR|os.O_TRUNC|os.O_CREATE, 0755)
 }
 

--- a/dfget/core/helper/test_helper.go
+++ b/dfget/core/helper/test_helper.go
@@ -22,7 +22,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
-	"path"
+	"path/filepath"
 
 	api_types "github.com/dragonflyoss/Dragonfly/apis/types"
 	"github.com/dragonflyoss/Dragonfly/dfget/config"
@@ -41,9 +41,9 @@ func CreateConfig(writer io.Writer, workHome string) *config.Config {
 	}
 	cfg := config.NewConfig()
 	cfg.WorkHome = workHome
-	cfg.RV.MetaPath = path.Join(cfg.WorkHome, "meta", "host.meta")
-	cfg.RV.SystemDataDir = path.Join(cfg.WorkHome, "data")
-	fileutils.CreateDirectory(path.Dir(cfg.RV.MetaPath))
+	cfg.RV.MetaPath = filepath.Join(cfg.WorkHome, "meta", "host.meta")
+	cfg.RV.SystemDataDir = filepath.Join(cfg.WorkHome, "data")
+	fileutils.CreateDirectory(filepath.Dir(cfg.RV.MetaPath))
 	fileutils.CreateDirectory(cfg.RV.SystemDataDir)
 
 	logrus.StandardLogger().Out = writer

--- a/dfget/core/uploader/peer_server_executor_test.go
+++ b/dfget/core/uploader/peer_server_executor_test.go
@@ -23,7 +23,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -47,7 +47,7 @@ type PeerServerExecutorTestSuite struct {
 
 func (s *PeerServerExecutorTestSuite) SetUpSuite(c *check.C) {
 	s.workHome, _ = ioutil.TempDir("/tmp", "dfget-PeerServerTestSuite-")
-	s.script = path.Join(s.workHome, "script.sh")
+	s.script = filepath.Join(s.workHome, "script.sh")
 	s.writeScript("")
 	s.start()
 }

--- a/dfget/core/uploader/uploader_util_test.go
+++ b/dfget/core/uploader/uploader_util_test.go
@@ -21,7 +21,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/dragonflyoss/Dragonfly/dfget/config"
 	"github.com/dragonflyoss/Dragonfly/version"
@@ -86,7 +86,7 @@ func (s *UploaderUtilTestSuite) TestGeneratePort(c *check.C) {
 }
 
 func (s *UploaderUtilTestSuite) TestGetPort(c *check.C) {
-	metaPath := path.Join(s.workHome, "meta")
+	metaPath := filepath.Join(s.workHome, "meta")
 	port := getPortFromMeta(metaPath)
 	c.Assert(port, check.Equals, 0)
 
@@ -102,7 +102,7 @@ func (s *UploaderUtilTestSuite) TestGetPort(c *check.C) {
 
 func (s *UploaderUtilTestSuite) TestUpdateServicePortInMeta(c *check.C) {
 	expectedPort := 80
-	metaPath := path.Join(s.workHome, "meta")
+	metaPath := filepath.Join(s.workHome, "meta")
 	updateServicePortInMeta(metaPath, expectedPort)
 	port := getPortFromMeta(metaPath)
 	c.Assert(port, check.Equals, expectedPort)

--- a/pkg/fileutils/fileutils_test.go
+++ b/pkg/fileutils/fileutils_test.go
@@ -21,7 +21,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/user"
-	"path"
 	"path/filepath"
 	"testing"
 
@@ -57,17 +56,17 @@ func (s *FileUtilTestSuite) TearDownSuite(c *check.C) {
 }
 
 func (s *FileUtilTestSuite) TestCreateDirectory(c *check.C) {
-	dirPath := path.Join(s.tmpDir, "TestCreateDirectory")
+	dirPath := filepath.Join(s.tmpDir, "TestCreateDirectory")
 	err := CreateDirectory(dirPath)
 	c.Assert(err, check.IsNil)
 
-	f, _ := os.Create(path.Join(dirPath, "createFile"))
+	f, _ := os.Create(filepath.Join(dirPath, "createFile"))
 	err = CreateDirectory(f.Name())
 	c.Assert(err, check.NotNil)
 
 	os.Chmod(dirPath, 0555)
 	defer os.Chmod(dirPath, 0755)
-	err = CreateDirectory(path.Join(dirPath, "1"))
+	err = CreateDirectory(filepath.Join(dirPath, "1"))
 	if s.username != "root" {
 		c.Assert(err, check.NotNil)
 	} else {
@@ -76,7 +75,7 @@ func (s *FileUtilTestSuite) TestCreateDirectory(c *check.C) {
 }
 
 func (s *FileUtilTestSuite) TestPathExists(c *check.C) {
-	pathStr := path.Join(s.tmpDir, "TestPathExists")
+	pathStr := filepath.Join(s.tmpDir, "TestPathExists")
 	c.Assert(PathExist(pathStr), check.Equals, false)
 
 	os.Create(pathStr)
@@ -84,7 +83,7 @@ func (s *FileUtilTestSuite) TestPathExists(c *check.C) {
 }
 
 func (s *FileUtilTestSuite) TestIsDir(c *check.C) {
-	pathStr := path.Join(s.tmpDir, "TestIsDir")
+	pathStr := filepath.Join(s.tmpDir, "TestIsDir")
 	c.Assert(IsDir(pathStr), check.Equals, false)
 
 	os.Create(pathStr)
@@ -96,24 +95,24 @@ func (s *FileUtilTestSuite) TestIsDir(c *check.C) {
 }
 
 func (s *FileUtilTestSuite) TestDeleteFile(c *check.C) {
-	pathStr := path.Join(s.tmpDir, "TestDeleteFile")
+	pathStr := filepath.Join(s.tmpDir, "TestDeleteFile")
 	os.Create(pathStr)
 	err := DeleteFile(pathStr)
 	c.Assert(err, check.IsNil)
 
-	dirStr := path.Join(s.tmpDir, "test_delete_file")
+	dirStr := filepath.Join(s.tmpDir, "test_delete_file")
 	os.Mkdir(dirStr, 0000)
 	err = DeleteFile(dirStr)
 	c.Assert(err, check.NotNil)
 
-	f := path.Join(s.tmpDir, "test", "empty", "file")
+	f := filepath.Join(s.tmpDir, "test", "empty", "file")
 	err = DeleteFile(f)
 	c.Assert(err, check.NotNil)
 }
 
 func (s *FileUtilTestSuite) TestDeleteFiles(c *check.C) {
-	f1 := path.Join(s.tmpDir, "TestDeleteFile001")
-	f2 := path.Join(s.tmpDir, "TestDeleteFile002")
+	f1 := filepath.Join(s.tmpDir, "TestDeleteFile001")
+	f2 := filepath.Join(s.tmpDir, "TestDeleteFile002")
 	os.Create(f1)
 	//os.Create(f2)
 	DeleteFiles(f1, f2)
@@ -122,8 +121,8 @@ func (s *FileUtilTestSuite) TestDeleteFiles(c *check.C) {
 
 func (s *FileUtilTestSuite) TestMoveFile(c *check.C) {
 
-	f1 := path.Join(s.tmpDir, "TestMovefileSrc01")
-	f2 := path.Join(s.tmpDir, "TestMovefileDstExist")
+	f1 := filepath.Join(s.tmpDir, "TestMovefileSrc01")
+	f2 := filepath.Join(s.tmpDir, "TestMovefileDstExist")
 	os.Create(f1)
 	os.Create(f2)
 	ioutil.WriteFile(f1, []byte("Test move file src"), 0755)
@@ -134,8 +133,8 @@ func (s *FileUtilTestSuite) TestMoveFile(c *check.C) {
 	f2Md5 := Md5Sum(f2)
 	c.Assert(f1Md5, check.Equals, f2Md5)
 
-	f3 := path.Join(s.tmpDir, "TestMovefileSrc02")
-	f4 := path.Join(s.tmpDir, "TestMovefileDstNonExist")
+	f3 := filepath.Join(s.tmpDir, "TestMovefileSrc02")
+	f4 := filepath.Join(s.tmpDir, "TestMovefileDstNonExist")
 	os.Create(f3)
 	ioutil.WriteFile(f3, []byte("Test move file src when dst not exist"), 0755)
 	f3Md5 := Md5Sum(f3)
@@ -144,47 +143,47 @@ func (s *FileUtilTestSuite) TestMoveFile(c *check.C) {
 	f4Md5 := Md5Sum(f4)
 	c.Assert(f3Md5, check.Equals, f4Md5)
 
-	f1 = path.Join(s.tmpDir, "TestMovefileSrcDir")
+	f1 = filepath.Join(s.tmpDir, "TestMovefileSrcDir")
 	os.Mkdir(f1, 0755)
 	err = MoveFile(f1, f2)
 	c.Assert(err, check.NotNil)
 }
 
 func (s *FileUtilTestSuite) TestOpenFile(c *check.C) {
-	f1 := path.Join(s.tmpDir, "dir1", "TestOpenFile")
+	f1 := filepath.Join(s.tmpDir, "dir1", "TestOpenFile")
 	_, err := OpenFile(f1, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0755)
 	c.Assert(err, check.IsNil)
 
-	f2 := path.Join(s.tmpDir, "TestOpenFile")
+	f2 := filepath.Join(s.tmpDir, "TestOpenFile")
 	os.Create(f2)
 	_, err = OpenFile(f2, os.O_RDONLY, 0666)
 	c.Assert(err, check.IsNil)
 }
 
 func (s *FileUtilTestSuite) TestLink(c *check.C) {
-	pathStr := path.Join(s.tmpDir, "TestLinkFile")
+	pathStr := filepath.Join(s.tmpDir, "TestLinkFile")
 	os.Create(pathStr)
-	linkStr := path.Join(s.tmpDir, "TestLinkName")
+	linkStr := filepath.Join(s.tmpDir, "TestLinkName")
 
 	err := Link(pathStr, linkStr)
 	c.Assert(err, check.IsNil)
 	c.Assert(PathExist(linkStr), check.Equals, true)
 
-	linkStr = path.Join(s.tmpDir, "TestLinkNameExist")
+	linkStr = filepath.Join(s.tmpDir, "TestLinkNameExist")
 	os.Create(linkStr)
 	err = Link(pathStr, linkStr)
 	c.Assert(err, check.IsNil)
 	c.Assert(PathExist(linkStr), check.Equals, true)
 
-	linkStr = path.Join(s.tmpDir, "testLinkNonExistDir")
+	linkStr = filepath.Join(s.tmpDir, "testLinkNonExistDir")
 	os.Mkdir(linkStr, 0755)
 	err = Link(pathStr, linkStr)
 	c.Assert(err, check.NotNil)
 }
 
 func (s *FileUtilTestSuite) TestCopyFile(c *check.C) {
-	srcPath := path.Join(s.tmpDir, "TestCopyFileSrc")
-	dstPath := path.Join(s.tmpDir, "TestCopyFileDst")
+	srcPath := filepath.Join(s.tmpDir, "TestCopyFileSrc")
+	dstPath := filepath.Join(s.tmpDir, "TestCopyFileDst")
 	err := CopyFile(srcPath, dstPath)
 	c.Assert(err, check.NotNil)
 
@@ -194,14 +193,14 @@ func (s *FileUtilTestSuite) TestCopyFile(c *check.C) {
 	err = CopyFile(srcPath, dstPath)
 	c.Assert(err, check.NotNil)
 
-	tmpPath := path.Join(s.tmpDir, "TestCopyFileTmp")
+	tmpPath := filepath.Join(s.tmpDir, "TestCopyFileTmp")
 	err = CopyFile(srcPath, tmpPath)
 	c.Assert(err, check.IsNil)
 }
 
 func (s *FileUtilTestSuite) TestMoveFileAfterCheckMd5(c *check.C) {
-	srcPath := path.Join(s.tmpDir, "TestMoveFileAfterCheckMd5Src")
-	dstPath := path.Join(s.tmpDir, "TestMoveFileAfterCheckMd5Dst")
+	srcPath := filepath.Join(s.tmpDir, "TestMoveFileAfterCheckMd5Src")
+	dstPath := filepath.Join(s.tmpDir, "TestMoveFileAfterCheckMd5Dst")
 	os.Create(srcPath)
 	ioutil.WriteFile(srcPath, []byte("Test move file after check md5"), 0755)
 	srcPathMd5 := Md5Sum(srcPath)
@@ -214,14 +213,14 @@ func (s *FileUtilTestSuite) TestMoveFileAfterCheckMd5(c *check.C) {
 	err = MoveFileAfterCheckMd5(srcPath, dstPath, srcPathMd5)
 	c.Assert(err, check.NotNil)
 
-	srcPath = path.Join(s.tmpDir, "TestMoveFileAfterCheckMd5Dir")
+	srcPath = filepath.Join(s.tmpDir, "TestMoveFileAfterCheckMd5Dir")
 	os.Mkdir(srcPath, 0755)
 	err = MoveFileAfterCheckMd5(srcPath, dstPath, srcPathMd5)
 	c.Assert(err, check.NotNil)
 }
 
 func (s *FileUtilTestSuite) TestMd5sum(c *check.C) {
-	pathStr := path.Join(s.tmpDir, "TestMd5Sum")
+	pathStr := filepath.Join(s.tmpDir, "TestMd5Sum")
 	_, _ = OpenFile(pathStr, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0000)
 	pathStrMd5 := Md5Sum(pathStr)
 	if s.username != "root" {
@@ -230,7 +229,7 @@ func (s *FileUtilTestSuite) TestMd5sum(c *check.C) {
 		c.Assert(pathStrMd5, check.Equals, "d41d8cd98f00b204e9800998ecf8427e")
 	}
 
-	pathStr = path.Join(s.tmpDir, "TestMd5SumDir")
+	pathStr = filepath.Join(s.tmpDir, "TestMd5SumDir")
 	os.Mkdir(pathStr, 0755)
 	pathStrMd5 = Md5Sum(pathStr)
 	c.Assert(pathStrMd5, check.Equals, "")

--- a/supernode/config/config_test.go
+++ b/supernode/config/config_test.go
@@ -19,7 +19,7 @@ package config
 import (
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-check/check"
@@ -62,7 +62,7 @@ func (s *SupernodeConfigTestSuite) TearDownSuite(c *check.C) {
 }
 
 func (s *SupernodeConfigTestSuite) TestConfig_Load(c *check.C) {
-	confPath := path.Join(s.workHome, "supernode.yml")
+	confPath := filepath.Join(s.workHome, "supernode.yml")
 	conf := NewConfig()
 	exp := &Config{}
 

--- a/supernode/store/local_storage.go
+++ b/supernode/store/local_storage.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/dragonflyoss/Dragonfly/pkg/fileutils"
@@ -73,7 +72,7 @@ func NewLocalStorage(conf string) (StorageDriver, error) {
 	}
 
 	// prepare the base dir
-	if !path.IsAbs(cfg.BaseDir) {
+	if !filepath.IsAbs(cfg.BaseDir) {
 		return nil, fmt.Errorf("not absolute path: %s", cfg.BaseDir)
 	}
 	if err := fileutils.CreateDirectory(cfg.BaseDir); err != nil {
@@ -243,7 +242,7 @@ func (ls *localStorage) Stat(ctx context.Context, raw *Raw) (*StorageInfo, error
 		return nil, fmt.Errorf("get create time error")
 	}
 	return &StorageInfo{
-		Path:       path.Join(raw.Bucket, raw.Key),
+		Path:       filepath.Join(raw.Bucket, raw.Key),
 		Size:       fileInfo.Size(),
 		CreateTime: statutils.Ctime(sys),
 		ModTime:    fileInfo.ModTime(),
@@ -293,19 +292,19 @@ func (ls *localStorage) Walk(ctx context.Context, raw *Raw) error {
 
 // preparePath gets the target path and creates the upper directory if it does not exist.
 func (ls *localStorage) preparePath(bucket, key string) (string, error) {
-	dir := path.Join(ls.BaseDir, bucket)
+	dir := filepath.Join(ls.BaseDir, bucket)
 
 	if err := fileutils.CreateDirectory(dir); err != nil {
 		return "", err
 	}
 
-	target := path.Join(dir, key)
+	target := filepath.Join(dir, key)
 	return target, nil
 }
 
 // statPath determines whether the target file exists and returns an fileMutex if so.
 func (ls *localStorage) statPath(bucket, key string) (string, os.FileInfo, error) {
-	filePath := path.Join(ls.BaseDir, bucket, key)
+	filePath := filepath.Join(ls.BaseDir, bucket, key)
 	f, err := os.Stat(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/supernode/store/local_storage_test.go
+++ b/supernode/store/local_storage_test.go
@@ -22,7 +22,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -55,7 +55,7 @@ func (s *LocalStorageSuite) SetUpSuite(c *check.C) {
 			&config.PluginProperties{
 				Name:    LocalStorageDriver,
 				Enabled: true,
-				Config:  "baseDir: " + path.Join(s.workHome, "repo"),
+				Config:  "baseDir: " + filepath.Join(s.workHome, "repo"),
 			},
 		},
 	}
@@ -321,7 +321,7 @@ func (s *LocalStorageSuite) BenchmarkPutSerial(c *check.C) {
 func (s *LocalStorageSuite) TestManager_Get(c *check.C) {
 	cfg := &config.Config{
 		BaseProperties: &config.BaseProperties{
-			HomeDir: path.Join(s.workHome, "test_mgr"),
+			HomeDir: filepath.Join(s.workHome, "test_mgr"),
 		},
 	}
 	mgr, _ := NewManager(cfg)
@@ -345,12 +345,12 @@ func (s *LocalStorageSuite) checkStat(raw *Raw, c *check.C) {
 	c.Assert(IsNilError(err), check.Equals, true)
 
 	driver := s.storeLocal.driver.(*localStorage)
-	pathTemp := path.Join(driver.BaseDir, raw.Bucket, raw.Key)
+	pathTemp := filepath.Join(driver.BaseDir, raw.Bucket, raw.Key)
 	f, _ := os.Stat(pathTemp)
 	sys, _ := fileutils.GetSys(f)
 
 	c.Assert(info, check.DeepEquals, &StorageInfo{
-		Path:       path.Join(raw.Bucket, raw.Key),
+		Path:       filepath.Join(raw.Bucket, raw.Key),
 		Size:       f.Size(),
 		ModTime:    f.ModTime(),
 		CreateTime: statutils.Ctime(sys),

--- a/supernode/store/store_mgr.go
+++ b/supernode/store/store_mgr.go
@@ -18,7 +18,7 @@ package store
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 	"sync"
 
 	"github.com/dragonflyoss/Dragonfly/supernode/config"
@@ -84,7 +84,7 @@ func (sm *Manager) getDefaultStorage() (*Store, error) {
 	if sm.cfg == nil {
 		return nil, fmt.Errorf("cannot init local storage without home path")
 	}
-	cfg := fmt.Sprintf("baseDir: %s", path.Join(sm.cfg.HomeDir, "repo"))
+	cfg := fmt.Sprintf("baseDir: %s", filepath.Join(sm.cfg.HomeDir, "repo"))
 	s, err := NewStore(LocalStorageDriver, NewLocalStorage, cfg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: SataQiu <1527062125@qq.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Using `path/filepath` instead of `path` for file operations.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1051 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


