### PR TITLE
filter peers of different areas

### DIFF
--- a/apis/types/df_get_task.go
+++ b/apis/types/df_get_task.go
@@ -68,6 +68,9 @@ type DfGetTask struct {
 
 	// task Id
 	TaskID string `json:"taskId,omitempty"`
+
+	// area is the area of this peer
+	Area string `json:"area,omitempty"`
 }
 
 // Validate validates this df get task

--- a/apis/types/peer_create_request.go
+++ b/apis/types/peer_create_request.go
@@ -39,6 +39,9 @@ type PeerCreateRequest struct {
 
 	// version number of dfget binary.
 	Version string `json:"version,omitempty"`
+
+	// area is the area of this peer
+	Area string `json:"area,omitempty"`
 }
 
 // Validate validates this peer create request

--- a/apis/types/peer_info.go
+++ b/apis/types/peer_info.go
@@ -47,6 +47,9 @@ type PeerInfo struct {
 
 	// version number of dfget binary
 	Version string `json:"version,omitempty"`
+
+	// area is the area of this peer
+	Area string `json:"area,omitempty"`
 }
 
 // Validate validates this peer info

--- a/apis/types/task_create_request.go
+++ b/apis/types/task_create_request.go
@@ -101,6 +101,9 @@ type TaskCreateRequest struct {
 	// --filter parameter of dfget. The usage of it is that different rawURL may generate the same taskID.
 	//
 	TaskURL string `json:"taskURL,omitempty"`
+
+	// area is the area of this peer
+	Area string `json:"area,omitempty"`
 }
 
 // Validate validates this task create request

--- a/apis/types/task_register_request.go
+++ b/apis/types/task_register_request.go
@@ -119,6 +119,9 @@ type TaskRegisterRequest struct {
 
 	// version number of dfget binary.
 	Version string `json:"version,omitempty"`
+
+	// area is the area of this peer
+	Area string `json:"area,omitempty"`
 }
 
 // Validate validates this task register request

--- a/cmd/dfget/app/root.go
+++ b/cmd/dfget/app/root.go
@@ -163,6 +163,10 @@ func initProperties() ([]*propertiesResult, error) {
 		cfg.ClientQueueSize = properties.ClientQueueSize
 	}
 
+	if stringutils.IsEmptyStr(cfg.Area) {
+		cfg.Area = properties.Area
+	}
+
 	currentUser, err := user.Current()
 	if err != nil {
 		printer.Println(fmt.Sprintf("get user error: %s", err))
@@ -262,6 +266,10 @@ func initFlags() {
 		"be verbose")
 	flagSet.StringVar(&cfg.WorkHome, "home", cfg.WorkHome,
 		"the work home directory of dfget")
+
+	// area awareness
+	flagSet.StringVarP(&cfg.Area, "area", "a", "",
+		"the area of this peer")
 
 	// pass to peer server which as a uploader server
 	flagSet.StringVar(&cfg.RV.LocalIP, "ip", "",

--- a/dfget/config/config.go
+++ b/dfget/config/config.go
@@ -64,6 +64,9 @@ type Properties struct {
 	// E.g. ["192.168.33.21=1", "192.168.33.22=2"]
 	Supernodes []*NodeWeight `yaml:"nodes,omitempty" json:"nodes,omitempty"`
 
+	// The physical area of this Peer
+	Area string `yaml:"area,omitempty" json:"area,omitempty"`
+
 	// LocalLimit rate limit about a single download task, format: G(B)/g/M(B)/m/K(B)/k/B
 	// pure number will also be parsed as Byte.
 	LocalLimit rate.Rate `yaml:"localLimit,omitempty" json:"localLimit,omitempty"`
@@ -208,6 +211,9 @@ type Config struct {
 	// Verbose indicates whether to be verbose.
 	// If set true, log level will be 'debug'.
 	Verbose bool `json:"verbose,omitempty"`
+
+	// Area of this peer
+	Area string `json:"area,omitempty"`
 
 	// Nodes specify supernodes.
 	Nodes []string `json:"-"`

--- a/dfget/core/regist/register.go
+++ b/dfget/core/regist/register.go
@@ -145,6 +145,7 @@ func (s *supernodeRegister) constructRegisterRequest(port int) *types.RegisterRe
 		Headers:    cfg.Header,
 		Dfdaemon:   cfg.DFDaemon,
 		Insecure:   cfg.Insecure,
+		Area:       cfg.Area,
 	}
 	if cfg.Md5 != "" {
 		req.Md5 = cfg.Md5

--- a/dfget/types/register_request.go
+++ b/dfget/types/register_request.go
@@ -42,6 +42,7 @@ type RegisterRequest struct {
 	TaskID      string   `json:"taskId,omitempty"`
 	FileLength  int64    `json:"fileLength,omitempty"`
 	AsSeed      bool     `json:"asSeed,omitempty"`
+	Area        string   `json:"area,omitempty"`
 }
 
 func (r *RegisterRequest) String() string {

--- a/supernode/daemon/mgr/mock/mock_scheduler_mgr.go
+++ b/supernode/daemon/mgr/mock/mock_scheduler_mgr.go
@@ -37,9 +37,9 @@ func (m *MockSchedulerMgr) EXPECT() *MockSchedulerMgrMockRecorder {
 }
 
 // Schedule mocks base method
-func (m *MockSchedulerMgr) Schedule(ctx context.Context, taskID, clientID, peerID string) ([]*mgr.PieceResult, error) {
+func (m *MockSchedulerMgr) Schedule(ctx context.Context, taskID, area, clientID, peerID string) ([]*mgr.PieceResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Schedule", ctx, taskID, clientID, peerID)
+	ret := m.ctrl.Call(m, "Schedule", ctx, taskID, area, clientID, peerID)
 	ret0, _ := ret[0].([]*mgr.PieceResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1

--- a/supernode/daemon/mgr/peer/manager.go
+++ b/supernode/daemon/mgr/peer/manager.go
@@ -81,6 +81,7 @@ func (pm *Manager) Register(ctx context.Context, peerCreateRequest *types.PeerCr
 		HostName: peerCreateRequest.HostName,
 		Port:     peerCreateRequest.Port,
 		Version:  peerCreateRequest.Version,
+		Area:     peerCreateRequest.Area,
 		Created:  strfmt.DateTime(time.Now()),
 	}
 	pm.peerStore.Put(id, peerInfo)

--- a/supernode/daemon/mgr/scheduler/manager.go
+++ b/supernode/daemon/mgr/scheduler/manager.go
@@ -221,7 +221,6 @@ func (sm *Manager) tryGetPID(ctx context.Context, taskID, area string, pieceNum 
 		if needSkip {
 			continue
 		}
-		logrus.Infof("AREA tryGetPID peerIDs[i](%s) not skip by area", peerIDs[i])
 
 		// if failed to get peerState, and then it should not be needed.
 		peerState, err := sm.progressMgr.GetPeerStateByPeerID(ctx, peerIDs[i])
@@ -268,6 +267,7 @@ func (sm *Manager) tryGetPID(ctx context.Context, taskID, area string, pieceNum 
 	return
 }
 
+// filterPeerByArea return true if the dst Peer needs to be skiped
 func (sm *Manager) filterPeerByArea(ctx context.Context, area, dstPID string) bool {
 
 	// if src peer not specify area parameter, all the other peers can serve it
@@ -275,7 +275,7 @@ func (sm *Manager) filterPeerByArea(ctx context.Context, area, dstPID string) bo
 		return false
 	}
 
-	//supernode serves all the peers who has registerd to it
+	//supernode serves all the peers who has registered to it
 	if sm.cfg.IsSuperPID(dstPID) {
 		return false
 	}

--- a/supernode/daemon/mgr/scheduler/manager_test.go
+++ b/supernode/daemon/mgr/scheduler/manager_test.go
@@ -41,8 +41,8 @@ func init() {
 type SchedulerMgrTestSuite struct {
 	mockCtl         *gomock.Controller
 	mockProgressMgr *mock.MockProgressMgr
-
-	manager *Manager
+	mockPeerMgr     *mock.MockPeerMgr
+	manager         *Manager
 }
 
 func (s *SchedulerMgrTestSuite) SetUpSuite(c *check.C) {
@@ -50,9 +50,11 @@ func (s *SchedulerMgrTestSuite) SetUpSuite(c *check.C) {
 	s.mockProgressMgr = mock.NewMockProgressMgr(s.mockCtl)
 	s.mockProgressMgr.EXPECT().GetPeerIDsByPieceNum(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{"peerID"}, nil).AnyTimes()
 
+	s.mockPeerMgr = mock.NewMockPeerMgr(s.mockCtl)
+
 	cfg := config.NewConfig()
 	cfg.SetSuperPID("fooPid")
-	s.manager, _ = NewManager(cfg, s.mockProgressMgr)
+	s.manager, _ = NewManager(cfg, s.mockPeerMgr, s.mockProgressMgr)
 }
 
 func (s *SchedulerMgrTestSuite) TearDownSuite(c *check.C) {

--- a/supernode/daemon/mgr/scheduler_mgr.go
+++ b/supernode/daemon/mgr/scheduler_mgr.go
@@ -30,5 +30,5 @@ type PieceResult struct {
 // SchedulerMgr is responsible for calculating scheduling results according to certain rules.
 type SchedulerMgr interface {
 	// Schedule gets scheduler result with specified taskID, clientID and peerID through some rules.
-	Schedule(ctx context.Context, taskID, clientID, peerID string) ([]*PieceResult, error)
+	Schedule(ctx context.Context, taskID, area, clientID, peerID string) ([]*PieceResult, error)
 }

--- a/supernode/daemon/mgr/task/manager_util.go
+++ b/supernode/daemon/mgr/task/manager_util.go
@@ -214,6 +214,7 @@ func (tm *Manager) addDfgetTask(ctx context.Context, req *types.TaskCreateReques
 		TaskID:      task.ID,
 		PeerID:      req.PeerID,
 		SupernodeIP: req.SupernodeIP,
+		Area:        req.Area,
 	}
 
 	if err := tm.dfgetTaskMgr.Add(ctx, dfgetTask); err != nil {
@@ -350,7 +351,7 @@ func (tm *Manager) parseAvailablePeers(ctx context.Context, clientID string, tas
 	// get scheduler pieceResult
 	logrus.Debugf("start scheduler for taskID: %s clientID: %s", task.ID, clientID)
 	startTime := time.Now()
-	pieceResult, err := tm.schedulerMgr.Schedule(ctx, task.ID, clientID, dfgetTask.PeerID)
+	pieceResult, err := tm.schedulerMgr.Schedule(ctx, task.ID, dfgetTask.Area, clientID, dfgetTask.PeerID)
 	if err != nil {
 		return false, nil, err
 	}

--- a/supernode/server/0.3_bridge.go
+++ b/supernode/server/0.3_bridge.go
@@ -106,6 +106,7 @@ func (s *Server) registry(ctx context.Context, rw http.ResponseWriter, req *http
 		HostName: strfmt.Hostname(request.HostName),
 		Port:     request.Port,
 		Version:  request.Version,
+		Area:     request.Area,
 	}
 	peerCreateResponse, err := s.PeerMgr.Register(ctx, peerCreateRequest)
 	if err != nil {
@@ -127,6 +128,7 @@ func (s *Server) registry(ctx context.Context, rw http.ResponseWriter, req *http
 		RawURL:      request.RawURL,
 		TaskURL:     request.TaskURL,
 		SupernodeIP: request.SuperNodeIP,
+		Area:        request.Area,
 	}
 	s.originClient.RegisterTLSConfig(taskCreateRequest.RawURL, request.Insecure, request.RootCAs)
 	resp, err := s.TaskMgr.Register(ctx, taskCreateRequest)

--- a/supernode/server/server.go
+++ b/supernode/server/server.go
@@ -90,7 +90,7 @@ func New(cfg *config.Config, logger *logrus.Logger, register prometheus.Register
 		return nil, err
 	}
 
-	schedulerMgr, err := scheduler.NewManager(cfg, progressMgr)
+	schedulerMgr, err := scheduler.NewManager(cfg, peerMgr, progressMgr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR implements the area awareness scheduler policy to the peers.
Previous discussion as the issue 428:
https://github.com/dragonflyoss/Dragonfly/issues/428

When dfget takes no area parameter,  supernode scheduler policy does not channge.
When dfget take a area with register reqeust, supernode keeps the area info with peerMgr and dfgetTask, and schedule the pieces downloading requests of src peer to the dst peers which is in the same areas. If no dst peer can be found within the same area, supernode will schedule the pieces downloading request to cdn mgr.


 
