### PR TITLE
fix: don't delete the parent directory of the task file

### DIFF
--- a/supernode/daemon/mgr/cdn/path_util.go
+++ b/supernode/daemon/mgr/cdn/path_util.go
@@ -69,13 +69,6 @@ func getMd5DataRaw(taskID string) *store.Raw {
 	}
 }
 
-func getParentRaw(taskID string) *store.Raw {
-	return &store.Raw{
-		Bucket: config.DownloadHome,
-		Key:    getParentKey(taskID),
-	}
-}
-
 func getHomeRaw() *store.Raw {
 	return &store.Raw{
 		Bucket: config.DownloadHome,
@@ -94,11 +87,6 @@ func deleteTaskFiles(ctx context.Context, cacheStore *store.Store, taskID string
 	}
 
 	if err := cacheStore.Remove(ctx, getDownloadRaw(taskID)); err != nil &&
-		!store.IsKeyNotFound(err) {
-		return err
-	}
-
-	if err := cacheStore.Remove(ctx, getParentRaw(taskID)); err != nil &&
 		!store.IsKeyNotFound(err) {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: lowzj <zj3142063@gmail.com>

### Ⅰ. Describe what this PR did
Don't delete the parent directory of the task file, it may delete all the files in the same directory.
For example, there're 2 tasks in the same directory `5cb`:
```
./download
└── 5cb
    ├── 5cb71a86d65802a16c6bbb03037404b8d745d911157a449ba277dfa927df281f
    └── 5cbc448ab2b3b86b4bce66ca0f7994fd01db68c1f487cd3b85e64ff21a37625c
```
The `GC` mechanism or other procedure to delete task `5cb71a86d65802a16c6bbb03037404b8d745d911157a449ba277dfa927df281f`, it will also delete all the files in directory `5cb`.

### Ⅱ. Does this pull request fix one issue?
fixes: #1015 #1011 #970

Issue #810 maybe caused by this,  but not sure according to the logs provided.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


