### PR TITLE
optimize the HTTPWithHeaders

### DIFF
--- a/pkg/httputils/http_util_test.go
+++ b/pkg/httputils/http_util_test.go
@@ -17,12 +17,15 @@
 package httputils
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -102,6 +105,30 @@ func (s *HTTPUtilTestSuite) TestHTTPStatusOk(c *check.C) {
 	for i := fasthttp.StatusContinue; i <= fasthttp.StatusNetworkAuthenticationRequired; i++ {
 		c.Assert(HTTPStatusOk(i), check.Equals, i == fasthttp.StatusOK)
 	}
+}
+
+func (s *HTTPUtilTestSuite) TestHttpGet(c *check.C) {
+	res, e := HTTPGetTimeout("http://"+s.host, nil, 0)
+	c.Assert(e, check.IsNil)
+	code := res.StatusCode
+	body, e := ioutil.ReadAll(res.Body)
+	c.Assert(e, check.IsNil)
+	res.Body.Close()
+
+	checkOk(c, code, body, e, 0)
+
+	res, e = HTTPGetTimeout("http://"+s.host, nil, 60*time.Millisecond)
+	c.Assert(e, check.IsNil)
+	code = res.StatusCode
+	body, e = ioutil.ReadAll(res.Body)
+	c.Assert(e, check.IsNil)
+	res.Body.Close()
+
+	checkOk(c, code, body, e, 0)
+
+	_, e = HTTPGetTimeout("http://"+s.host, nil, 20*time.Millisecond)
+	c.Assert(e, check.NotNil)
+	c.Assert(strings.Contains(e.Error(), context.DeadlineExceeded.Error()), check.Equals, true)
 }
 
 func (s *HTTPUtilTestSuite) TestParseQuery(c *check.C) {


### PR DESCRIPTION
…ort and add timeout in request context to share the http client.

Signed-off-by: allen.wq <allen.wq@alipay.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Optimize the HTTPWithHeaders. When do a http request, share the transport and add timeout in request context to share the http client.
In the early version, if we do a request with HTTPWithHeaders, new transport will be generated every request, which cases a lot of goroutines for cached conn in transport. 

In my unit test, it causes error:
```
go test -race -v
race: limit on 8128 simultaneously alive goroutines is exceeded, dying
```

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
Add ut.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


