### PR TITLE
feature: try to download from back source even if download timeout with dragonfly

### DIFF
--- a/dfget/core/downloader/downloader.go
+++ b/dfget/core/downloader/downloader.go
@@ -49,6 +49,7 @@ func DoDownloadTimeout(downloader Downloader, timeout time.Duration) error {
 	go func() {
 		ch <- downloader.Run()
 	}()
+
 	var err error
 	select {
 	case err = <-ch:

--- a/dfget/core/downloader/p2p_downloader/p2p_downloader.go
+++ b/dfget/core/downloader/p2p_downloader/p2p_downloader.go
@@ -18,6 +18,7 @@ package downloader
 
 import (
 	"bytes"
+	"fmt"
 	"math/rand"
 	"os"
 	"strconv"
@@ -26,7 +27,6 @@ import (
 	"github.com/dragonflyoss/Dragonfly/dfget/config"
 	"github.com/dragonflyoss/Dragonfly/dfget/core/api"
 	"github.com/dragonflyoss/Dragonfly/dfget/core/downloader"
-	backDown "github.com/dragonflyoss/Dragonfly/dfget/core/downloader/back_downloader"
 	"github.com/dragonflyoss/Dragonfly/dfget/core/helper"
 	"github.com/dragonflyoss/Dragonfly/dfget/core/regist"
 	"github.com/dragonflyoss/Dragonfly/dfget/types"
@@ -199,11 +199,8 @@ func (p2p *P2PDownloader) Run() error {
 			}
 		}
 
-		// NOTE: Should we call it directly here?
-		// Maybe we should return an error and let the caller decide whether to call it.
 		if p2p.cfg.BackSourceReason != 0 {
-			backDownloader := backDown.NewBackDownloader(p2p.cfg, p2p.RegisterResult)
-			return backDownloader.Run()
+			return fmt.Errorf("failed to download with %s pattern, reason: %d", p2p.cfg.Pattern, p2p.cfg.BackSourceReason)
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Starnop <starnopg@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
There is a probability that it will fail when dfget use `p2p` pattern to download the file from supernode. So the `dfget` should try to download from the source station again if the value of the `notbs` flag is false even if failed to download timeout with dragonfly.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


