### PR TITLE
bugfix: fix untested case due to prefix missing

### DIFF
--- a/pkg/errortypes/supernode_errors_test.go
+++ b/pkg/errortypes/supernode_errors_test.go
@@ -61,7 +61,7 @@ func (suite *SupernodeErrorTestSuite) TestIsUnknowError(c *check.C) {
 	c.Assert(IsUnknowError(*err2), check.Equals, false)
 }
 
-func (suite *SupernodeErrorTestSuite) IsPeerContinue(c *check.C) {
+func (suite *SupernodeErrorTestSuite) TestIsPeerContinue(c *check.C) {
 	err1 := New(11, "peer continue")
 	err2 := New(0, "test")
 	c.Assert(IsPeerContinue(*err1), check.Equals, true)


### PR DESCRIPTION
Signed-off-by: Guangwen Feng <fenggw-fnst@cn.fujitsu.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Fix untested unit test case due to prefix missing. The check.Suite requires any method to start with the "Test" prefix. So fix this.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


