### PR TITLE
Fix the bug in unit tests about sync.Pool

### DIFF
--- a/pkg/pool/writer_pool_test.go
+++ b/pkg/pool/writer_pool_test.go
@@ -1,3 +1,6 @@
+// WriterPool is no-op under race detector, so all these tests do not work.
+// +build !race
+
 /*
  * Copyright The Dragonfly Authors.
  *
@@ -19,6 +22,7 @@ package pool
 import (
 	"bytes"
 	"io/ioutil"
+	"runtime"
 	"sync"
 	"testing"
 
@@ -26,6 +30,11 @@ import (
 )
 
 func TestWriter(t *testing.T) {
+	// Limit to 1 processor to make sure that the goroutine doesn't migrate
+	// to another P between AcquireWriter and ReleaseWriter calls.
+	prev := runtime.GOMAXPROCS(1)
+	defer runtime.GOMAXPROCS(prev)
+
 	tmp := writerPool
 	writerPool = &sync.Pool{}
 


### PR DESCRIPTION

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Callers should not assume any relation between values passed to `Put` and the values returned by `Get`.

Ref: https://github.com/golang/go/blob/master/src/sync/pool.go#L116-L151
```go
// Get selects an arbitrary item from the Pool, removes it from the
// Pool, and returns it to the caller.
// Get may choose to ignore the pool and treat it as empty.
// Callers should not assume any relation between values passed to Put and
// the values returned by Get.
//
// If Get would otherwise return nil and p.New is non-nil, Get returns
// the result of calling p.New.
func (p *Pool) Get() interface{} {
```

Ref: https://github.com/golang/go/blob/master/src/sync/pool_test.go#L28-L42
```go
	// Make sure that the goroutine doesn't migrate to another P
	// between Put and Get calls.
	Runtime_procPin()
	p.Put("a")
	p.Put("b")
	if g := p.Get(); g != "a" {
		t.Fatalf("got %#v; want a", g)
	}
	if g := p.Get(); g != "b" {
		t.Fatalf("got %#v; want b", g)
	}
	if g := p.Get(); g != nil {
		t.Fatalf("got %#v; want nil", g)
	}
	Runtime_procUnpin()
```

It seems that we should pin the P when do the unit test :)

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
Fixes: #1416

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it

```sh
make unit-test
```


### Ⅴ. Special notes for reviews


