### PR TITLE
bugfix: notify supernode client piece task success under cdn pattern

### DIFF
--- a/dfget/core/downloader/p2p_downloader/client_writer.go
+++ b/dfget/core/downloader/p2p_downloader/client_writer.go
@@ -215,6 +215,7 @@ func (cw *ClientWriter) write(piece *Piece) error {
 	startTime := time.Now()
 	if !cw.p2pPattern {
 		cw.targetQueue.Put(piece)
+		go sendSuccessPiece(cw.api, cw.cfg.RV.Cid, piece, time.Since(startTime), cw.notifyQueue)
 		return nil
 	}
 


### PR DESCRIPTION
Signed-off-by: zhouchencheng <zhouchencheng@bilibili.com>

### Ⅰ. Describe what this PR did
dfget should notify supernode to mark client piece task success after the piece has been download by it.

### Ⅱ. Does this pull request fix one issue?
fixes #1434 
fixes #1392


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


