### PR TITLE
bugfix: fix connection leak when statuscode check is not passed

### DIFF
--- a/supernode/httpclient/origin_http_client.go
+++ b/supernode/httpclient/origin_http_client.go
@@ -186,6 +186,7 @@ func (client *OriginClient) Download(url string, headers map[string]string, chec
 	if checkCode(resp.StatusCode) {
 		return resp, nil
 	}
+	resp.Body.Close()
 	return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 }
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

When CDN is triggered, the supernode will send http request to the sourceUrl to download the file.
If the http response status code is not 200 or 206(e.g. 403), the transport will not be closed.
This PR fixes this bug. 

### Ⅱ. Does this pull request fix one issue?

yes.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

Obviously, resp.Body.Close() is always needed.

### Ⅳ. Describe how to verify it

Providing an file download url which needs authentication (for example, a s3 share link), use dfget to download that file for hundreds of  times.

Then `watch "lsof | grep socket | wc -l"` on the supernode server, lots of sockets will be open even if the dfget tasks are already failed.

### Ⅴ. Special notes for reviews

none
