### PR TITLE
bugfix: disable displaying auto generation tag in cli docs for supernode

### DIFF
--- a/cmd/supernode/app/root.go
+++ b/cmd/supernode/app/root.go
@@ -57,11 +57,12 @@ It's the tracker and scheduler in the P2P network that choose appropriate downlo
 It's also a CDN server that caches downloaded data from source to avoid downloading the same files from source repeatedly.`
 
 var rootCmd = &cobra.Command{
-	Use:          "supernode",
-	Short:        "the central control server of Dragonfly used for scheduling and cdn cache",
-	Long:         supernodeDescription,
-	Args:         cobra.NoArgs,
-	SilenceUsage: true,
+	Use:               "supernode",
+	Short:             "the central control server of Dragonfly used for scheduling and cdn cache",
+	Long:              supernodeDescription,
+	Args:              cobra.NoArgs,
+	DisableAutoGenTag: true, // disable displaying auto generation tag in cli docs
+	SilenceUsage:      true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// load config file.
 		if err := readConfigFile(supernodeViper, cmd); err != nil {


### PR DESCRIPTION
Signed-off-by: Starnop <starnopg@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
The generated doc of supernode by spf13/cobra will display auto-generation tag in cli docs which like this
> ###### Auto generated by spf13/cobra on 29-Nov-2019

We should disable it.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


