### PR TITLE
feature: add 'config default' command to print the default configuration of components

### DIFF
--- a/cmd/dfdaemon/app/root.go
+++ b/cmd/dfdaemon/app/root.go
@@ -106,7 +106,10 @@ func init() {
 	rf.StringSlice("node", nil, "specify the addresses(host:port) of supernodes that will be passed to dfget.")
 
 	exitOnError(bindRootFlags(viper.GetViper()), "bind root command flags")
+
+	// add sub commands
 	rootCmd.AddCommand(cmd.NewGenDocCommand("dfdaemon"))
+	rootCmd.AddCommand(cmd.NewConfigCommand("dfdaemon", getDefaultConfig))
 }
 
 // bindRootFlags binds flags on rootCmd to the given viper instance.
@@ -157,6 +160,11 @@ func Execute() {
 			os.Exit(1)
 		}
 	}
+}
+
+// getDefaultConfig returns the default configuration of dfdaemon
+func getDefaultConfig() (interface{}, error) {
+	return getConfigFromViper(rootCmd, viper.GetViper())
 }
 
 // getConfigFromViper returns dfdaemon config from the given viper instance

--- a/cmd/supernode/app/root.go
+++ b/cmd/supernode/app/root.go
@@ -122,7 +122,10 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	setupFlags(rootCmd)
+
+	// add sub commands
 	rootCmd.AddCommand(cmd.NewGenDocCommand("supernode"))
+	rootCmd.AddCommand(cmd.NewConfigCommand("supernode", getDefaultConfig))
 }
 
 // setupFlags setups flags for command line.
@@ -295,6 +298,11 @@ func readConfigFile(v *viper.Viper, cmd *cobra.Command) error {
 	}
 
 	return nil
+}
+
+// getDefaultConfig returns the default configuration of supernode
+func getDefaultConfig() (interface{}, error) {
+	return getConfigFromViper(viper.GetViper())
 }
 
 // getConfigFromViper returns supernode config from the given viper instance

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/dragonflyoss/Dragonfly/pkg/printer"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+// NewConfigCommand returns cobra.Command for "<component> config" command
+func NewConfigCommand(componentName string, defaultComponentConfigFunc func() (interface{}, error)) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: fmt.Sprintf("Manage the configurations of %s", componentName),
+		Args:  cobra.NoArgs,
+	}
+
+	cmd.AddCommand(newConfigPrintDefaultCommand(componentName, defaultComponentConfigFunc))
+	return cmd
+}
+
+// newConfigPrintDefaultCommand returns cobra.Command for "<component> config default" command
+func newConfigPrintDefaultCommand(componentName string, defaultComponentConfigFunc func() (interface{}, error)) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "default",
+		Short:         fmt.Sprintf("Print the default configurations of %s in yaml format", componentName),
+		Args:          cobra.NoArgs,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runConfigPrintDefault(defaultComponentConfigFunc)
+		},
+	}
+	return cmd
+}
+
+func runConfigPrintDefault(defaultComponentConfigFunc func() (interface{}, error)) error {
+	cfg, err := defaultComponentConfigFunc()
+	if err != nil {
+		return errors.Wrap(err, "failed to get component default configurations")
+	}
+	d, err := yaml.Marshal(cfg)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal component default configurations")
+	}
+	printer.Print(string(d))
+	return nil
+}

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -35,6 +35,13 @@ type StdPrinter struct {
 }
 
 // Println outputs info to console directly.
+func (sp *StdPrinter) Print(msg string) {
+	if sp.Out != nil {
+		fmt.Fprint(sp.Out, msg)
+	}
+}
+
+// Println outputs info to console directly.
 func (sp *StdPrinter) Println(msg string) {
 	if sp.Out != nil {
 		fmt.Fprintln(sp.Out, msg)
@@ -45,6 +52,13 @@ func (sp *StdPrinter) Println(msg string) {
 func (sp *StdPrinter) Printf(format string, a ...interface{}) {
 	if sp.Out != nil {
 		fmt.Fprintf(sp.Out, format+"\n", a...)
+	}
+}
+
+// Print outputs info to console directly.
+func Print(msg string) {
+	if Printer.Out != nil {
+		fmt.Fprint(Printer.Out, msg)
 	}
 }
 


### PR DESCRIPTION

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
feature: add 'config default' command to print the default configuration of components

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

ref: #1069


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it
```sh
dfdaemon config default
dfget config default
supernode config default
```

### Ⅴ. Special notes for reviews

/cc @Starnop 
