### PR TITLE
refactor: refactor dfget/core with SupernodeLocator

### DIFF
--- a/cmd/dfget/app/root_test.go
+++ b/cmd/dfget/app/root_test.go
@@ -38,7 +38,7 @@ type dfgetSuit struct {
 
 func (suit *dfgetSuit) Test_initFlagsNoArguments() {
 	initProperties()
-	suit.Equal(cfg.Nodes, []string{"127.0.0.1:8002"})
+	suit.Equal(cfg.Nodes, []string(nil))
 	suit.Equal(cfg.LocalLimit, 20*rate.MB)
 	suit.Equal(cfg.TotalLimit, rate.Rate(0))
 	suit.Equal(cfg.Notbs, false)

--- a/dfget/config/config.go
+++ b/dfget/config/config.go
@@ -91,8 +91,9 @@ type Properties struct {
 
 // NewProperties creates a new properties with default values.
 func NewProperties() *Properties {
+	// don't set Supernodes as default value, the SupernodeLocator will
+	// do this in a better way.
 	return &Properties{
-		Supernodes:      GetDefaultSupernodesValue(),
 		LocalLimit:      DefaultLocalLimit,
 		MinRate:         DefaultMinRate,
 		ClientQueueSize: DefaultClientQueueSize,

--- a/dfget/core/regist/register_test.go
+++ b/dfget/core/regist/register_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/dragonflyoss/Dragonfly/apis/types"
 	"github.com/dragonflyoss/Dragonfly/dfget/config"
 	. "github.com/dragonflyoss/Dragonfly/dfget/core/helper"
+	"github.com/dragonflyoss/Dragonfly/dfget/locator"
 	"github.com/dragonflyoss/Dragonfly/pkg/constants"
 
 	"github.com/go-check/check"
@@ -58,10 +59,9 @@ func (s *RegistTestSuite) TearDownSuite(c *check.C) {
 }
 
 func (s *RegistTestSuite) TestNewRegisterResult(c *check.C) {
-	result := NewRegisterResult("node", []string{"1"}, "url", "taskID",
+	result := NewRegisterResult("node", "url", "taskID",
 		10, 1, "supernode")
 	c.Assert(result.Node, check.Equals, "node")
-	c.Assert(result.RemainderNodes, check.DeepEquals, []string{"1"})
 	c.Assert(result.URL, check.Equals, "url")
 	c.Assert(result.TaskID, check.Equals, "taskID")
 	c.Assert(result.FileLength, check.Equals, int64(10))
@@ -78,8 +78,10 @@ func (s *RegistTestSuite) TestSupernodeRegister_Register(c *check.C) {
 	m := new(MockSupernodeAPI)
 	m.RegisterFunc = CreateRegisterFunc()
 
+	nodeStr := "127.0.0.1:8002"
+	snLocator, _ := locator.NewStaticLocatorFromStr("test", []string{nodeStr})
 	var f = func(ec int, msg string, data *RegisterResult) {
-		register := NewSupernodeRegister(cfg, m)
+		register := NewSupernodeRegister(cfg, m, snLocator)
 		resp, e := register.Register(0)
 		if msg == "" {
 			c.Assert(e, check.IsNil)
@@ -92,24 +94,24 @@ func (s *RegistTestSuite) TestSupernodeRegister_Register(c *check.C) {
 		}
 	}
 
-	cfg.Nodes = []string{""}
+	snLocator.Next()
 	f(constants.HTTPError, "empty response, unknown error", nil)
 
-	cfg.Nodes = []string{"x"}
+	snLocator.Refresh()
 	f(501, "invalid source url", nil)
 
-	cfg.Nodes = []string{"x"}
+	snLocator.Refresh()
 	cfg.URL = "http://taobao.com"
 	f(constants.CodeNeedAuth, "need auth", nil)
 
-	cfg.Nodes = []string{"x"}
+	snLocator.Refresh()
 	cfg.URL = "http://github.com"
 	f(constants.CodeWaitAuth, "wait auth", nil)
 
-	cfg.Nodes = []string{"x"}
+	snLocator.Refresh()
 	cfg.URL = "http://lowzj.com"
 	f(constants.Success, "", &RegisterResult{
-		Node: "x", RemainderNodes: []string{}, URL: cfg.URL, TaskID: "a",
+		Node: nodeStr, URL: cfg.URL, TaskID: "a",
 		FileLength: 100, PieceSize: 10})
 
 	f(constants.HTTPError, "empty response, unknown error", nil)
@@ -118,7 +120,7 @@ func (s *RegistTestSuite) TestSupernodeRegister_Register(c *check.C) {
 func (s *RegistTestSuite) TestSupernodeRegister_constructRegisterRequest(c *check.C) {
 	buf := &bytes.Buffer{}
 	cfg := s.createConfig(buf)
-	register := &supernodeRegister{nil, cfg, ""}
+	register := &supernodeRegister{nil, nil, cfg, nil}
 
 	cfg.Identifier = "id"
 	req := register.constructRegisterRequest(0)

--- a/dfget/locator/locator.go
+++ b/dfget/locator/locator.go
@@ -16,6 +16,10 @@
 
 package locator
 
+import (
+	"fmt"
+)
+
 // SupernodeLocator defines the way how to get available supernodes.
 // Developers can implement their own locator more flexibly , not just get the
 // supernode list from configuration or CLI.
@@ -73,6 +77,10 @@ type Supernode struct {
 	Weight    int
 	GroupName string
 	Metrics   *SupernodeMetrics
+}
+
+func (s *Supernode) String() string {
+	return fmt.Sprintf("%s:%d", s.IP, s.Port)
 }
 
 // SupernodeMetrics holds metrics used for the locator to choose supernode.

--- a/dfget/locator/locator_test.go
+++ b/dfget/locator/locator_test.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package locator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+func TestSuite(t *testing.T) {
+	suite.Run(t, new(LocatorTestSuite))
+}
+
+type LocatorTestSuite struct {
+	suite.Suite
+}
+
+func (s *LocatorTestSuite) TestSupernodeGroup_GetNode() {
+	node := &Supernode{
+		IP:   "127.0.0.1",
+		Port: 8002,
+	}
+	group := &SupernodeGroup{
+		Nodes: []*Supernode{node},
+	}
+	s.Nil(group.GetNode(-1))
+	s.Nil(group.GetNode(1))
+	s.Equal(group.GetNode(0), node)
+}
+
+func (s *LocatorTestSuite) TestSupernode_String() {
+	node := &Supernode{
+		IP:   "127.0.0.1",
+		Port: 8002,
+	}
+	s.Equal(node.String(), "127.0.0.1:8002")
+}

--- a/dfget/locator/manager.go
+++ b/dfget/locator/manager.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package locator
+
+import (
+	"sync"
+
+	"github.com/dragonflyoss/Dragonfly/dfget/config"
+)
+
+const (
+	// GroupDefaultName indicates all the supernodes in this group are set as
+	// default value. It's only used when the supernode list from configuration
+	// or CLI is empty.
+	GroupDefaultName = "default"
+
+	// GroupConfigName indicates all the supernodes in this group come from
+	// configuration or CLI.
+	GroupConfigName = "config"
+)
+
+var mutex sync.Mutex
+
+// DefaultBuilder returns a supernode locator with default value when supernodes
+// in the config file is empty.
+var DefaultBuilder Builder = func(cfg *config.Config) SupernodeLocator {
+	if cfg == nil || len(cfg.Nodes) == 0 {
+		return NewStaticLocator(GroupDefaultName, config.GetDefaultSupernodesValue())
+	}
+	locator, _ := NewStaticLocatorFromStr(GroupConfigName, cfg.Nodes)
+	return locator
+}
+
+// Builder defines the constructor of SupernodeLocator.
+type Builder func(cfg *config.Config) SupernodeLocator
+
+// CreateLocator creates a supernode locator with the giving config.
+func CreateLocator(cfg *config.Config) SupernodeLocator {
+	mutex.Lock()
+	defer mutex.Unlock()
+	return DefaultBuilder(cfg)
+}
+
+// RegisterLocator provides a way for users to customize SupernodeLocator.
+// This function should be invoked before CreateLocator.
+func RegisterLocator(builder Builder) {
+	mutex.Lock()
+	defer mutex.Unlock()
+	DefaultBuilder = builder
+}


### PR DESCRIPTION
Signed-off-by: lowzj <zj3142063@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
This pull request uses interface `SupernodeLocator` to refactor the `dfget/core` to get supernode list instead of configurations. 
It also provides a way for users to customized their own `SupernodeLocator` to replace the default implementation, for example:
```golang
package main

import (
    "github.com/dragonflyoss/Dragonfly/cmd/dfget/app"
    "github.com/dragonflyoss/Dragonfly/dfget/config"
    "github.com/dragonflyoss/Dragonfly/dfget/locator"
)

func init() {
    // use customized implementation to replace default one
    // execute it in the `init` function
    // or move it into `main` function, before `app.Execute()`
    locator.RegisterLocator(func(cfg *config.Config) locator.SupernodeLocator {
        return NewDynamicLocator(cfg)
    })
}

// customized implementation of SupernodeLocator

func NewDynamicLocator(cfg *config.Config) *DynamicLocator {
    return &DynamicLocator{}
}

var _ locator.SupernodeLocator = &DynamicLocator{}

type DynamicLocator struct {
}
// implementation the interface SupernodeLocator here

func main() {
    app.Execute()
}
```
### Ⅱ. Does this pull request fix one issue?
fixes: #1293 


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


