### PR TITLE
bugfix: update cdn fail when the content is being read and the source server is down

### DIFF
--- a/dfget/core/core.go
+++ b/dfget/core/core.go
@@ -188,11 +188,11 @@ func downloadFile(cfg *config.Config, supernodeAPI api.SupernodeAPI,
 	}
 
 	if success {
-		logrus.Infof("download SUCCESS from supernode %s cost:%.3fs length:%d",
-			cfg.Nodes, time.Since(cfg.StartTime).Seconds(), cfg.RV.FileLength)
+		logrus.Infof("download SUCCESS cost:%.3fs length:%d",
+			time.Since(cfg.StartTime).Seconds(), cfg.RV.FileLength)
 	} else {
-		logrus.Infof("download FAIL from supernode %s cost:%.3fs length:%d reason:%d",
-			cfg.Nodes, time.Since(cfg.StartTime).Seconds(), cfg.RV.FileLength, cfg.BackSourceReason)
+		logrus.Infof("download FAIL cost:%.3fs length:%d reason:%d error:%v",
+			time.Since(cfg.StartTime).Seconds(), cfg.RV.FileLength, cfg.BackSourceReason, err)
 	}
 	return err
 }

--- a/dfget/core/regist/register_test.go
+++ b/dfget/core/regist/register_test.go
@@ -76,9 +76,8 @@ func (s *RegistTestSuite) TestSupernodeRegister_Register(c *check.C) {
 	m := new(MockSupernodeAPI)
 	m.RegisterFunc = CreateRegisterFunc()
 
-	register := NewSupernodeRegister(cfg, m)
-
 	var f = func(ec int, msg string, data *RegisterResult) {
+		register := NewSupernodeRegister(cfg, m)
 		resp, e := register.Register(0)
 		if msg == "" {
 			c.Assert(e, check.IsNil)
@@ -92,7 +91,7 @@ func (s *RegistTestSuite) TestSupernodeRegister_Register(c *check.C) {
 	}
 
 	cfg.Nodes = []string{""}
-	f(constants.HTTPError, "connection refused", nil)
+	f(constants.HTTPError, "empty response, unknown error", nil)
 
 	cfg.Nodes = []string{"x"}
 	f(501, "invalid source url", nil)
@@ -117,7 +116,7 @@ func (s *RegistTestSuite) TestSupernodeRegister_Register(c *check.C) {
 func (s *RegistTestSuite) TestSupernodeRegister_constructRegisterRequest(c *check.C) {
 	buf := &bytes.Buffer{}
 	cfg := s.createConfig(buf)
-	register := &supernodeRegister{nil, cfg}
+	register := &supernodeRegister{nil, cfg, ""}
 
 	cfg.Identifier = "id"
 	req := register.constructRegisterRequest(0)

--- a/supernode/daemon/mgr/cdn/manager.go
+++ b/supernode/daemon/mgr/cdn/manager.go
@@ -153,7 +153,7 @@ func (cm *Manager) TriggerCDN(ctx context.Context, task *types.TaskInfo) (*types
 	downloadMetadata, err := cm.writer.startWriter(ctx, cm.cfg, reader, task, startPieceNum, httpFileLength, pieceContSize)
 	if err != nil {
 		logrus.Errorf("failed to write for task %s: %v", task.ID, err)
-		return nil, err
+		return getUpdateTaskInfoWithStatusOnly(types.TaskInfoCdnStatusFAILED), err
 	}
 
 	realMD5 := reader.Md5()


### PR DESCRIPTION
Signed-off-by: Starnop <starnopg@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
If supernode is writing to the CDN cache and the source server goes down, the cdn status of task will not be updated failed for now. This PR will fix it.

In addition, if dfget failed to download from `supernode xxx`, it will migrate to other supenodes in the node list of dfget. It's unreasonable to register to the supernode  that just failed, and it will bring a few questions:
+ It doesn't make much sense to try again for the same supernode.
+ The cid of dfgetTask will not change. So two dfgetTask with same cid will be registered on the same supernode, which will cause some data confusion.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1150

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
**Attention**
In the meantime, another problem has also been found.

```
dragonfly_supernode_dfgettasks{callsystem="",status="RUNNING"} 1
dragonfly_supernode_dfgettasks{callsystem="",status="WAITING"} 0
```
 When dfget migrate to the other supernodes, the current supernode doesn't know that. So the state of dfgettask will keep running. I will start a new PR to do that.