### PR TITLE
bugfix: retry multi times if failed to report pieces

### DIFF
--- a/dfget/core/api/supernode_api.go
+++ b/dfget/core/api/supernode_api.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dragonflyoss/Dragonfly/dfget/types"
 	"github.com/dragonflyoss/Dragonfly/pkg/constants"
 	"github.com/dragonflyoss/Dragonfly/pkg/httputils"
+	"github.com/pkg/errors"
 
 	"github.com/sirupsen/logrus"
 )
@@ -114,10 +115,11 @@ func (api *supernodeAPI) ReportPiece(node string, req *types.ReportPieceRequest)
 	resp = new(types.BaseResponse)
 	if e = api.get(url, resp); e != nil {
 		logrus.Errorf("failed to report piece{taskid:%s,range:%s},err: %v", req.TaskID, req.PieceRange, e)
-		return nil, e
+		return nil, errors.Wrapf(e, "failed to report piece{taskid:%s,range:%s}", req.TaskID, req.PieceRange)
 	}
 	if resp.Code != constants.CodeGetPieceReport {
 		logrus.Errorf("failed to report piece{taskid:%s,range:%s} to supernode: api response code is %d not equal to %d", req.TaskID, req.PieceRange, resp.Code, constants.CodeGetPieceReport)
+		return nil, errors.Wrapf(e, "failed to report piece{taskid:%s,range:%s} to supernode: api response code is %d not equal to %d", req.TaskID, req.PieceRange, resp.Code, constants.CodeGetPieceReport)
 	}
 	return
 }

--- a/dfget/core/api/supernode_api_test.go
+++ b/dfget/core/api/supernode_api_test.go
@@ -103,10 +103,10 @@ func (s *SupernodeAPITestSuite) TestSupernodeAPI_ReportPiece(c *check.C) {
 		TaskID:     "sssss",
 		PieceRange: "0-11",
 	}
-	s.mock.GetFunc = s.mock.CreateGetFunc(200, []byte(`{"Code":700}`), nil)
+	s.mock.GetFunc = s.mock.CreateGetFunc(200, []byte(`{"Code":611}`), nil)
 	r, e := s.api.ReportPiece(localhost, req)
 	c.Check(e, check.IsNil)
-	c.Check(r.Code, check.Equals, 700)
+	c.Check(r.Code, check.Equals, 611)
 }
 
 func (s *SupernodeAPITestSuite) TestSupernodeAPI_ServiceDown(c *check.C) {


### PR DESCRIPTION
Signed-off-by: Starnop <starnopg@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Sometimes dfget will fail to report pieces to supernode for some reason, such as supernode cannot handle it. And then supernode will mark that this task has not been completed forever. That's not expected. So we should add a retry mechanism to reduce the chance of errors.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


