### PR TITLE
fix buffer overwrite issue

### DIFF
--- a/dfget/core/downloader/p2p_downloader/client_stream_writer.go
+++ b/dfget/core/downloader/p2p_downloader/client_stream_writer.go
@@ -165,6 +165,9 @@ func (csw *ClientStreamWriter) writePieceToPipe(p *Piece) error {
 		}
 
 		_, err := io.Copy(csw.pipeWriter, p.RawContent(csw.cdnSource == apiTypes.CdnSourceSource))
+		if p.autoReset {
+			p.ResetContent()
+		}
 		if err != nil {
 			return err
 		}

--- a/dfget/core/downloader/p2p_downloader/client_writer.go
+++ b/dfget/core/downloader/p2p_downloader/client_writer.go
@@ -246,6 +246,9 @@ func writePieceToFile(piece *Piece, file *os.File, cdnSource apiTypes.CdnSource)
 
 	writer := pool.AcquireWriter(file)
 	_, err := io.Copy(writer, piece.RawContent(noWrapper))
+	if piece.autoReset {
+		piece.ResetContent()
+	}
 	pool.ReleaseWriter(writer)
 	writer = nil
 	return err

--- a/dfget/core/downloader/p2p_downloader/piece.go
+++ b/dfget/core/downloader/p2p_downloader/piece.go
@@ -66,11 +66,6 @@ type Piece struct {
 func (p *Piece) RawContent(noWrapper bool) *bytes.Buffer {
 	contents := p.Content.Bytes()
 	length := len(contents)
-	defer func() {
-		if p.autoReset {
-			p.ResetContent()
-		}
-	}()
 
 	if noWrapper {
 		return bytes.NewBuffer(contents[:])


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

RawContent func returns a buffer io, when enable autoReset, the buffer io can be reused by AcquireBufferSize, so, if first piece is processed slow than an other, the faster piece will overwrite buffer.

```
func (p *Piece) RawContent(noWrapper bool) *bytes.Buffer {
	contents := p.Content.Bytes()
	length := len(contents)
	defer func() {
		if p.autoReset {
			p.ResetContent()
		}
	}()

	if noWrapper {
		return bytes.NewBuffer(contents[:])
	}
	if length >= 5 {
		return bytes.NewBuffer(contents[4 : length-1])
	}
	return nil
}
```

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fix #1415 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

N/A

### Ⅳ. Describe how to verify it

N/A

### Ⅴ. Special notes for reviews


