### PR TITLE
Configure dfclient/dfdaemon/dfget log file path via 'logConfig.path' property

### DIFF
--- a/cmd/dfdaemon/app/init.go
+++ b/cmd/dfdaemon/app/init.go
@@ -80,15 +80,13 @@ func initLogger(cfg config.Properties) error {
 		cfg.WorkHome = filepath.Join(current.HomeDir, ".small-dragonfly")
 	}
 
-	logFilePath := filepath.Join(cfg.WorkHome, "logs", "dfdaemon.log")
-
 	opts := []dflog.Option{
-		dflog.WithLogFile(logFilePath, cfg.LogConfig.MaxSize, cfg.LogConfig.MaxBackups),
+		dflog.WithLogFile(cfg.LogConfig.Path, cfg.LogConfig.MaxSize, cfg.LogConfig.MaxBackups),
 		dflog.WithSign(fmt.Sprintf("%d", os.Getpid())),
 		dflog.WithDebug(cfg.Verbose),
 	}
 
-	logrus.Debugf("use log file %s", logFilePath)
+	logrus.Debugf("use log file %s", cfg.LogConfig.Path)
 
 	return errors.Wrap(dflog.Init(logrus.StandardLogger(), opts...), "init log")
 }

--- a/cmd/dfdaemon/app/init.go
+++ b/cmd/dfdaemon/app/init.go
@@ -79,7 +79,9 @@ func initLogger(cfg config.Properties) error {
 		}
 		cfg.WorkHome = filepath.Join(current.HomeDir, ".small-dragonfly")
 	}
-
+	if cfg.LogConfig.Path == "" {
+		cfg.LogConfig.Path = filepath.Join(cfg.WorkHome, "logs", "dfdaemon.log")
+	}
 	opts := []dflog.Option{
 		dflog.WithLogFile(cfg.LogConfig.Path, cfg.LogConfig.MaxSize, cfg.LogConfig.MaxBackups),
 		dflog.WithSign(fmt.Sprintf("%d", os.Getpid())),

--- a/cmd/dfget/app/root.go
+++ b/cmd/dfget/app/root.go
@@ -188,10 +188,12 @@ func initProperties() ([]*propertiesResult, error) {
 // while console log will output the dfget client's log in console/terminal for
 // debugging usage.
 func initClientLog() error {
-	logFilePath := filepath.Join(cfg.WorkHome, "logs", "dfclient.log")
+	if cfg.LogConfig.Path == "" {
+		cfg.LogConfig.Path = filepath.Join(cfg.WorkHome, "logs", "dfclient.log")
+	}
 
 	opts := []dflog.Option{
-		dflog.WithLogFile(logFilePath, cfg.LogConfig.MaxSize, cfg.LogConfig.MaxBackups),
+		dflog.WithLogFile(cfg.LogConfig.Path, cfg.LogConfig.MaxSize, cfg.LogConfig.MaxBackups),
 		dflog.WithSign(cfg.Sign),
 		dflog.WithDebug(cfg.Verbose),
 	}

--- a/cmd/dfget/app/server.go
+++ b/cmd/dfget/app/server.go
@@ -82,10 +82,11 @@ func runServer() error {
 }
 
 func initServerLog() error {
-	logFilePath := filepath.Join(cfg.WorkHome, "logs", "dfserver.log")
-
+	if cfg.LogConfig.Path == "" {
+		cfg.LogConfig.Path = filepath.Join(cfg.WorkHome, "logs", "dfserver.log")
+	}
 	opts := []dflog.Option{
-		dflog.WithLogFile(logFilePath, cfg.LogConfig.MaxSize, cfg.LogConfig.MaxBackups),
+		dflog.WithLogFile(cfg.LogConfig.Path, cfg.LogConfig.MaxSize, cfg.LogConfig.MaxBackups),
 		dflog.WithSign(cfg.Sign),
 		dflog.WithDebug(cfg.Verbose),
 	}

--- a/docs/config/dfdaemon_config_template.yml
+++ b/docs/config/dfdaemon_config_template.yml
@@ -77,5 +77,5 @@ maxprocs: 10
 
 # Logging
 logConfig:
-  # Log file path
-  path: /dev/stdout
+   # Log file path
+   path: /dev/stdout

--- a/docs/config/dfdaemon_config_template.yml
+++ b/docs/config/dfdaemon_config_template.yml
@@ -74,3 +74,8 @@ verbose: false
 
 # The maximum number of CPUs that the dfdaemon can use
 maxprocs: 10
+
+# Logging
+logConfig:
+  # Log file path
+  path: /dev/stdout

--- a/docs/config/dfdaemon_properties.md
+++ b/docs/config/dfdaemon_properties.md
@@ -10,6 +10,7 @@ The following startup parameters are supported for `dfdaemon`
 | ------------- | ------------- |
 | dfget_flags |	dfget properties |
 | dfpath | dfget bin path |
+| logConfig | Logging properties |
 | hijack_https | HijackHTTPS is the list of hosts whose https requests should be hijacked by dfdaemon. The first matched rule will be used |
 | localrepo | Temp output dir of dfdaemon, by default `$HOME/.small-dragonfly/dfdaemon/data/` |
 | proxies | Proxies is the list of rules for the transparent proxy |

--- a/pkg/dflog/log.go
+++ b/pkg/dflog/log.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -35,6 +36,10 @@ type LogConfig struct {
 	// MaxBackups is the maximum number of old log files to retain.
 	// The default value is 1.
 	MaxBackups int `yaml:"maxBackups" json:"maxBackups"`
+
+	// Path is the location of log file
+	// The default value is logs/dfdaemon.log
+	Path string `yaml:"path" json:"path"`
 }
 
 // DefaultLogTimeFormat defines the timestamp format.
@@ -72,7 +77,7 @@ func getLumberjack(l *logrus.Logger) *lumberjack.Logger {
 func WithLogFile(f string, maxSize, maxBackups int) Option {
 	return func(l *logrus.Logger) error {
 		if f == "" {
-			return nil
+			f = filepath.Join("logs", "dfdaemon.log")
 		}
 		if maxSize <= 0 {
 			maxSize = 40

--- a/pkg/dflog/log.go
+++ b/pkg/dflog/log.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -77,7 +76,7 @@ func getLumberjack(l *logrus.Logger) *lumberjack.Logger {
 func WithLogFile(f string, maxSize, maxBackups int) Option {
 	return func(l *logrus.Logger) error {
 		if f == "" {
-			f = filepath.Join("logs", "dfdaemon.log")
+			return nil
 		}
 		if maxSize <= 0 {
 			maxSize = 40


### PR DESCRIPTION
Signed-off-by: YanzheL lee.yanzhe@yanzhe.org
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Currently, there is no option for user to customize the log file path, which causes inconvenience while using `dfclient` in container.

For a typical use case, it is expected that the dfclient container logs to stdout so we can inspect the logs via `docker logs -f <dfclient>` instead of checking the log file in default location `~/.small-dragonfly/logs/dfdaemon.log`

This PR enables user to configure the log file path via configuration property `logConfig.path`.

For example
```yaml
logConfig:
  path: /dev/stdout
```

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

Already tested in container.

### Ⅳ. Describe how to verify it

1. Build the dockerfile

2. Add this property in dfclient configuration file

   ```yaml
   logConfig:
     path: /dev/stdout
   ```

3. You will see the log in `stdout` instead of the default location `~/.small-dragonfly/logs/dfdaemon.log`

### Ⅴ. Special notes for reviews


