### PR TITLE
docs: modify the container id to be run in user guide

### DIFF
--- a/docs/user_guide/install_server.md
+++ b/docs/user_guide/install_server.md
@@ -70,8 +70,7 @@ Or you can build your own supernode image.
 **NOTE:** Replace ${supernodeDockerImageId} with the ID obtained at the previous step.
 
 ```sh
-version=1.0.0
-docker run -d --name supernode --restart=always -p 8001:8001 -p 8002:8002 -v /home/admin/supernode:/home/admin/supernode dragonflyoss/supernode:$version --download-port=8001
+docker run -d --name supernode --restart=always -p 8001:8001 -p 8002:8002 -v /home/admin/supernode:/home/admin/supernode ${supernodeDockerImageId} --download-port=8001
 ```
 
 ## Procedure - When Deploying with Physical Machines


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

In the [Start Supernode](https://github.com/qhb1001/Dragonfly/blob/master/docs/user_guide/install_server.md#start-supernode) section of server installation user guide, the environment variable `${supernodeDockerImageId}` is not added into the command below. 

If the default command is executed, the user-defined docker container will not be run. Rather, the official supernode would be started. And I correct the container to be run.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

None

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

docs

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


