### PR TITLE
bugfix: dfget overwrite /dev/null

### DIFF
--- a/apis/types/task_metrics_request.go
+++ b/apis/types/task_metrics_request.go
@@ -74,6 +74,10 @@ func (m *TaskMetricsRequest) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateFileLength(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -104,6 +108,19 @@ func (m *TaskMetricsRequest) validatePort(formats strfmt.Registry) error {
 	}
 
 	if err := validate.MaximumInt("port", "body", int64(m.Port), 65000, false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *TaskMetricsRequest) validateFileLength(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.FileLength) { // not required
+		return nil
+	}
+
+	if err := validate.MinimumInt("fileLength", "body", int64(m.FileLength), 0, false); err != nil {
 		return err
 	}
 

--- a/dfget/config/constants.go
+++ b/dfget/config/constants.go
@@ -120,6 +120,8 @@ const (
 	DefaultDownloadTimeout = 5 * time.Minute
 
 	DefaultSupernodePort = 8002
+
+	PathDevNull = "/dev/null"
 )
 
 /* errors code */

--- a/dfget/core/downloader/downloader.go
+++ b/dfget/core/downloader/downloader.go
@@ -80,6 +80,14 @@ func MoveFile(src string, dst string, expectMd5 string) error {
 			return fmt.Errorf("Md5NotMatch, real:%s expect:%s", realMd5, expectMd5)
 		}
 	}
+
+	if dst == config.PathDevNull {
+		err := fileutils.DeleteFile(src)
+		logrus.Infof("delete src:%s due to redirect to '/dev/null' result:%t cost:%.3f",
+			src, err == nil, time.Since(start).Seconds())
+		return err
+	}
+
 	err := fileutils.MoveFile(src, dst)
 	logrus.Infof("move src:%s to dst:%s result:%t cost:%.3f",
 		src, dst, err == nil, time.Since(start).Seconds())


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
1. bugfix: dfget will overwrite the `/dev/null` and caused some issue
2. bugfix: supernode will panic when receive metrics report from dfget which the fileLength is -1 (default value)

### Ⅱ. Does this pull request fix one issue?
N.A

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
N.A


### Ⅳ. Describe how to verify it
```
dfget -u http://google.com -o /dev/null
ls /dev/null
```
before the patch, /dev/null will be a regular file
after the patch, /dev/null will not be changed

### Ⅴ. Special notes for reviews


