### PR TITLE
fix typo: fix comment for type SchedulePieceDataResult

### DIFF
--- a/dfget/corev2/basic/types.go
+++ b/dfget/corev2/basic/types.go
@@ -28,7 +28,7 @@ type SchedulePeerInfo struct {
 	Path string
 }
 
-// SchedulerResult defines the result of schedule of range data.
+// SchedulePieceDataResult defines the result of schedule of range data.
 type SchedulePieceDataResult struct {
 	Off  int64
 	Size int64


### PR DESCRIPTION
Signed-off-by: Guangwen Feng <fenggw-fnst@cn.fujitsu.com>

### Ⅰ. Describe what this PR did
Fix incorrect comment in dfget/corev2/basic/types.go, 'SchedulerResult' -> 'SchedulePieceDataResult'

### Ⅱ. Does this pull request fix one issue?
NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

### Ⅳ. Describe how to verify it

### Ⅴ. Special notes for reviews
