### PR TITLE
bugfix: fix dfget panic when crossWrite is true

### DIFF
--- a/dfget/core/downloader/p2p_downloader/client_stream_writer.go
+++ b/dfget/core/downloader/p2p_downloader/client_stream_writer.go
@@ -164,7 +164,7 @@ func (csw *ClientStreamWriter) writePieceToPipe(p *Piece) error {
 			break
 		}
 
-		_, err := io.Copy(csw.pipeWriter, p.RawContent(csw.cdnSource == apiTypes.CdnSourceSource))
+		_, err := p.WriteTo(csw.pipeWriter, csw.cdnSource == apiTypes.CdnSourceSource)
 		if err != nil {
 			return err
 		}

--- a/dfget/core/downloader/p2p_downloader/client_writer.go
+++ b/dfget/core/downloader/p2p_downloader/client_writer.go
@@ -18,7 +18,6 @@ package downloader
 
 import (
 	"context"
-	"io"
 	"math/rand"
 	"os"
 	"time"
@@ -220,6 +219,7 @@ func (cw *ClientWriter) write(piece *Piece) error {
 	}
 
 	if cw.acrossWrite {
+		piece.IncWriter()
 		cw.targetQueue.Put(piece)
 	}
 
@@ -245,7 +245,7 @@ func writePieceToFile(piece *Piece, file *os.File, cdnSource apiTypes.CdnSource)
 	}
 
 	writer := pool.AcquireWriter(file)
-	_, err := io.Copy(writer, piece.RawContent(noWrapper))
+	_, err := piece.WriteTo(writer, noWrapper)
 	pool.ReleaseWriter(writer)
 	writer = nil
 	return err


### PR DESCRIPTION

Signed-off-by: zhouchencheng <zhouchencheng@bilibili.com>


### Ⅰ. Describe what this PR did
when  dfget's `--output` and `--home`  directories are mounted under different disk device, it makes the hard link between them fails to create. At that time, `crossWrite` will be true.

And the same piece will be written to different files twice. Currently the `autoreset` field in piece is always true, so the piece buffer will reset after the first written, then the second written will trigger panic.

### Ⅱ. Does this pull request fix one issue?
fixes #1410


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


