### PR TITLE
fix password too small error 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,8 +147,8 @@ release:  ## Build a release
 .PHONY: release
 
 df.key:
-	openssl genrsa -des3 -passout pass:x -out df.pass.key 2048
-	openssl rsa -passin pass:x -in df.pass.key -out df.key
+	openssl genrsa -des3 -passout pass:xxxx -out df.pass.key 2048
+	openssl rsa -passin pass:xxxx -in df.pass.key -out df.key
 	rm df.pass.key
 
 df.crt: df.key


### PR DESCRIPTION
Signed-off-by: Dominic Yin <yindongchao@inspur.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

change default `passin` and `passout` to `xxxx` to avoid password too short error when `make df.crt`

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fix #1525 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


