### PR TITLE
add stat_linux_mips64le.go to support for building on mips64el

### DIFF
--- a/pkg/stat/stat_linux_mips64le.go
+++ b/pkg/stat/stat_linux_mips64le.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright The Dragonfly Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package util
+
+import (
+	"syscall"
+	"time"
+)
+
+// Atime returns the last access time in time.Time.
+func Atime(stat *syscall.Stat_t) time.Time {
+	return time.Unix(stat.Atim.Sec, stat.Atim.Nsec)
+}
+
+// AtimeSec returns the last access time in seconds.
+func AtimeSec(stat *syscall.Stat_t) int64 {
+	return stat.Atim.Sec
+}
+
+// Ctime returns the create time in time.Time.
+func Ctime(stat *syscall.Stat_t) time.Time {
+	return time.Unix(stat.Ctim.Sec, stat.Ctim.Nsec)
+}
+
+// CtimeSec returns the create time in seconds.
+func CtimeSec(stat *syscall.Stat_t) int64 {
+	return stat.Ctim.Sec
+}


### PR DESCRIPTION
Signed-off-by: Dominic Yin <yindongchao@inspur.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

add stat_linux_mips64le.go to support for building on mips64el

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)


### Ⅳ. Describe how to verify it
```sh
# export GOOS=linux
# export GOARCH=mips64le
# make build
Begin to build dfget, dfdaemon and supernode.
./hack/build.sh
Begin to build in the local environment.
BUILD: dfget in /src/bin/linux_mips64le/dfget
BUILD: dfdaemon in /src/bin/linux_mips64le/dfdaemon
BUILD: supernode in /src/bin/linux_mips64le/supernode
```
### Ⅴ. Special notes for reviews


