### PR TITLE
fix typo: 'the the' -> 'the'

### DIFF
--- a/dfget/config/supernode_value.go
+++ b/dfget/config/supernode_value.go
@@ -146,7 +146,7 @@ func ParseNodesSlice(value []string) ([]*NodeWight, error) {
 	}
 
 	var result []*NodeWight
-	// get the the greatest common divisor of the weight slice and
+	// get the greatest common divisor of the weight slice and
 	// divide all weights by the greatest common divisor.
 	gcdNumber := algorithm.GCDSlice(weightKey)
 	for _, v := range nodeWightSlice {


### PR DESCRIPTION
Signed-off-by: Guangwen Feng <fenggw-fnst@cn.fujitsu.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Fix a typo 'the the' -> 'the' in dfget/config/supernode_value.go

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


