### PR TITLE
fix the "index out of range" error when the length of speed is 0.

### DIFF
--- a/pkg/netutils/netutils.go
+++ b/pkg/netutils/netutils.go
@@ -98,7 +98,7 @@ func NetLimit() *rate.Rate {
 				continue
 			}
 			speed := compile.FindStringSubmatch(fields[1])
-			if len(speed) == 0 {
+			if len(speed) <= 1 {
 				continue
 			}
 			if tmpLimit, err := strconv.ParseUint(speed[1], 0, 32); err == nil {

--- a/pkg/netutils/netutils.go
+++ b/pkg/netutils/netutils.go
@@ -98,6 +98,9 @@ func NetLimit() *rate.Rate {
 				continue
 			}
 			speed := compile.FindStringSubmatch(fields[1])
+			if len(speed) == 0 {
+				continue
+			}
 			if tmpLimit, err := strconv.ParseUint(speed[1], 0, 32); err == nil {
 				tmpLimit = tmpLimit / 8
 				if tmpLimit > maxInterfaceLimit {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
fix the "index out of range" error when the length of speed is 0.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

dfdaemon -h

ERRO[0000] parse default net limit error:runtime error: index out of range
panic: value method github.com/dragonflyoss/Dragonfly/pkg/rate.Rate.String called using nil *Rate pointer
goroutine 1 [running]:
github.com/dragonflyoss/Dragonfly/pkg/rate.(*Rate).String(0x0, 0x253, 0x0)
:1 +0x5f
github.com/spf13/pflag.(*FlagSet).VarPF(0xc0001a6600, 0xbd4160, 0x0, 0xae7ace, 0x9, 0x0, 0x0, 0xaeba0c, 0xf, 0xa)
/go/pkg/mod/github.com/spf13/pflag@v1.0.3/flag.go:817 +0x35
github.com/spf13/pflag.(*FlagSet).VarP(...)
/go/pkg/mod/github.com/spf13/pflag@v1.0.3/flag.go:825
github.com/spf13/pflag.(*FlagSet).Var(...)
/go/pkg/mod/github.com/spf13/pflag@v1.0.3/flag.go:806
github.com/dragonflyoss/Dragonfly/cmd/dfdaemon/app.init.1()
/go/src/github.com/dragonflyoss/Dragonfly/cmd/dfdaemon/app/root.go:104 +0x660

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


