### PR TITLE
fix: GCDSlice returns 1 when slice is empty

### DIFF
--- a/dfget/config/supernode_value.go
+++ b/dfget/config/supernode_value.go
@@ -152,7 +152,7 @@ func ParseNodesSlice(value []string) ([]*NodeWeight, error) {
 	for _, v := range nodeWeightSlice {
 		result = append(result, &NodeWeight{
 			Node:   v.Node,
-			Weight: (v.Weight / gcdNumber),
+			Weight: v.Weight / gcdNumber,
 		})
 	}
 

--- a/pkg/algorithm/algorithm.go
+++ b/pkg/algorithm/algorithm.go
@@ -17,8 +17,13 @@
 package algorithm
 
 // GCDSlice returns the greatest common divisor of a slice.
+// It returns 1 when s is empty because that any number divided by 1 is still
+// itself.
 func GCDSlice(s []int) int {
 	length := len(s)
+	if length == 0 {
+		return 1
+	}
 	if length == 1 {
 		return s[0]
 	}

--- a/pkg/algorithm/algorithm_test.go
+++ b/pkg/algorithm/algorithm_test.go
@@ -53,6 +53,8 @@ func (suit *AlgorithmSuite) TestGCDSlice() {
 		slice  []int
 		result int
 	}{
+		{nil, 1},
+		{[]int{2}, 2},
 		{[]int{2, 2, 4}, 2},
 		{[]int{5, 10, 25}, 5},
 		{[]int{1, 3, 5}, 1},


### PR DESCRIPTION
Signed-off-by: lowzj <zj3142063@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
The `GCDSlice` does not consider the situation when the giving slice is nil or empty.
This pr makes it returns 1 when s is empty because that any number divided by 1 is still
itself.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


