### PR TITLE
bugfix: support truncate the file when put

### DIFF
--- a/supernode/daemon/mgr/cdn/path_util.go
+++ b/supernode/daemon/mgr/cdn/path_util.go
@@ -57,6 +57,7 @@ func getMetaDataRaw(taskID string) *store.Raw {
 	return &store.Raw{
 		Bucket: config.DownloadHome,
 		Key:    getMetaDataKey(taskID),
+		Trunc:  true,
 	}
 }
 
@@ -64,6 +65,7 @@ func getMd5DataRaw(taskID string) *store.Raw {
 	return &store.Raw{
 		Bucket: config.DownloadHome,
 		Key:    getMd5DataKey(taskID),
+		Trunc:  true,
 	}
 }
 

--- a/supernode/daemon/mgr/cdn/reporter.go
+++ b/supernode/daemon/mgr/cdn/reporter.go
@@ -142,7 +142,7 @@ func (re *reporter) processCacheByReadFile(ctx context.Context, taskID string, m
 		FileLength: result.fileLength,
 	}
 	if err := re.metaDataManager.updateStatusAndResult(ctx, taskID, fmd); err != nil {
-		logrus.Infof("failed to update status and result fileMetaData(%+v) for taskID(%s): %v", fmd, taskID, err)
+		logrus.Errorf("failed to update status and result fileMetaData(%+v) for taskID(%s): %v", fmd, taskID, err)
 		return nil, nil, err
 	}
 	logrus.Infof("success to update status and result fileMetaData(%+v) for taskID(%s)", fmd, taskID)

--- a/supernode/store/local_storage.go
+++ b/supernode/store/local_storage.go
@@ -174,7 +174,12 @@ func (ls *localStorage) Put(ctx context.Context, raw *Raw, data io.Reader) error
 	lock(path, raw.Offset, false)
 	defer unLock(path, raw.Offset, false)
 
-	f, err := fileutils.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0644)
+	var f *os.File
+	if raw.Trunc {
+		f, err = fileutils.OpenFile(path, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0644)
+	} else {
+		f, err = fileutils.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0644)
+	}
 	if err != nil {
 		return err
 	}
@@ -210,7 +215,12 @@ func (ls *localStorage) PutBytes(ctx context.Context, raw *Raw, data []byte) err
 	lock(path, raw.Offset, false)
 	defer unLock(path, raw.Offset, false)
 
-	f, err := fileutils.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0644)
+	var f *os.File
+	if raw.Trunc {
+		f, err = fileutils.OpenFile(path, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0644)
+	} else {
+		f, err = fileutils.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0644)
+	}
 	if err != nil {
 		return err
 	}

--- a/supernode/store/storage_driver.go
+++ b/supernode/store/storage_driver.go
@@ -76,6 +76,7 @@ type Raw struct {
 	Key    string
 	Offset int64
 	Length int64
+	Trunc  bool
 	WalkFn filepath.WalkFunc
 }
 


### PR DESCRIPTION
Signed-off-by: Starnop <starnopg@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

When we put data to the storage driver, it should be possible to choose whether it's erased firstly if it already exists. So I add a `trunc bool` field in this PR. And for the issue #1055, we should make  `trunc` as true.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1055 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


