### PR TITLE
feat(dfdaemon): add disk usage metrics

### DIFF
--- a/client/daemon/metrics/metrics.go
+++ b/client/daemon/metrics/metrics.go
@@ -99,7 +99,7 @@ var (
 		Namespace: types.MetricsNamespace,
 		Subsystem: types.DfdaemonMetricsName,
 		Name:      "piece_task_total",
-		Help:      "Counter of the total failed piece tasks.",
+		Help:      "Counter of the total piece tasks.",
 	})
 
 	PieceTaskFailedCount = promauto.NewCounter(prometheus.CounterOpts{
@@ -171,6 +171,41 @@ var (
 		Name:      "version",
 		Help:      "Version info of the service.",
 	}, []string{"major", "minor", "git_version", "git_commit", "platform", "build_time", "go_version", "go_tags", "go_gcflags"})
+
+	DataDiskUsage = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: types.MetricsNamespace,
+		Subsystem: types.DfdaemonMetricsName,
+		Name:      "data_disk_usage_total",
+		Help:      "Gauger of the disk usage of data directory.",
+	})
+
+	DataDiskCapacity = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: types.MetricsNamespace,
+		Subsystem: types.DfdaemonMetricsName,
+		Name:      "data_disk_capacity_total",
+		Help:      "Gauger of disk capacity of data directory.",
+	})
+
+	DataUnReclaimedUsage = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: types.MetricsNamespace,
+		Subsystem: types.DfdaemonMetricsName,
+		Name:      "data_unreclaimed_usage_total",
+		Help:      "Gauger of unreclaimed data usage of data directory.",
+	})
+
+	DataDiskGCThreshold = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: types.MetricsNamespace,
+		Subsystem: types.DfdaemonMetricsName,
+		Name:      "data_disk_gc_threshold_total",
+		Help:      "Gauger of disk gc threshold of data directory.",
+	})
+
+	DataDiskGCThresholdPercent = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: types.MetricsNamespace,
+		Subsystem: types.DfdaemonMetricsName,
+		Name:      "data_disk_gc_threshold_percent",
+		Help:      "Gauger of disk gc threshold percent of data directory.",
+	})
 )
 
 func New(addr string) *http.Server {

--- a/client/daemon/storage/storage_manager.go
+++ b/client/daemon/storage/storage_manager.go
@@ -807,10 +807,6 @@ func (s *storageManager) TryGC() (bool, error) {
 		}
 		return true
 	})
-	diskUsage := s.diskUsage()
-	if diskUsage != nil {
-
-	}
 	quotaBytesExceed := totalNotMarkedSize - int64(s.storeOption.DiskGCThreshold)
 	quotaExceed := s.storeOption.DiskGCThreshold > 0 && quotaBytesExceed > 0
 

--- a/client/daemon/storage/storage_manager.go
+++ b/client/daemon/storage/storage_manager.go
@@ -20,6 +20,7 @@ package storage
 
 import (
 	"context"
+	"d7y.io/dragonfly/v2/client/daemon/metrics"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -806,10 +807,24 @@ func (s *storageManager) TryGC() (bool, error) {
 		}
 		return true
 	})
+	diskUsage := s.diskUsage()
+	if diskUsage != nil {
 
+	}
 	quotaBytesExceed := totalNotMarkedSize - int64(s.storeOption.DiskGCThreshold)
 	quotaExceed := s.storeOption.DiskGCThreshold > 0 && quotaBytesExceed > 0
-	usageExceed, usageBytesExceed := s.diskUsageExceed()
+
+	metrics.DataUnReclaimedUsage.Set(float64(totalNotMarkedSize))
+	metrics.DataDiskGCThreshold.Set(float64(s.storeOption.DiskGCThreshold))
+	metrics.DataDiskGCThresholdPercent.Set(s.storeOption.DiskGCThresholdPercent)
+
+	usage := s.diskUsage()
+	if usage != nil {
+		metrics.DataDiskUsage.Set(float64(usage.Used))
+		metrics.DataDiskCapacity.Set(float64(usage.Total))
+	}
+
+	usageExceed, usageBytesExceed := s.diskUsageExceed(usage)
 
 	if quotaExceed || usageExceed {
 		var bytesExceed int64
@@ -941,13 +956,20 @@ func (s *storageManager) forceGC() (bool, error) {
 	return true, nil
 }
 
-func (s *storageManager) diskUsageExceed() (exceed bool, bytes int64) {
-	if s.storeOption.DiskGCThresholdPercent <= 0 {
-		return false, 0
-	}
+func (s *storageManager) diskUsage() *disk.UsageStat {
 	usage, err := disk.Usage(s.storeOption.DataPath)
 	if err != nil {
 		logger.Warnf("get %s disk usage error: %s", s.storeOption.DataPath, err)
+		return nil
+	}
+	return usage
+}
+
+func (s *storageManager) diskUsageExceed(usage *disk.UsageStat) (exceed bool, bytes int64) {
+	if s.storeOption.DiskGCThresholdPercent <= 0 {
+		return false, 0
+	}
+	if usage == nil {
 		return false, 0
 	}
 	logger.Debugf("disk usage: %+v", usage)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

collect disk usage metrics for dfdaemon

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

currently there is no disk usage metrics for data directory usage, we need to monitor the disk dfdaemon used

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
