### PR TITLE
 bugfix(dfget) fix panic for slice bounds out of range when sendSuccessPiece

### DIFF
--- a/dfget/core/downloader/p2p_downloader/client_writer.go
+++ b/dfget/core/downloader/p2p_downloader/client_writer.go
@@ -291,7 +291,7 @@ func sendSuccessPiece(api api.SupernodeAPI, cid string, piece *Piece, cost time.
 
 	if cost.Seconds() > 2.0 {
 		logrus.Infof(
-			"async writer and report suc from dst:%s... cost:%.3f for range:%s",
-			piece.DstCid[:25], cost.Seconds(), piece.Range)
+			"async writer and report suc from dst:%s cost:%.3f for range:%s",
+			piece.DstCid, cost.Seconds(), piece.Range)
 	}
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

bugfix(dfget) fix panic for slice bounds out of range when sendSuccessPiece

### Ⅱ. Does this pull request fix one issue?
NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
N/A

### Ⅳ. Describe how to verify it
N/A

### Ⅴ. Special notes for reviews

panic log:

--2020-09-27 13:58:52--  http://xxx:10086/v1/filecontent?path=/home/yunwei/papapa/1072116196/inventory-20200805160005-shard_2-segment858.idx

dfget version:1.0.4

workspace:/root/.small-dragonfly

sign:18761-1601186332.332

client:xxx connected to node:xxx:8002

start download by dragonfly...

migrated to node:xxx:8002

panic: runtime error: slice bounds out of range

goroutine 68 [running]:

github.com/dragonflyoss/Dragonfly/dfget/core/downloader/p2p_downloader.sendSuccessPiece(0xbbbec0, 0xc000458030, 0xc00009e060, 0x22, 0xc0000e0600, 0x12916dce5, 0xbba4c0, 0xc0000ae548)

\t/go/src/github.com/dragonflyoss/Dragonfly/dfget/core/downloader/p2p_downloader/client_writer.go:294 +0x5f8

created by github.com/dragonflyoss/Dragonfly/dfget/core/downloader/p2p_downloader.(*ClientWriter).write

\t/go/src/github.com/dragonflyoss/Dragonfly/dfget/core/downloader/p2p_downloader/client_writer.go:229 +0x170

