### PR TITLE
fix: remove default registry definition in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY --from=builder /opt/dragonfly/df-client /opt/dragonfly/df-client
 EXPOSE 65001
 
 # use the https://index.docker.io as default registry.
-CMD [ "--registry", "https://index.docker.io" ]
+# more cli config see https://github.com/dragonflyoss/Dragonfly/blob/master/docs/cli_reference/dfdaemon.md
+# CMD [ "--registry", "https://index.docker.io" ]
 
 ENTRYPOINT [ "/opt/dragonfly/df-client/dfdaemon" ]

--- a/docs/config/dfdaemon_config_template.yml
+++ b/docs/config/dfdaemon_config_template.yml
@@ -61,7 +61,8 @@ ratelimit: 20M
 localrepo: /home/admin/.small-dragonfly/dfdaemon/data/
 
 # dfget path, which is the relative file path for the dfdaemon
-dfpath: ./dfget
+# default /opt/dragonfly/df-client/dfget
+dfpath: /opt/dragonfly/df-client/dfget
 
 # https options
 # port: 12001


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

fix: remove default registry definition in Dockerfile.
fix: change dfpath default value in dfdaemon config template.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

1. CLI的参数优先级大于配置文件的，官方镜像带了--registry参数， 导致使用的时候 必须手动覆盖掉
2. 修改配置文件的文档错误
