### PR TITLE
fix: unset the default value of totallimit

### DIFF
--- a/cmd/dfget/app/root_test.go
+++ b/cmd/dfget/app/root_test.go
@@ -39,7 +39,7 @@ func (suit *dfgetSuit) Test_initFlagsNoArguments() {
 	initProperties()
 	suit.Equal(cfg.Nodes, []string{"127.0.0.1:8002"})
 	suit.Equal(cfg.LocalLimit, 20*rate.MB)
-	suit.Equal(cfg.TotalLimit, 20*rate.MB)
+	suit.Equal(cfg.TotalLimit, rate.Rate(0))
 	suit.Equal(cfg.Notbs, false)
 	suit.Equal(cfg.DFDaemon, false)
 	suit.Equal(cfg.Console, false)

--- a/dfget/config/config.go
+++ b/dfget/config/config.go
@@ -96,7 +96,6 @@ func NewProperties() *Properties {
 		LocalLimit:      DefaultLocalLimit,
 		MinRate:         DefaultMinRate,
 		ClientQueueSize: DefaultClientQueueSize,
-		TotalLimit:      DefaultTotalLimit,
 	}
 }
 

--- a/dfget/config/constants.go
+++ b/dfget/config/constants.go
@@ -52,7 +52,6 @@ const (
 	DefaultNode            = "127.0.0.1"
 	DefaultLocalLimit      = 20 * rate.MB
 	DefaultMinRate         = 64 * rate.KB
-	DefaultTotalLimit      = 20 * rate.MB
 	DefaultClientQueueSize = 6
 	DefaultSupernodeWeight = 1
 )


### PR DESCRIPTION
Signed-off-by: lowzj <zj3142063@gmail.com>

### Ⅰ. Describe what this PR did

The total limit of `dfget` is used to limit downloading speed of all the tasks on the same host. It's designed to be set by user explicitly, it should not be set by default. Otherwise it doesn't work if users only set flag `locallimit` but not set `totallimit`. 

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


