### PR TITLE
bugfix: dfdaemon does not back to source when download failed by dfget

### DIFF
--- a/dfdaemon/exception/errors.go
+++ b/dfdaemon/exception/errors.go
@@ -24,8 +24,8 @@ func (authError *AuthError) Error() string {
 	return "NOT AUTH"
 }
 
-// IsNotAuth is to judge whether an error is AuthError.
-func IsNotAuth(err error) bool {
+// IsAuthError is to judge whether an error is AuthError.
+func IsAuthError(err error) bool {
 	if _, ok := err.(*AuthError); ok {
 		return true
 	}

--- a/dfdaemon/transport/transport.go
+++ b/dfdaemon/transport/transport.go
@@ -138,7 +138,7 @@ func (roundTripper *DFRoundTripper) RoundTrip(req *http.Request) (*http.Response
 		// result for different requests
 		req.Header.Del("Accept-Encoding")
 		logrus.Debugf("round trip with dfget: %s", req.URL.String())
-		if res, err := roundTripper.download(req, req.URL.String()); err == nil || !exception.IsNotAuth(err) {
+		if res, err := roundTripper.download(req, req.URL.String()); err == nil || exception.IsAuthError(err) {
 			return res, err
 		}
 	}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
bugfix: dfdaemon does not back to source when download failed by dfget

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
no

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

N/A

### Ⅳ. Describe how to verify it
N/A

### Ⅴ. Special notes for reviews


