### PR TITLE
enable abbreviated commit object as fallback 

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -9,7 +9,7 @@ DFGET_BINARY_NAME=dfget
 SUPERNODE_BINARY_NAME=supernode
 PKG=github.com/dragonflyoss/Dragonfly
 BUILD_IMAGE=golang:1.13.15
-VERSION=$(git describe --tags "$(git rev-list --tags --max-count=1)")
+VERSION=$(git describe --tags --always "$(git rev-list --tags --max-count=1)")
 REVISION=$(git rev-parse --short HEAD)
 DATE=$(date "+%Y%m%d-%H:%M:%S")
 LDFLAGS="-X ${PKG}/version.version=${VERSION:1} -X ${PKG}/version.revision=${REVISION} -X ${PKG}/version.buildDate=${DATE}"


### PR DESCRIPTION
enable abbreviated commit object as fallback  when getting version at building

Signed-off-by: Dominic Yin <yindongchao@inspur.com>

### Ⅰ. Describe what this PR did

In some situations there could be no tag info in repo if user did not run ` git fetch --tags` by hand, which will leads to error on `git describe --tags`

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


