### PR TITLE
fix: skip the sync peer that does not belong to the scheduler cluster

### DIFF
--- a/manager/job/sync_peers.go
+++ b/manager/job/sync_peers.go
@@ -39,7 +39,8 @@ import (
 	resource "d7y.io/dragonfly/v2/scheduler/resource/standard"
 )
 
-// SyncPeers is an interface for sync peers.
+// SyncPeers is an interface for sync peers. It is only supported in Rust client,
+// refer to https://github.com/dragonflyoss/client.
 type SyncPeers interface {
 	// CreateSyncPeers creates sync peers job, and merge the sync peer results with the data
 	// in the peer table in the database. It is a synchronous operation, and it will returns
@@ -195,6 +196,13 @@ func (s *syncPeers) mergePeers(ctx context.Context, scheduler models.Scheduler, 
 	// Convert sync peer results from slice to map.
 	syncPeers := make(map[string]*resource.Host, len(results))
 	for _, result := range results {
+		// Skip the sync peer that does not belong to the scheduler cluster,
+		// it is only supported in Rust client. The golang client lacks the
+		// SchedulerClusterID field.
+		if result.SchedulerClusterID == 0 {
+			continue
+		}
+
 		syncPeers[result.ID] = result
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes changes to the `manager/job/sync_peers.go` file to improve the synchronization of peers, specifically addressing compatibility with the Rust client. The most important changes include updating the `SyncPeers` interface documentation and adding a condition to handle scheduler clusters in the `mergePeers` function.

Documentation update:

* [`manager/job/sync_peers.go`](diffhunk://#diff-e9f785a9d48a7b2ad2641434fc567ca957fe98308c11fadc0e53d6e82df00debL42-R43): Updated the `SyncPeers` interface comment to specify that it is only supported in the Rust client.

Functionality improvement:

* [`manager/job/sync_peers.go`](diffhunk://#diff-e9f785a9d48a7b2ad2641434fc567ca957fe98308c11fadc0e53d6e82df00debR199-R205): Added a condition in the `mergePeers` function to skip sync peers that do not belong to the scheduler cluster, as the Golang client lacks the `SchedulerClusterID` field.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
