### PR TITLE
fix: use StringArrayVar to parse http header

### DIFF
--- a/cmd/dfget/app/root.go
+++ b/cmd/dfget/app/root.go
@@ -238,7 +238,7 @@ func initFlags() {
 		"filter some query params of URL, use char '&' to separate different params"+
 			"\neg: -f 'key&sign' will filter 'key' and 'sign' query param"+
 			"\nin this way, different but actually the same URLs can reuse the same downloading task")
-	flagSet.StringSliceVar(&cfg.Header, "header", nil,
+	flagSet.StringArrayVar(&cfg.Header, "header", nil,
 		"http header, eg: --header='Accept: *' --header='Host: abc'")
 	flagSet.VarP(config.NewSupernodesValue(&cfg.Supernodes, nil), "node", "n",
 		"specify the addresses(host:port=weight) of supernodes where the host is necessary, the port(default: 8002) and the weight(default:1) are optional. And the type of weight must be integer")

--- a/cmd/dfget/app/root_test.go
+++ b/cmd/dfget/app/root_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/dragonflyoss/Dragonfly/dfget/config"
 	"github.com/dragonflyoss/Dragonfly/pkg/errortypes"
 	"github.com/dragonflyoss/Dragonfly/pkg/rate"
+
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/suite"
 )
@@ -89,6 +90,17 @@ func (suit *dfgetSuit) Test_initProperties() {
 		suit.Equal(cfg.TotalLimit, v.expected.TotalLimit)
 		suit.Equal(cfg.ClientQueueSize, v.expected.ClientQueueSize)
 	}
+}
+
+func (suit *dfgetSuit) Test_HeaderFlags() {
+	originCfg := *cfg
+	defer func() {
+		cfg = &originCfg
+	}()
+	flagSet := rootCmd.Flags()
+	flagSet.Parse([]string{"--header", "Host: abc", "--header", "Date:Mon, 30 Dec 2019"})
+
+	suit.Equal(cfg.Header, []string{"Host: abc", "Date:Mon, 30 Dec 2019"})
 }
 
 func (suit *dfgetSuit) Test_transFilter() {


### PR DESCRIPTION
StringSliceVar will separated by comma, which is not suitable for field
like Date:Mon, 30 Dec 2019, use StringArrayVar instead

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


