### PR TITLE
bugfix: lock file before check server port

### DIFF
--- a/dfget/core/uploader/peer_server_executor.go
+++ b/dfget/core/uploader/peer_server_executor.go
@@ -82,6 +82,10 @@ func (pe *peerServerExecutor) StartPeerServerProcess(cfg *config.Config) (port i
 	}
 	defer fileLock.Unlock()
 
+	if port = pe.checkPeerServerExist(cfg, 0); port > 0 {
+		return port, nil
+	}
+
 	cmd := exec.Command(os.Args[0], "server",
 		"--ip", cfg.RV.LocalIP,
 		"--port", strconv.Itoa(cfg.RV.PeerPort),


### PR DESCRIPTION
Signed-off-by: zhouchencheng <zhouchencheng@bilibili.com>

### Ⅰ. Describe what this PR did
Meta dir should be locked before `checkPeerServerExist`. Otherwise, any processes that wait for the lock will execute dfget server command again.


### Ⅱ. Does this pull request fix one issue?
fixes #1086 


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


