### PR TITLE
Added 2 fuzzers

### DIFF
--- a/dfget/core/uploader/uploader_fuzz.go
+++ b/dfget/core/uploader/uploader_fuzz.go
@@ -1,0 +1,26 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uploader
+
+func FuzzParseParams(data []byte) int {
+	s := string(data)
+	_, err := parseParams(s, s, s)
+	if err != nil {
+		return 0
+	}
+	return 1
+}

--- a/supernode/daemon/mgr/cdn/cdn_fuzz.go
+++ b/supernode/daemon/mgr/cdn/cdn_fuzz.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cdn
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+
+	"github.com/sirupsen/logrus"
+)
+
+func Fuzz(data []byte) int {
+	// Don't spam output with parse failures
+	logrus.SetOutput(ioutil.Discard)
+	r := bytes.NewReader(data)
+	sr := newSuperReader()
+	_, err := sr.readFile(context.Background(), r, true, true)
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
I am bringing the 2 fuzzers from https://github.com/dragonflyoss/Dragonfly/pull/865 back into the upstream repository.

As agreed with @lowzj we are applying to run the fuzzers on oss-fuzz. I have setup an integration application [here](https://github.com/google/oss-fuzz/pull/3790). To complete that application, we need the 2 fuzzers merged here on the upstream repo.