### PR TITLE
feature: allow dfdaemon to listen port on 0~65535

### DIFF
--- a/dfdaemon/config/config.go
+++ b/dfdaemon/config/config.go
@@ -118,7 +118,7 @@ type Properties struct {
 
 // Validate validates the config
 func (p *Properties) Validate() error {
-	if p.Port <= 2000 || p.Port > 65535 {
+	if p.Port <= 0 || p.Port > 65535 {
 		return dferr.Newf(
 			constant.CodeExitPortInvalid,
 			"invalid port %d", p.Port,

--- a/dfdaemon/config/config_test.go
+++ b/dfdaemon/config/config_test.go
@@ -57,7 +57,7 @@ func (ts *configTestSuite) TestValidatePort() {
 	c := defaultConfig()
 	r := ts.Require()
 
-	for _, p := range []uint{0, 80, 2000, 65536} {
+	for _, p := range []uint{0, 65536} {
 		c.Port = p
 		err := c.Validate()
 		r.NotNil(err)
@@ -66,7 +66,7 @@ func (ts *configTestSuite) TestValidatePort() {
 		r.Equal(constant.CodeExitPortInvalid, de.Code)
 	}
 
-	for _, p := range []uint{2001, 65001, 65535} {
+	for _, p := range []uint{80, 2001, 65001, 65535} {
 		c.Port = p
 		r.Nil(c.Validate())
 	}


### PR DESCRIPTION

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

modify dfdaemon port validate method, allow to expose more port to listen.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

test case 
dfdaemon/config/config_test.go


### Ⅴ. Special notes for reviews

Here is a case:
We have a private docker registry, named https://docker.pt.komey.com.
and we want to make our user to None care about the registry address,
So we'd like to config our DNS（docker.pt.komey.com） record for a specific region to 127.0.0.1 and expose dfdaemon on 443 port. Which may make our users have No feeling about the difference between the regions which didn't deploy dragonfly.
