### PR TITLE
Support none root deployment

### DIFF
--- a/build/images/base/Dockerfile
+++ b/build/images/base/Dockerfile
@@ -22,3 +22,10 @@ RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& tar -C /usr/local -xzf golang.tar.gz \
 	&& rm golang.tar.gz \
 	&& go install github.com/go-delve/delve/cmd/dlv@v1.7.0
+
+# Create none root user and group
+ARG USER_NAME=dragonfly
+ARG USER_UID=1000
+ARG GROUP_NAME=dragonfly
+ARG GROUP_GID=1000
+RUN groupadd -g $GROUP_GID $GROUP_NAME && useradd -u $USER_UID -g $GROUP_GID -m -s /bin/bash $USER_NAME

--- a/build/images/dfdaemon/Dockerfile
+++ b/build/images/dfdaemon/Dockerfile
@@ -29,11 +29,28 @@ RUN if [ "$(uname -m)" = "ppc64le" ]; then \
 
 FROM ${BASE_IMAGE}
 
+ARG USER_NAME=dragonfly
+ARG USER_UID=1000
+ARG GROUP_NAME=dragonfly
+ARG GROUP_GID=1000
+
 ENV PATH=/opt/dragonfly/bin:$PATH
 RUN echo "hosts: files dns" > /etc/nsswitch.conf
 
-COPY --from=builder /opt/dragonfly/bin/dfget /opt/dragonfly/bin/dfget
-COPY --from=health /bin/grpc_health_probe /bin/grpc_health_probe
+# NOTE: Command works for alpine linux, for other distro please update run statement or create user/group in base image
+RUN if [ getent group "$GROUP_NAME" ]; then \
+    echo "group exists"; \
+    else \
+    addgroup -S -g $GROUP_GID $GROUP_NAME; \
+    fi
+RUN if [ getent passwd "$USER_NAME" ]; then \
+    echo "user exists"; \
+    else \
+    adduser -S -u $USER_UID -G $GROUP_NAME  -D $USER_NAME; \
+    fi
+
+COPY --from=builder --chown=$GROUP_NAME:$USER_NAME /opt/dragonfly/bin/dfget /opt/dragonfly/bin/dfget
+COPY --from=health --chown=$GROUP_NAME:$USER_NAME /bin/grpc_health_probe /bin/grpc_health_probe
 
 EXPOSE 65001
 

--- a/build/images/manager/Dockerfile
+++ b/build/images/manager/Dockerfile
@@ -43,6 +43,11 @@ RUN if [ "$(uname -m)" = "ppc64le" ]; then \
 
 FROM ${BASE_IMAGE}
 
+ARG USER_NAME=dragonfly
+ARG USER_UID=1000
+ARG GROUP_NAME=dragonfly
+ARG GROUP_GID=1000
+
 WORKDIR /opt/dragonfly
 
 ENV PATH=/opt/dragonfly/bin:$PATH
@@ -50,8 +55,20 @@ ENV PATH=/opt/dragonfly/bin:$PATH
 RUN mkdir -p /opt/dragonfly/bin/manager/console \
     && echo "hosts: files dns" > /etc/nsswitch.conf
 
-COPY --from=server-builder /opt/dragonfly/bin/manager /opt/dragonfly/bin/server
-COPY --from=health /bin/grpc_health_probe /bin/grpc_health_probe
+# NOTE: Command works for alpine linux, for other distro please update run statement or create user/group in base image
+RUN if [ getent group "$GROUP_NAME" ]; then \
+    echo "group exists"; \
+    else \
+    addgroup -S -g $GROUP_GID $GROUP_NAME; \
+    fi
+RUN if [ getent passwd "$USER_NAME" ]; then \
+    echo "user exists"; \
+    else \
+    adduser -S -u $USER_UID -G $GROUP_NAME  -D $USER_NAME; \
+    fi
+
+COPY --from=server-builder --chown=$GROUP_NAME:$USER_NAME /opt/dragonfly/bin/manager /opt/dragonfly/bin/server
+COPY --from=health --chown=$GROUP_NAME:$USER_NAME /bin/grpc_health_probe /bin/grpc_health_probe
 
 EXPOSE 8080 65003
 

--- a/build/images/scheduler/Dockerfile
+++ b/build/images/scheduler/Dockerfile
@@ -29,11 +29,28 @@ RUN if [ "$(uname -m)" = "ppc64le" ]; then \
 
 FROM ${BASE_IMAGE}
 
+ARG USER_NAME=dragonfly
+ARG USER_UID=1000
+ARG GROUP_NAME=dragonfly
+ARG GROUP_GID=1000
+
 ENV PATH=/opt/dragonfly/bin:$PATH
 RUN echo "hosts: files dns" > /etc/nsswitch.conf
 
-COPY --from=builder /opt/dragonfly/bin/scheduler /opt/dragonfly/bin/scheduler
-COPY --from=health /bin/grpc_health_probe /bin/grpc_health_probe
+# NOTE: Command works for alpine linux, for other distro please update run statement or create user/group in base image
+RUN if [ getent group "$GROUP_NAME" ]; then \
+    echo "group exists"; \
+    else \
+    addgroup -S -g $GROUP_GID $GROUP_NAME; \
+    fi
+RUN if [ getent passwd "$USER_NAME" ]; then \
+    echo "user exists"; \
+    else \
+    adduser -S -u $USER_UID -G $GROUP_NAME  -D $USER_NAME; \
+    fi
+
+COPY --from=builder --chown=$GROUP_NAME:$USER_NAME /opt/dragonfly/bin/scheduler /opt/dragonfly/bin/scheduler
+COPY --from=health --chown=$GROUP_NAME:$USER_NAME /bin/grpc_health_probe /bin/grpc_health_probe
 
 EXPOSE 8002
 

--- a/build/images/trainer/Dockerfile
+++ b/build/images/trainer/Dockerfile
@@ -29,11 +29,28 @@ RUN if [ "$(uname -m)" = "ppc64le" ]; then \
 
 FROM ${BASE_IMAGE}
 
+ARG USER_NAME=dragonfly
+ARG USER_UID=1000
+ARG GROUP_NAME=dragonfly
+ARG GROUP_GID=1000
+
 ENV PATH=/opt/dragonfly/bin:$PATH
 RUN echo "hosts: files dns" > /etc/nsswitch.conf
 
-COPY --from=builder /opt/dragonfly/bin/trainer /opt/dragonfly/bin/trainer
-COPY --from=health /bin/grpc_health_probe /bin/grpc_health_probe
+# NOTE: Command works for alpine linux, for other distro please update run statement or create user/group in base image
+RUN if [ getent group "$GROUP_NAME" ]; then \
+    echo "group exists"; \
+    else \
+    addgroup -S -g $GROUP_GID $GROUP_NAME; \
+    fi
+RUN if [ getent passwd "$USER_NAME" ]; then \
+    echo "user exists"; \
+    else \
+    adduser -S -u $USER_UID -G $GROUP_NAME  -D $USER_NAME; \
+    fi
+
+COPY --from=builder --chown=$GROUP_NAME:$USER_NAME /opt/dragonfly/bin/trainer /opt/dragonfly/bin/trainer
+COPY --from=health --chown=$GROUP_NAME:$USER_NAME /bin/grpc_health_probe /bin/grpc_health_probe
 
 EXPOSE 9090
 

--- a/cmd/manager/cmd/root.go
+++ b/cmd/manager/cmd/root.go
@@ -107,6 +107,10 @@ func initDfpath(cfg *config.ServerConfig) (dfpath.Dfpath, error) {
 		options = append(options, dfpath.WithPluginDir(cfg.PluginDir))
 	}
 
+	if cfg.DataDir != "" {
+		options = append(options, dfpath.WithDataDir(cfg.DataDir))
+	}
+
 	return dfpath.New(options...)
 }
 

--- a/deploy/docker-compose/README.md
+++ b/deploy/docker-compose/README.md
@@ -2,6 +2,15 @@
 
 > Currently, docker compose deploying is tested just in single host, no HA support.
 
+## Build local images for Docker Compose
+
+Try the command below in the dragonfly root directory.
+
+```shell
+export D7Y_REGISTRY=dragonflyoss
+make docker-build
+```
+
 ## Deploy with Docker Compose
 
 The `run.sh` script will generate config and deploy all components with `docker-compose`.

--- a/deploy/docker-compose/docker-compose.yaml
+++ b/deploy/docker-compose/docker-compose.yaml
@@ -44,6 +44,9 @@ services:
       interval: 1s
       timeout: 2s
       retries: 30
+    # Enable when running in none root mode
+    # user: "1000:1000"
+    command: ["--verbose", "--console"]
     ports:
       - 65003:65003
       - 8080:8080
@@ -61,6 +64,9 @@ services:
       interval: 1s
       timeout: 2s
       retries: 30
+    command: ["--verbose", "--console"]
+    # Enable when running in none root mode
+    # user: "1000:1000"
     volumes:
       - ./log/peer:/var/log/dragonfly/daemon
       - ./config/dfget.yaml:/etc/dragonfly/dfget.yaml:ro
@@ -83,6 +89,9 @@ services:
     volumes:
       - ./log/scheduler:/var/log/dragonfly/scheduler
       - ./config/scheduler.yaml:/etc/dragonfly/scheduler.yaml:ro
+    # Enable when running in none root mode
+    # user: "1000:1000"
+    command: ["--verbose", "--console"]
     ports:
       - 8002:8002
 
@@ -101,6 +110,9 @@ services:
     volumes:
       - ./log/seed-peer:/var/log/dragonfly/daemon
       - ./config/seed-peer.yaml:/etc/dragonfly/dfget.yaml:ro
+    # Enable when running in none root mode
+    # user: "1000:1000"
+    command: ["--verbose", "--console"]
     ports:
       - 65006:65006
       - 65007:65007

--- a/deploy/docker-compose/template/dfget.template.yaml
+++ b/deploy/docker-compose/template/dfget.template.yaml
@@ -6,27 +6,32 @@ aliveTime: 0s
 gcInterval: 1m0s
 
 # WorkHome is working directory.
-# In linux, default value is /usr/local/dragonfly.
+# In linux, default value is /usr/local/dragonfly,
+# And when running within none root, the path should locate to homedir, for example: /home/dragonfly/.dragonfly
 # In macos(just for testing), default value is /Users/$USER/.dragonfly.
 workHome: ''
 
 # logDir is the log directory.
-# In linux, default value is /var/log/dragonfly.
+# In linux, default value is /var/log/dragonfly,
+# And when running within none root, the path should locate to homedir, for example: /home/dragonfly/.dragonfly/logs
 # In macos(just for testing), default value is /Users/$USER/.dragonfly/logs.
 logDir: ''
 
 # cacheDir is dynconfig cache directory.
-# In linux, default value is /var/cache/dragonfly.
+# In linux, default value is /var/cache/dragonfly,
+# And when running within none root, the path should locate to homedir, for example: /home/dragonfly/.dragonfly/cache
 # In macos(just for testing), default value is /Users/$USER/.dragonfly/cache.
 cacheDir: ''
 
 # pluginDir is the plugin directory.
-# In linux, default value is /usr/local/dragonfly/plugins.
+# In linux, default value is /usr/local/dragonfly/plugins,
+# And when running within none root, the path should locate to homedir, for example: /home/dragonfly/.dragonfly/plugins
 # In macos(just for testing), default value is /Users/$USER/.dragonfly/plugins.
 pluginDir: ''
 
 # dataDir is the download data directory.
-# In linux, default value is /var/lib/dragonfly.
+# In linux, default value is /var/lib/dragonfly,
+# And when running within none root, the path should locate to homedir, for example: /home/dragonfly/.dragonfly/data
 # In macos(just for testing), default value is /Users/$USER/.dragonfly/data.
 dataDir: ''
 

--- a/deploy/docker-compose/template/manager.template.yaml
+++ b/deploy/docker-compose/template/manager.template.yaml
@@ -16,21 +16,34 @@ server:
     # REST server address
     addr: :8080
   # WorkHome is working directory.
-  # In linux, default value is /usr/local/dragonfly.
+  # In linux, default value is /usr/local/dragonfly,
+  # And when running within none root, the path should locate to homedir, for example: /home/dragonfly/.dragonfly
   # In macos(just for testing), default value is /Users/$USER/.dragonfly.
   workHome: ''
+
   # logDir is the log directory.
-  # In linux, default value is /var/log/dragonfly.
+  # In linux, default value is /var/log/dragonfly,
+  # And when running within none root, the path should locate to homedir, for example: /home/dragonfly/.dragonfly/logs
   # In macos(just for testing), default value is /Users/$USER/.dragonfly/logs.
   logDir: ''
+
   # cacheDir is dynconfig cache directory.
-  # In linux, default value is /var/cache/dragonfly.
+  # In linux, default value is /var/cache/dragonfly,
+  # And when running within none root, the path should locate to homedir, for example: /home/dragonfly/.dragonfly/cache
   # In macos(just for testing), default value is /Users/$USER/.dragonfly/cache.
   cacheDir: ''
+
   # pluginDir is the plugin directory.
-  # In linux, default value is /usr/local/dragonfly/plugins.
+  # In linux, default value is /usr/local/dragonfly/plugins,
+  # And when running within none root, the path should locate to homedir, for example: /home/dragonfly/.dragonfly/plugins
   # In macos(just for testing), default value is /Users/$USER/.dragonfly/plugins.
   pluginDir: ''
+
+  # dataDir is the download data directory.
+  # In linux, default value is /var/lib/dragonfly,
+  # And when running within none root, the path should locate to homedir, for example: /home/dragonfly/.dragonfly/data
+  # In macos(just for testing), default value is /Users/$USER/.dragonfly/data.
+  dataDir: ''
 
 auth:
   jwt:

--- a/deploy/docker-compose/template/scheduler.template.yaml
+++ b/deploy/docker-compose/template/scheduler.template.yaml
@@ -9,23 +9,28 @@ server:
   # # Server host.
   # host: localhost
   # WorkHome is working directory.
-  # In linux, default value is /usr/local/dragonfly.
+  # In linux, default value is /usr/local/dragonfly,
+  # And when running within none root, the path should locate to homedir, for example: /home/dragonfly/.dragonfly
   # In macos(just for testing), default value is /Users/$USER/.dragonfly.
   workHome: ''
   # logDir is the log directory.
-  # In linux, default value is /var/log/dragonfly.
+  # In linux, default value is /var/log/dragonfly,
+  # And when running within none root, the path should locate to homedir, for example: /home/dragonfly/.dragonfly/logs
   # In macos(just for testing), default value is /Users/$USER/.dragonfly/logs.
   logDir: ''
   # cacheDir is dynconfig cache directory.
-  # In linux, default value is /var/cache/dragonfly.
+  # In linux, default value is /var/cache/dragonfly,
+  # And when running within none root, the path should locate to homedir, for example: /home/dragonfly/.dragonfly/cache
   # In macos(just for testing), default value is /Users/$USER/.dragonfly/cache.
   cacheDir: ''
   # pluginDir is the plugin directory.
-  # In linux, default value is /usr/local/dragonfly/plugins.
+  # In linux, default value is /usr/local/dragonfly/plugins,
+  # And when running within none root, the path should locate to homedir, for example: /home/dragonfly/.dragonfly/plugins
   # In macos(just for testing), default value is /Users/$USER/.dragonfly/plugins.
   pluginDir: ''
-  # dataDir is the directory.
-  # In linux, default value is /var/lib/dragonfly.
+  # dataDir is the download data directory.
+  # In linux, default value is /var/lib/dragonfly,
+  # And when running within none root, the path should locate to homedir, for example: /home/dragonfly/.dragonfly/data
   # In macos(just for testing), default value is /Users/$USER/.dragonfly/data.
   dataDir: ''
 

--- a/deploy/docker-compose/template/seed-peer.template.yaml
+++ b/deploy/docker-compose/template/seed-peer.template.yaml
@@ -6,27 +6,32 @@ aliveTime: 0s
 gcInterval: 1m0s
 
 # WorkHome is working directory.
-# In linux, default value is /usr/local/dragonfly.
+# In linux, default value is /usr/local/dragonfly,
+# And when running within none root, the path should locate to homedir, for example: /home/dragonfly/.dragonfly
 # In macos(just for testing), default value is /Users/$USER/.dragonfly.
 workHome: ''
 
 # logDir is the log directory.
-# In linux, default value is /var/log/dragonfly.
+# In linux, default value is /var/log/dragonfly,
+# And when running within none root, the path should locate to homedir, for example: /home/dragonfly/.dragonfly/logs
 # In macos(just for testing), default value is /Users/$USER/.dragonfly/logs.
 logDir: ''
 
 # cacheDir is dynconfig cache directory.
-# In linux, default value is /var/cache/dragonfly.
+# In linux, default value is /var/cache/dragonfly,
+# And when running within none root, the path should locate to homedir, for example: /home/dragonfly/.dragonfly/cache
 # In macos(just for testing), default value is /Users/$USER/.dragonfly/cache.
 cacheDir: ''
 
 # pluginDir is the plugin directory.
-# In linux, default value is /usr/local/dragonfly/plugins.
+# In linux, default value is /usr/local/dragonfly/plugins,
+# And when running within none root, the path should locate to homedir, for example: /home/dragonfly/.dragonfly/plugins
 # In macos(just for testing), default value is /Users/$USER/.dragonfly/plugins.
 pluginDir: ''
 
 # dataDir is the download data directory.
-# In linux, default value is /var/lib/dragonfly.
+# In linux, default value is /var/lib/dragonfly,
+# # And when running within none root, the path should locate to homedir, for example: /home/dragonfly/.dragonfly/data
 # In macos(just for testing), default value is /Users/$USER/.dragonfly/data.
 dataDir: ''
 

--- a/manager/config/config.go
+++ b/manager/config/config.go
@@ -81,6 +81,9 @@ type ServerConfig struct {
 	// Server plugin directory.
 	PluginDir string `yaml:"pluginDir" mapstructure:"pluginDir"`
 
+	// Server storage data directory.
+	DataDir string `yaml:"dataDir" mapstructure:"dataDir"`
+
 	// GRPC server configuration.
 	GRPC GRPCConfig `yaml:"grpc" mapstructure:"grpc"`
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Support build and deploy dragonfly within none root user.

<!--- Describe your changes in detail -->
1. Create dragonfly user and group in base/manager/scheduler/dfdaemon/trainer image
2. Use none root user in docker compose yaml
3. Add dataDir config option for manager, which is used for overwrite the default value
4. Update several path for docker compose configuration

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
For security concern, it's better to have process running within none root user.

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
Not fully understand the whole picture of draognfly and within this update the seed peer will take several minutes to become ready
```
2024-01-07T09:51:26.533Z	INFO	zap/server_interceptors.go:39	finished unary call with code OK	{"grpc.start_time": "2024-01-07T09:51:26Z", "grpc.request.deadline": "2024-01-07T09:51:27Z", "system": "grpc", "span.kind": "server", "grpc.service": "grpc.health.v1.Health", "grpc.method": "Check", "grpc.code": "OK", "grpc.time_ms": 0.056}
2024-01-07T09:51:27.652Z	INFO	zap/server_interceptors.go:39	finished unary call with code OK	{"grpc.start_time": "2024-01-07T09:51:27Z", "grpc.request.deadline": "2024-01-07T09:51:28Z", "system": "grpc", "span.kind": "server", "grpc.service": "grpc.health.v1.Health", "grpc.method": "Check", "grpc.code": "OK", "grpc.time_ms": 0.021}
2024-01-07T09:51:28.782Z	INFO	zap/server_interceptors.go:39	finished unary call with code OK	{"grpc.start_time": "2024-01-07T09:51:28Z", "grpc.request.deadline": "2024-01-07T09:51:29Z", "system": "grpc", "span.kind": "server", "grpc.service": "grpc.health.v1.Health", "grpc.method": "Check", "grpc.code": "OK", "grpc.time_ms": 0.036}
2024-01-07T09:51:29.923Z	INFO	zap/server_interceptors.go:39	finished unary call with code OK	{"grpc.start_time": "2024-01-07T09:51:29Z", "grpc.request.deadline": "2024-01-07T09:51:30Z", "system": "grpc", "span.kind": "server", "grpc.service": "grpc.health.v1.Health", "grpc.method": "Check", "grpc.code": "OK", "grpc.time_ms": 0.095}
2024-01-07T09:51:31.097Z	INFO	zap/server_interceptors.go:39	finished unary call with code OK	{"grpc.start_time": "2024-01-07T09:51:31Z", "grpc.request.deadline": "2024-01-07T09:51:32Z", "system": "grpc", "span.kind": "server", "grpc.service": "grpc.health.v1.Health", "grpc.method": "Check", "grpc.code": "OK", "grpc.time_ms": 0.068}
2024-01-07T09:51:32.215Z	INFO	zap/server_interceptors.go:39	finished unary call with code OK	{"grpc.start_time": "2024-01-07T09:51:32Z", "grpc.request.deadline": "2024-01-07T09:51:33Z", "system": "grpc", "span.kind": "server", "grpc.service": "grpc.health.v1.Health", "grpc.method": "Check", "grpc.code": "OK", "grpc.time_ms": 0.158}
2024-01-07T09:51:33.367Z	INFO	zap/server_interceptors.go:39	finished unary call with code OK	{"grpc.start_time": "2024-01-07T09:51:33Z", "grpc.request.deadline": "2024-01-07T09:51:34Z", "system": "grpc", "span.kind": "server", "grpc.service": "grpc.health.v1.Health", "grpc.method": "Check", "grpc.code": "OK", "grpc.time_ms": 0.04}
2024-01-07T09:51:33.759Z	INFO	zap/server_interceptors.go:39	finished unary call with code OK	{"grpc.start_time": "2024-01-07T09:51:33Z", "grpc.request.deadline": "2024-01-07T09:51:35Z", "system": "grpc", "span.kind": "server", "grpc.service": "grpc.health.v1.Health", "grpc.method": "Check", "grpc.code": "OK", "grpc.time_ms": 0.038}
2024-01-07T09:51:33.767Z	INFO	zap/server_interceptors.go:39	finished unary call with code OK	{"grpc.start_time": "2024-01-07T09:51:33Z", "grpc.request.deadline": "2024-01-07T09:51:35Z", "system": "grpc", "span.kind": "server", "grpc.service": "grpc.health.v1.Health", "grpc.method": "Check", "grpc.code": "OK", "grpc.time_ms": 0.024}
2024-01-07T09:51:33.772Z	INFO	zap/server_interceptors.go:39	finished unary call with code OK	{"grpc.start_time": "2024-01-07T09:51:33Z", "grpc.request.deadline": "2024-01-07T09:51:35Z", "system": "grpc", "span.kind": "server", "grpc.service": "grpc.health.v1.Health", "grpc.method": "Check", "grpc.code": "OK", "grpc.time_ms": 0.056}
2024-01-07T09:51:33.778Z	INFO	zap/server_interceptors.go:39	finished unary call with code OK	{"grpc.start_time": "2024-01-07T09:51:33Z", "grpc.request.deadline": "2024-01-07T09:51:35Z", "system": "grpc", "span.kind": "server", "grpc.service": "grpc.health.v1.Health", "grpc.method": "Check", "grpc.code": "OK", "grpc.time_ms": 0.028}
2024-01-07T09:51:34.465Z	INFO	zap/server_interceptors.go:39	finished unary call with code OK	{"grpc.start_time": "2024-01-07T09:51:34Z", "grpc.request.deadline": "2024-01-07T09:51:35Z", "system": "grpc", "span.kind": "server", "grpc.service": "grpc.health.v1.Health", "grpc.method": "Check", "grpc.code": "OK", "grpc.time_ms": 0.165}
2024-01-07T09:51:35.580Z	INFO	zap/server_interceptors.go:39	finished unary call with code OK	{"grpc.start_time": "2024-01-07T09:51:35Z", "grpc.request.deadline": "2024-01-07T09:51:36Z", "system": "grpc", "span.kind": "server", "grpc.service": "grpc.health.v1.Health", "grpc.method": "Check", "grpc.code": "OK", "grpc.time_ms": 0.022}
2024-01-07T09:51:35.801Z	ERROR	grpclog/grpclog.go:55	[scheduler_resolver]resolve addresses error schedulers not found
google.golang.org/grpc/internal/grpclog.ErrorDepth
	/go/pkg/mod/google.golang.org/grpc@v1.60.0-dev/internal/grpclog/grpclog.go:55
google.golang.org/grpc/grpclog.(*componentData).ErrorDepth
	/go/pkg/mod/google.golang.org/grpc@v1.60.0-dev/grpclog/component.go:46
google.golang.org/grpc/grpclog.(*componentData).Errorf
	/go/pkg/mod/google.golang.org/grpc@v1.60.0-dev/grpclog/component.go:79
d7y.io/dragonfly/v2/pkg/resolver.(*SchedulerResolver).ResolveNow
	/go/src/d7y.io/dragonfly/v2/pkg/resolver/scheduler_resolver.go:84
d7y.io/dragonfly/v2/pkg/resolver.(*SchedulerResolver).OnNotify
	/go/src/d7y.io/dragonfly/v2/pkg/resolver/scheduler_resolver.go:109
d7y.io/dragonfly/v2/client/config.(*dynconfigManager).Notify
	/go/src/d7y.io/dragonfly/v2/client/config/dynconfig_manager.go:242
d7y.io/dragonfly/v2/client/config.(*dynconfigManager).Serve
	/go/src/d7y.io/dragonfly/v2/client/config/dynconfig_manager.go:268
d7y.io/dragonfly/v2/client/daemon.(*clientDaemon).Serve.func10
	/go/src/d7y.io/dragonfly/v2/client/daemon/daemon.go:744
golang.org/x/sync/errgroup.(*Group).Go.func1
	/go/pkg/mod/golang.org/x/sync@v0.5.0/errgroup/errgroup.go:75
```
Status after 10 minutes of docker compose, the seed peer finally turns into ready.
<img width="1521" alt="image" src="https://github.com/dragonflyoss/Dragonfly2/assets/5671225/36c99c59-7e6f-459f-ab3f-1d8a7ec446ea">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
