### PR TITLE
bugfix: fix missing error message 'Unable to autodetect advertiser ip…

### DIFF
--- a/cmd/supernode/app/root.go
+++ b/cmd/supernode/app/root.go
@@ -375,8 +375,8 @@ func setAdvertiseIP(cfg *config.Config) error {
 		return errors.Wrapf(errortypes.ErrSystemError, "failed to get ip list: %v", err)
 	}
 	if len(ipList) == 0 {
-		logrus.Debugf("get empty system's unicast interface addresses")
-		return nil
+		logrus.Errorf("get empty system's unicast interface addresses")
+		return errors.Wrapf(errortypes.ErrSystemError, "Unable to autodetect advertiser ip, please set it via --advertise-ip")
 	}
 
 	cfg.AdvertiseIP = ipList[0]


### PR DESCRIPTION
…, please set it via --advertise-ip'

related to #1428

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
This PR have fixed the missing error message bug in #1428. 

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
Fixes #1428.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

There is already a root_test file, and the test  need under the condition when the container  only shows the loopback address.

### Ⅳ. Describe how to verify it

Just return error when only can get the loopback address instead of writing debug information into the logs.
 ### Ⅴ. Special notes for reviews
None.

