### PR TITLE
Fix unlimited piece concurrent download

### DIFF
--- a/cmd/dfget/app/root.go
+++ b/cmd/dfget/app/root.go
@@ -262,6 +262,8 @@ func initFlags() {
 		"be verbose")
 	flagSet.StringVar(&cfg.WorkHome, "home", cfg.WorkHome,
 		"the work home directory of dfget")
+	flagSet.IntVar(&cfg.MaxPieceConcurrent, "max-piece-concurrent", 100,
+		"maximum concurrent goroutines to download pieces")
 
 	// pass to peer server which as a uploader server
 	flagSet.StringVar(&cfg.RV.LocalIP, "ip", "",

--- a/dfget/config/config.go
+++ b/dfget/config/config.go
@@ -235,6 +235,9 @@ type Config struct {
 	// The reason of backing to source.
 	BackSourceReason int `json:"-"`
 
+	// Maximum concurrent goroutines to download pieces
+	MaxPieceConcurrent int `json:"maxPieceConcurrent"`
+
 	// Embedded Properties holds all configurable properties.
 	Properties
 }

--- a/dfget/config/config.go
+++ b/dfget/config/config.go
@@ -261,6 +261,7 @@ func NewConfig() *Config {
 	}
 	cfg.User = currentUser.Username
 	cfg.RV.FileLength = -1
+	cfg.MaxPieceConcurrent = 100
 	cfg.ConfigFiles = []string{DefaultYamlConfigFile, DefaultIniConfigFile}
 	return cfg
 }

--- a/dfget/config/config_test.go
+++ b/dfget/config/config_test.go
@@ -54,13 +54,12 @@ func (suite *ConfigSuite) SetUpTest(c *check.C) {
 
 func (suite *ConfigSuite) TestConfig_String(c *check.C) {
 	cfg := NewConfig()
-	expected := "{\"url\":\"\",\"output\":\"\""
+	expected := `{"url":"","output":""`
 	c.Assert(strings.Contains(cfg.String(), expected), check.Equals, true)
 	cfg.LocalLimit = 20 * rate.MB
 	cfg.MinRate = 64 * rate.KB
 	cfg.Pattern = "p2p"
-	expected = "\"url\":\"\",\"output\":\"\",\"pattern\":\"p2p\"," +
-		"\"localLimit\":\"20MB\",\"minRate\":\"64KB\""
+	expected = `"url":"","output":"","pattern":"p2p","maxPieceConcurrent":100,"localLimit":"20MB","minRate":"64KB"`
 	c.Assert(strings.Contains(cfg.String(), expected), check.Equals, true)
 }
 
@@ -176,7 +175,8 @@ func (suite *ConfigSuite) TestProperties_Load(c *check.C) {
 			content: "nodes:\n\t- 10.10.10.1", errMsg: "yaml", expected: nil},
 		{create: true, ext: "yaml",
 			content: "nodes:\n  - 10.10.10.1\n  - 10.10.10.2\n",
-			errMsg:  "", expected: &Properties{Supernodes: []*NodeWeight{
+			errMsg:  "",
+			expected: &Properties{Supernodes: []*NodeWeight{
 				{"10.10.10.1:8002", 1},
 				{"10.10.10.2:8002", 1},
 			}}},


### PR DESCRIPTION
Signed-off-by: Jim Ma <majinjing3@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Add a flat to limit piece concurrency.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

Sometime supernode schedules a lot of pieces for one dfget task, currently, dfget will download all pieces concurrently, while cost a lot of memory.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

N/A

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


