### PR TITLE
修复bug或优化，对已经下载完成的片，客户端再次获得supernode调度后，上报当前片成功的状态。

### DIFF
--- a/dfget/core/downloader/p2p_downloader/client_writer.go
+++ b/dfget/core/downloader/p2p_downloader/client_writer.go
@@ -295,38 +295,3 @@ func sendSuccessPiece(api api.SupernodeAPI, cid string, piece *Piece, cost time.
 			piece.DstCid, cost.Seconds(), piece.Range)
 	}
 }
-
-func sendSuccessAlreadyDownloadedPiece(api api.SupernodeAPI, node string, taskID string, cid string, dstCid string, pieceRange string, notifyQueue queue.Queue) {
-	reportPieceRequest := &types.ReportPieceRequest{
-		TaskID:     taskID,
-		Cid:        cid,
-		DstCid:     dstCid,
-		PieceRange: pieceRange,
-	}
-
-	var retry = 0
-	var maxRetryTime = 3
-	for {
-		if retry >= maxRetryTime {
-			logrus.Errorf("failed to report piece to supernode with request(%+v) even after retrying max retry time", reportPieceRequest)
-			break
-		}
-
-		_, err := api.ReportPiece(node, reportPieceRequest)
-		if err == nil {
-			if notifyQueue != nil {
-				notifyQueue.Put("success")
-			}
-			if retry > 0 {
-				logrus.Warnf("success to report piece with request(%+v) after retrying (%d) times", reportPieceRequest, retry)
-			}
-			break
-		}
-
-		sleepTime := time.Duration(rand.Intn(500)+50) * time.Millisecond
-		logrus.Warnf("failed to report piece to supernode with request(%+v) for (%d) times and will retry after sleep %.3fs", reportPieceRequest, retry, sleepTime.Seconds())
-		time.Sleep(sleepTime)
-		retry++
-	}
-
-}

--- a/dfget/core/downloader/p2p_downloader/client_writer.go
+++ b/dfget/core/downloader/p2p_downloader/client_writer.go
@@ -296,9 +296,9 @@ func sendSuccessPiece(api api.SupernodeAPI, cid string, piece *Piece, cost time.
 	}
 }
 
-func sendSuccessAlreadyDownloadedPiece(api api.SupernodeAPI, node string, taskId string, cid string, dstCid string, pieceRange string, notifyQueue queue.Queue) {
+func sendSuccessAlreadyDownloadedPiece(api api.SupernodeAPI, node string, taskID string, cid string, dstCid string, pieceRange string, notifyQueue queue.Queue) {
 	reportPieceRequest := &types.ReportPieceRequest{
-		TaskID:     taskId,
+		TaskID:     taskID,
 		Cid:        cid,
 		DstCid:     dstCid,
 		PieceRange: pieceRange,

--- a/dfget/core/downloader/p2p_downloader/p2p_downloader.go
+++ b/dfget/core/downloader/p2p_downloader/p2p_downloader.go
@@ -459,14 +459,9 @@ func (p2p *P2PDownloader) processPiece(response *types.PullPieceTaskResponse,
 		v, ok := p2p.pieceSet[pieceRange]
 		if ok && v {
 			alreadyDownload = append(alreadyDownload, pieceRange)
-			p2p.queue.Put(NewPiece(p2p.taskID,
-				p2p.node,
-				pieceTask.Cid,
-				pieceRange,
-				constants.ResultSemiSuc,
-				constants.TaskStatusRunning,
-				p2p.RegisterResult.CDNSource))
-			go sendSuccessAlreadyDownloadedPiece(p2p.API, p2p.node, p2p.taskID, p2p.cfg.RV.Cid, pieceTask.Cid, pieceTask.Range, p2p.notifyQueue)
+			alreadyDownloadedPiece := NewPiece(p2p.taskID, p2p.node, pieceTask.Cid, pieceRange, constants.ResultSemiSuc, constants.TaskStatusRunning, p2p.RegisterResult.CDNSource)
+			p2p.queue.Put(alreadyDownloadedPiece)
+			go sendSuccessPiece(p2p.API, p2p.cfg.RV.Cid, alreadyDownloadedPiece, 0, p2p.notifyQueue)
 			continue
 		}
 		if !ok {

--- a/dfget/core/downloader/p2p_downloader/p2p_downloader.go
+++ b/dfget/core/downloader/p2p_downloader/p2p_downloader.go
@@ -466,6 +466,7 @@ func (p2p *P2PDownloader) processPiece(response *types.PullPieceTaskResponse,
 				constants.ResultSemiSuc,
 				constants.TaskStatusRunning,
 				p2p.RegisterResult.CDNSource))
+			go sendSuccessAlreadyDownloadedPiece(p2p.API, p2p.node, p2p.taskID, p2p.cfg.RV.Cid, pieceTask.Cid, pieceTask.Range, p2p.notifyQueue)
 			continue
 		}
 		if !ok {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

修复bug或优化，对已经下载完成的片，客户端再次获得supernode调度后，上报当前片成功的状态。

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

无

### Ⅳ. Describe how to verify it

下载大文件>=2G，首次下载中（该文件supernode不具备cdn资源，dfclent不具备p2p资源，即客户端与服务端都没有该文件），在dfclent使用p2p下载过程中的某个时刻（此时supernode cdn已填充完毕或者填充过程中），删除supernode的cdn资源，因为资源被删除，此时会引发dfclent下载片http 404，dfclient会上报该片的错误信息，supernode收到错误信息后，会将此文件对应task信息全部清除，清除后，dfclient请求supernode失败后触发迁移（即更换其他supernode再次下载），触发迁移逻辑后，由于结构P2PDownloader的pieceSet未被重新初始化，再次请求调度后，某些片信息被认为是（already downloaded piece）已存在的状态，已存在逻辑中直接跳过了对片的处理，导致某些已存在的片未得到重新汇报success的状态，但其实该文件在客户端已经是完整的，但是supernode没有收到dfclient汇报成功状态导致一直被调度，而调度的片dfclient认为已存在又被跳过，所以陷入了一种死循环的状态，简单理解为 dfclient 认为piece 0 已存在，supernode 认为在dfclient piece 0不存在，当dfclient请求调度后，supernode将 piece 0再次调度。
此问题在，dragonfly 1.01中已稳定复现，在新版本中，由于bug已修复 4bbbc80 fix: delete empty directory in local storage，触发概率将大大降低。