### PR TITLE
feat(dfdaemon): add redirect to proxy rule

### DIFF
--- a/dfdaemon/config/config.go
+++ b/dfdaemon/config/config.go
@@ -64,6 +64,9 @@ var fs = afero.NewOsFs()
 //     # proxy requests directly, without dfget
 //     - regx: no-proxy-reg
 //       direct: true
+//     # proxy requests with redirect
+//     - regx: some-registry
+//       redirect: another-registry
 //
 //     hijack_https:
 //       # key pair used to hijack https requests
@@ -385,10 +388,12 @@ type Proxy struct {
 	Regx     *Regexp `yaml:"regx" json:"regx"`
 	UseHTTPS bool    `yaml:"use_https" json:"use_https"`
 	Direct   bool    `yaml:"direct" json:"direct"`
+	// Redirect is the host to redirect to, if not empty
+	Redirect string `yaml:"redirect" json:"redirect"`
 }
 
 // NewProxy returns a new proxy rule with given attributes.
-func NewProxy(regx string, useHTTPS bool, direct bool) (*Proxy, error) {
+func NewProxy(regx string, useHTTPS bool, direct bool, redirect string) (*Proxy, error) {
 	exp, err := NewRegexp(regx)
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid regexp")
@@ -398,6 +403,7 @@ func NewProxy(regx string, useHTTPS bool, direct bool) (*Proxy, error) {
 		Regx:     exp,
 		UseHTTPS: useHTTPS,
 		Direct:   direct,
+		Redirect: redirect,
 	}, nil
 }
 

--- a/dfdaemon/config/config_test.go
+++ b/dfdaemon/config/config_test.go
@@ -220,7 +220,7 @@ func (ts *configTestSuite) TestProxyNew() {
 		validRegexp := ".*"
 		useHTTPS := false
 		direct := false
-		p, err := NewProxy(validRegexp, useHTTPS, direct)
+		p, err := NewProxy(validRegexp, useHTTPS, direct, "")
 		r.Nil(err)
 		r.NotNil(p)
 		r.Equal(useHTTPS, p.UseHTTPS)
@@ -229,7 +229,7 @@ func (ts *configTestSuite) TestProxyNew() {
 	}
 
 	{
-		p, err := NewProxy(`\K`, false, false)
+		p, err := NewProxy(`\K`, false, false, "")
 		r.Nil(p)
 		r.NotNil(err)
 		r.True(strings.HasPrefix(err.Error(), "invalid regexp:"))
@@ -238,7 +238,7 @@ func (ts *configTestSuite) TestProxyNew() {
 
 func (ts *configTestSuite) TestProxyMatch() {
 	r := ts.Require()
-	p, err := NewProxy("blobs/sha256.*", false, false)
+	p, err := NewProxy("blobs/sha256.*", false, false, "")
 	r.Nil(err)
 	r.NotNil(p)
 

--- a/dfdaemon/proxy/proxy.go
+++ b/dfdaemon/proxy/proxy.go
@@ -259,6 +259,10 @@ func (proxy *Proxy) shouldUseDfget(req *http.Request) bool {
 			if rule.UseHTTPS {
 				req.URL.Scheme = "https"
 			}
+			if rule.Redirect != "" {
+				req.URL.Host = rule.Redirect
+				req.Host = rule.Redirect
+			}
 			return !rule.Direct
 		}
 	}


### PR DESCRIPTION
Signed-off-by: inoc603 <inoc603@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Allow dfdaemon to redirect proxy request to another host.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #1046 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it

Start dfdaemon with the following config:

```yaml
proxies:
  - regx: google.com
    redirect: github.com
```

Use `curl` to verify that the redirect

```
http_proxy=127.0.0.1:65001 curl -v http://google.com
```

### Ⅴ. Special notes for reviews


