### PR TITLE
feature: Hijack HTTPS by generating leaf TLS certs on the fly issued by user provided CA.

### DIFF
--- a/dfdaemon/proxy/cert.go
+++ b/dfdaemon/proxy/cert.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package proxy
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"math/big"
+	"net"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+type LeafCertSpec struct {
+	publicKey crypto.PublicKey
+
+	privateKey crypto.PrivateKey
+
+	signatureAlgorithm x509.SignatureAlgorithm
+}
+
+// genLeafCert generates a Leaf TLS certificate and sign it with given CA
+func genLeafCert(ca *tls.Certificate, leafCertSpec *LeafCertSpec, host string) (*tls.Certificate, error) {
+	now := time.Now().Add(-1 * time.Hour).UTC()
+	if !ca.Leaf.IsCA {
+		return nil, errors.New("CA cert is not a CA")
+	}
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		logrus.Errorf("failed to generate serial number: %s", err)
+		return nil, err
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          serialNumber,
+		Subject:               pkix.Name{CommonName: host},
+		NotBefore:             now,
+		NotAfter:              now.Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageDataEncipherment | x509.KeyUsageKeyAgreement,
+		BasicConstraintsValid: true,
+		SignatureAlgorithm:    leafCertSpec.signatureAlgorithm,
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		tmpl.DNSNames = []string{host}
+	} else {
+		tmpl.IPAddresses = []net.IP{ip}
+	}
+	newCert, err := x509.CreateCertificate(rand.Reader, tmpl, ca.Leaf, leafCertSpec.publicKey, ca.PrivateKey)
+	if err != nil {
+		logrus.Errorf("failed to generate leaf cert %s", err)
+		return nil, err
+	}
+	cert := new(tls.Certificate)
+	cert.Certificate = append(cert.Certificate, newCert)
+	cert.PrivateKey = leafCertSpec.privateKey
+	cert.Leaf, _ = x509.ParseCertificate(newCert)
+	return cert, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/go-openapi/strfmt v0.0.0-20171222154016-4dd3d302e100
 	github.com/go-openapi/swag v0.0.0-20170606142751-f3f9494671f9
 	github.com/go-openapi/validate v0.0.0-20170705144413-8a82927c942c
+	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef
 	github.com/golang/mock v1.3.1
 	github.com/gorilla/context v0.0.0-20181012153548-51ce91d2eadd // indirect
 	github.com/gorilla/mux v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,7 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef h1:veQD95Isof8w9/WXiA+pa3tz3fJXkt5B7QaRBrM62gk=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1 h1:G5FRp8JnTd7RQH5kemVNlMeyXQAztQ3mOWV95KxsXH8=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=


### PR DESCRIPTION
Signed-off-by: YanzheL <lee.yanzhe@yanzhe.org>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Why do you propose this PR

The current implementation of HTTPS hijacking is simple but not correct.

It uses user provided TLS server cert `df.crt` and `df.key` to decrypt HTTPS connection. However, this cert cannot be a CA, which means every TLS connection is encrypted by the same cert from user point of view.

This is not a standard behavior of a HTTPS Man-In-The-Middle proxy, and will cause various issues.

1. The cert used by HTTPS hijacking cannot be automatically verified by applications because the Common Name (or Server-Alternative-Names) is always same and it doesn't match the host of every connection. So user have to configure their applications manually to force-ignore the TLS verification.

   This prevents `dfclient` be used as a general system-level HTTPS proxy without affecting user applications.

2. Some applications cannot be configured to trust a specific TLS cert or ignore TLS verification error (e.g.  Google Chrome). Instead, the only way to achieve it is to configure them to trust the CA, or add the CA to system trust store.

### II. Describe what this PR did

1. If `df.crt` and `df.key` is a CA key-pair, then `dfclient` use it to issue leaf TLS certs for every connection whose host matches pre-configured hijacking rules.

   User can either add the CA to system trust store, or configure individual application to trust it. 

   Since the common name of leaf cert is set as the target host, the connection will be verified by user application automatically as normal.

2. If `df.crt` and `df.key` is not a CA key-pair, the behavior of `dfclient` is same as the old way: this cert is used in hijacking instead of generating new certs per connection.

3. So this PR is fully backward-compatible and will NOT break user applications.


### ⅡI. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

Potential issues are stated above.

### IV. Potential use cases

1. Maybe now we can cache HTTPS docker registries (Probably fixes #525).

   The dfdaemon acts as a decrypting MITM HTTPS proxy, so it can 'see' the request body of docker image pull requests to remote private HTTPS registries. If we can see the body, then we can cache it as well.

2. Generic HTTPS caching proxy, just like squid. Cache anything in a distributed way, and not just for HTTP contents. We can also use dfdaemon to speed up normal webpage loading in browser.


### V. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

I'm working on unit tests, but currently I don't have much time....
For now, I just tested this feature in container, and everything seems good.

### VI. Describe how to verify it

1. Prepare a self-signed CA with private key.

2. Configure dfdaemon to use this key pair, and also configure the hijack rules, proxy rules.

   ```yaml
   proxies:
     - regx: blobs/sha256.* # Caching docker images
     - regx: '.*\.png' # Caching png files.
   hijack_https:
     cert: ca.crt
     key: ca.key
     hosts:
       - regx: '.*'    # Decrypt all sites, for test.
   ```

3. Setup dfdaemon as your system's http(s) proxy.

   ```shell
   export HTTP_PROXY=http://127.0.0.1:65001; export HTTPS_PROXY=http://127.0.0.1:65001;
   ```

4. Check the TLS cert return by target site.

   ```shell
   curl -vkL https://alibaba.com -o /dev/null
   ```

   This command will report that the TLS cert of `alibaba.com`is signed by your CA.

   The dfdaemon log will indicate that it is downloading png files of `alibaba.com`


### ⅤII. Special notes for reviews

This PR reuses CA's private key (and signature algorithm) to generate per-connection certs. I think it can save key-generation overhead and there is no need to use new TLS private key for every connection since the generated cert is temporal (Default valid time is 24 hours).

As for security, if the private key of CA is leaked someway, generating new private key for every connection will not improve security (maybe???). So reusing CA private key does not bring much security issues.

If this is not appropriate, I can change it.