### PR TITLE
Add ARM64 in goreleaser and Travis-CI

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,9 +13,13 @@ builds:
     main: cmd/supernode/main.go
     goarch:
       - amd64
+      - arm64
     goos:
       - linux
       - darwin
+    ignore:
+      - goos: darwin
+        goarch: arm64
     ldflags:
       - -s -w -X github.com/dragonflyoss/Dragonfly/version.version={{.Version}}
       - -X github.com/dragonflyoss/Dragonfly/version.revision={{.ShortCommit}}
@@ -26,9 +30,13 @@ builds:
     main: cmd/dfget/main.go
     goarch:
       - amd64
+      - arm64
     goos:
       - linux
       - darwin
+    ignore:
+      - goos: darwin
+        goarch: arm64
     ldflags:
       - -s -w -X github.com/dragonflyoss/Dragonfly/version.version={{.Version}}
       - -X github.com/dragonflyoss/Dragonfly/version.revision={{.ShortCommit}}
@@ -39,9 +47,13 @@ builds:
     main: cmd/dfdaemon/main.go
     goarch:
       - amd64
+      - arm64
     goos:
       - linux
       - darwin
+    ignore:
+      - goos: darwin
+        goarch: arm64
     ldflags:
       - -s -w -X github.com/dragonflyoss/Dragonfly/version.version={{.Version}}
       - -X github.com/dragonflyoss/Dragonfly/version.revision={{.ShortCommit}}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@
 services:
   - docker
 sudo: false
+arch:
+  - amd64
+  - arm64
 git:
   depth: false
 language: go

--- a/Dockerfile.supernode
+++ b/Dockerfile.supernode
@@ -11,7 +11,7 @@ ARG GOPROXY
 RUN make build-supernode && make install-supernode
 RUN make build-client && make install-client
 
-FROM dragonflyoss/nginx:apline
+FROM nginx:1.19.2-alpine
 
 RUN apk --no-cache add ca-certificates bash
 


### PR DESCRIPTION
- Updated the .goreleaser.yml file to generate linux/arm64 binaries.
- Added arm64 job in Travis-CI.
- Replaced dragonflyoss/nginx:apline with nginx:1.19.2-alpine image for supernode image.

Resolves #1486.