### PR TITLE
feat: replicate persistent cache task when task needs persistent replicas

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	cloud.google.com/go/storage v1.50.0
-	d7y.io/api/v2 v2.1.12
+	d7y.io/api/v2 v2.1.16
 	github.com/MysteriousPotato/go-lockable v1.0.0
 	github.com/RichardKnop/machinery v1.10.8
 	github.com/Showmax/go-fqdn v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ cloud.google.com/go/storage v1.50.0 h1:3TbVkzTooBvnZsk7WaAQfOsNrdoM8QHusXA1cpk6Q
 cloud.google.com/go/storage v1.50.0/go.mod h1:l7XeiD//vx5lfqE3RavfmU9yvk5Pp0Zhcv482poyafY=
 cloud.google.com/go/trace v1.11.2 h1:4ZmaBdL8Ng/ajrgKqY5jfvzqMXbrDcBsUGXOT9aqTtI=
 cloud.google.com/go/trace v1.11.2/go.mod h1:bn7OwXd4pd5rFuAnTrzBuoZ4ax2XQeG3qNgYmfCy0Io=
-d7y.io/api/v2 v2.1.12 h1:jFo4TA6sRVSbcjPlFrig8S+7P37pww4bFbeTxcGhd54=
-d7y.io/api/v2 v2.1.12/go.mod h1:zPZ7m8yC1LZH9VR4ACcvrphhPIVKSS2c3QHG+PRSixU=
+d7y.io/api/v2 v2.1.16 h1:ql4PaC17eG0NSteu+4cijrQ7vA/P/Xki4we66Q7FbQw=
+d7y.io/api/v2 v2.1.16/go.mod h1:zPZ7m8yC1LZH9VR4ACcvrphhPIVKSS2c3QHG+PRSixU=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0/go.mod h1:uGG2W01BaETf0Ozp+QxxKJdMBNRWPdstHG0Fmdwn1/U=

--- a/scheduler/resource/persistentcache/host_manager_mock.go
+++ b/scheduler/resource/persistentcache/host_manager_mock.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	set "d7y.io/dragonfly/v2/pkg/container/set"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -82,6 +83,21 @@ func (m *MockHostManager) LoadAll(arg0 context.Context) ([]*Host, error) {
 func (mr *MockHostManagerMockRecorder) LoadAll(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadAll", reflect.TypeOf((*MockHostManager)(nil).LoadAll), arg0)
+}
+
+// LoadRandom mocks base method.
+func (m *MockHostManager) LoadRandom(arg0 context.Context, arg1 int, arg2 set.SafeSet[string]) ([]*Host, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LoadRandom", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]*Host)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LoadRandom indicates an expected call of LoadRandom.
+func (mr *MockHostManagerMockRecorder) LoadRandom(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadRandom", reflect.TypeOf((*MockHostManager)(nil).LoadRandom), arg0, arg1, arg2)
 }
 
 // RunGC mocks base method.

--- a/scheduler/resource/persistentcache/peer_manager_mock.go
+++ b/scheduler/resource/persistentcache/peer_manager_mock.go
@@ -142,6 +142,21 @@ func (mr *MockPeerManagerMockRecorder) LoadAllByTaskID(arg0, arg1 any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadAllByTaskID", reflect.TypeOf((*MockPeerManager)(nil).LoadAllByTaskID), arg0, arg1)
 }
 
+// LoadPersistentAllByTaskID mocks base method.
+func (m *MockPeerManager) LoadPersistentAllByTaskID(arg0 context.Context, arg1 string) ([]*Peer, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LoadPersistentAllByTaskID", arg0, arg1)
+	ret0, _ := ret[0].([]*Peer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LoadPersistentAllByTaskID indicates an expected call of LoadPersistentAllByTaskID.
+func (mr *MockPeerManagerMockRecorder) LoadPersistentAllByTaskID(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadPersistentAllByTaskID", reflect.TypeOf((*MockPeerManager)(nil).LoadPersistentAllByTaskID), arg0, arg1)
+}
+
 // Store mocks base method.
 func (m *MockPeerManager) Store(arg0 context.Context, arg1 *Peer) error {
 	m.ctrl.T.Helper()

--- a/scheduler/resource/persistentcache/task.go
+++ b/scheduler/resource/persistentcache/task.go
@@ -77,13 +77,13 @@ type Task struct {
 	Application string
 
 	// Persistet cache task piece length.
-	PieceLength int32
+	PieceLength uint64
 
 	// ContentLength is persistent cache task total content length.
-	ContentLength int64
+	ContentLength uint64
 
 	// TotalPieceCount is total piece count.
-	TotalPieceCount int32
+	TotalPieceCount uint32
 
 	// Persistent cache task state machine.
 	FSM *fsm.FSM
@@ -102,8 +102,8 @@ type Task struct {
 }
 
 // New persistent cache task instance.
-func NewTask(id, tag, application, state string, persistentReplicaCount uint64, pieceLength int32,
-	contentLength int64, totalPieceCount int32, ttl time.Duration, createdAt, updatedAt time.Time,
+func NewTask(id, tag, application, state string, persistentReplicaCount, pieceLength, contentLength uint64,
+	totalPieceCount uint32, ttl time.Duration, createdAt, updatedAt time.Time,
 	log *logger.SugaredLoggerOnWith) *Task {
 	t := &Task{
 		ID:                     id,

--- a/scheduler/resource/persistentcache/task_manager_mock.go
+++ b/scheduler/resource/persistentcache/task_manager_mock.go
@@ -85,10 +85,10 @@ func (mr *MockTaskManagerMockRecorder) LoadAll(arg0 any) *gomock.Call {
 }
 
 // LoadCorrentReplicaCount mocks base method.
-func (m *MockTaskManager) LoadCorrentReplicaCount(arg0 context.Context, arg1 string) (int64, error) {
+func (m *MockTaskManager) LoadCorrentReplicaCount(arg0 context.Context, arg1 string) (uint64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadCorrentReplicaCount", arg0, arg1)
-	ret0, _ := ret[0].(int64)
+	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -100,10 +100,10 @@ func (mr *MockTaskManagerMockRecorder) LoadCorrentReplicaCount(arg0, arg1 any) *
 }
 
 // LoadCurrentPersistentReplicaCount mocks base method.
-func (m *MockTaskManager) LoadCurrentPersistentReplicaCount(arg0 context.Context, arg1 string) (int64, error) {
+func (m *MockTaskManager) LoadCurrentPersistentReplicaCount(arg0 context.Context, arg1 string) (uint64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadCurrentPersistentReplicaCount", arg0, arg1)
-	ret0, _ := ret[0].(int64)
+	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/scheduler/scheduling/evaluator/evaluator.go
+++ b/scheduler/scheduling/evaluator/evaluator.go
@@ -61,13 +61,13 @@ const (
 // Evaluator is an interface that evaluates the parents.
 type Evaluator interface {
 	// EvaluateParents sort parents by evaluating multiple feature scores.
-	EvaluateParents(parents []*standard.Peer, child *standard.Peer, taskPieceCount int32) []*standard.Peer
+	EvaluateParents(parents []*standard.Peer, child *standard.Peer, taskPieceCount uint32) []*standard.Peer
 
 	// IsBadParent determine if peer is a bad parent, it can not be selected as a parent.
 	IsBadParent(peer *standard.Peer) bool
 
 	// EvaluatePersistentCacheParents sort persistent cache parents by evaluating multiple feature scores.
-	EvaluatePersistentCacheParents(parents []*persistentcache.Peer, child *persistentcache.Peer, taskPieceCount int32) []*persistentcache.Peer
+	EvaluatePersistentCacheParents(parents []*persistentcache.Peer, child *persistentcache.Peer, taskPieceCount uint32) []*persistentcache.Peer
 
 	// IsBadPersistentCacheParent determine if persistent cache peer is a bad parent, it can not be selected as a parent.
 	IsBadPersistentCacheParent(peer *persistentcache.Peer) bool

--- a/scheduler/scheduling/evaluator/evaluator_base.go
+++ b/scheduler/scheduling/evaluator/evaluator_base.go
@@ -57,7 +57,7 @@ func newEvaluatorBase() Evaluator {
 }
 
 // EvaluateParents sort parents by evaluating multiple feature scores.
-func (e *evaluatorBase) EvaluateParents(parents []*standard.Peer, child *standard.Peer, totalPieceCount int32) []*standard.Peer {
+func (e *evaluatorBase) EvaluateParents(parents []*standard.Peer, child *standard.Peer, totalPieceCount uint32) []*standard.Peer {
 	sort.Slice(
 		parents,
 		func(i, j int) bool {
@@ -69,7 +69,7 @@ func (e *evaluatorBase) EvaluateParents(parents []*standard.Peer, child *standar
 }
 
 // evaluateParents sort parents by evaluating multiple feature scores.
-func (e *evaluatorBase) evaluateParents(parent *standard.Peer, child *standard.Peer, totalPieceCount int32) float64 {
+func (e *evaluatorBase) evaluateParents(parent *standard.Peer, child *standard.Peer, totalPieceCount uint32) float64 {
 	parentLocation := parent.Host.Network.Location
 	parentIDC := parent.Host.Network.IDC
 	childLocation := child.Host.Network.Location
@@ -84,7 +84,7 @@ func (e *evaluatorBase) evaluateParents(parent *standard.Peer, child *standard.P
 }
 
 // EvaluatePersistentCacheParents sort persistent cache parents by evaluating multiple feature scores.
-func (e *evaluatorBase) EvaluatePersistentCacheParents(parents []*persistentcache.Peer, child *persistentcache.Peer, totalPieceCount int32) []*persistentcache.Peer {
+func (e *evaluatorBase) EvaluatePersistentCacheParents(parents []*persistentcache.Peer, child *persistentcache.Peer, totalPieceCount uint32) []*persistentcache.Peer {
 	sort.Slice(
 		parents,
 		func(i, j int) bool {
@@ -96,7 +96,7 @@ func (e *evaluatorBase) EvaluatePersistentCacheParents(parents []*persistentcach
 }
 
 // evaluatePersistentCacheParents sort persistent cache parents by evaluating multiple feature scores.
-func (e *evaluatorBase) evaluatePersistentCacheParents(parent *persistentcache.Peer, child *persistentcache.Peer, totalPieceCount int32) float64 {
+func (e *evaluatorBase) evaluatePersistentCacheParents(parent *persistentcache.Peer, child *persistentcache.Peer, totalPieceCount uint32) float64 {
 	parentLocation := parent.Host.Network.Location
 	parentIDC := parent.Host.Network.IDC
 	childLocation := child.Host.Network.Location
@@ -108,7 +108,7 @@ func (e *evaluatorBase) evaluatePersistentCacheParents(parent *persistentcache.P
 }
 
 // calculatePieceScore 0.0~unlimited larger and better.
-func (e *evaluatorBase) calculatePieceScore(parentFinishedPieceCount uint, childFinishedPieceCount uint, totalPieceCount int32) float64 {
+func (e *evaluatorBase) calculatePieceScore(parentFinishedPieceCount uint, childFinishedPieceCount uint, totalPieceCount uint32) float64 {
 	// If the total piece is determined, normalize the number of
 	// pieces downloaded by the parent node.
 	if totalPieceCount > 0 {

--- a/scheduler/scheduling/evaluator/evaluator_base_test.go
+++ b/scheduler/scheduling/evaluator/evaluator_base_test.go
@@ -176,7 +176,7 @@ func TestEvaluatorBase_EvaluateParents(t *testing.T) {
 		name            string
 		parents         []*resource.Peer
 		child           *resource.Peer
-		totalPieceCount int32
+		totalPieceCount uint32
 		mock            func(parent []*resource.Peer, child *resource.Peer)
 		expect          func(t *testing.T, parents []*resource.Peer)
 	}{
@@ -340,7 +340,7 @@ func TestEvaluatorBase_evaluate(t *testing.T) {
 		name            string
 		parent          *resource.Peer
 		child           *resource.Peer
-		totalPieceCount int32
+		totalPieceCount uint32
 		mock            func(parent *resource.Peer, child *resource.Peer)
 		expect          func(t *testing.T, score float64)
 	}{
@@ -406,7 +406,7 @@ func TestEvaluatorBase_calculatePieceScore(t *testing.T) {
 		name            string
 		parent          *resource.Peer
 		child           *resource.Peer
-		totalPieceCount int32
+		totalPieceCount uint32
 		mock            func(parent *resource.Peer, child *resource.Peer)
 		expect          func(t *testing.T, score float64)
 	}{

--- a/scheduler/scheduling/evaluator/plugin_test.go
+++ b/scheduler/scheduling/evaluator/plugin_test.go
@@ -44,7 +44,7 @@ func TestPlugin_Load(t *testing.T) {
 	output, err = cmd.CombinedOutput()
 	assert.Nil(err)
 	if err != nil {
-		t.Fatalf(string(output))
+		t.Fatal(string(output))
 		return
 	}
 
@@ -53,7 +53,7 @@ func TestPlugin_Load(t *testing.T) {
 	output, err = cmd.CombinedOutput()
 	assert.Nil(err)
 	if err != nil {
-		t.Fatalf(string(output))
+		t.Fatal(string(output))
 		return
 	}
 
@@ -66,7 +66,7 @@ func TestPlugin_Load(t *testing.T) {
 	output, err = cmd.CombinedOutput()
 	assert.Nil(err)
 	if err != nil {
-		t.Fatalf(string(output))
+		t.Fatal(string(output))
 		return
 	}
 }

--- a/scheduler/scheduling/evaluator/testdata/main.go
+++ b/scheduler/scheduling/evaluator/testdata/main.go
@@ -32,7 +32,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	candidateParents := e.EvaluateParents([]*standard.Peer{&standard.Peer{}}, &standard.Peer{}, int32(0))
+	candidateParents := e.EvaluateParents([]*standard.Peer{&standard.Peer{}}, &standard.Peer{}, uint32(0))
 	if len(candidateParents) != 1 {
 		fmt.Println("EvaluateParents failed")
 		os.Exit(1)
@@ -43,7 +43,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	candidatePersistentCacheParents := e.EvaluatePersistentCacheParents([]*persistentcache.Peer{&persistentcache.Peer{}}, &persistentcache.Peer{}, int32(0))
+	candidatePersistentCacheParents := e.EvaluatePersistentCacheParents([]*persistentcache.Peer{&persistentcache.Peer{}}, &persistentcache.Peer{}, uint32(0))
 	if len(candidatePersistentCacheParents) != 1 {
 		fmt.Println("EvaluatePersistentCacheParents failed")
 		os.Exit(1)

--- a/scheduler/scheduling/evaluator/testdata/plugin/evaluator.go
+++ b/scheduler/scheduling/evaluator/testdata/plugin/evaluator.go
@@ -24,7 +24,7 @@ import (
 type evaluator struct{}
 
 // EvaluateParents sort parents by evaluating multiple feature scores.
-func (e *evaluator) EvaluateParents(parents []*standard.Peer, child *standard.Peer, taskPieceCount int32) []*standard.Peer {
+func (e *evaluator) EvaluateParents(parents []*standard.Peer, child *standard.Peer, taskPieceCount uint32) []*standard.Peer {
 	return []*standard.Peer{&standard.Peer{}}
 }
 
@@ -34,7 +34,7 @@ func (e *evaluator) IsBadParent(peer *standard.Peer) bool {
 }
 
 // EvaluatePersistentCacheParents sort persistent cache parents by evaluating multiple feature scores.
-func (e *evaluator) EvaluatePersistentCacheParents(parents []*persistentcache.Peer, child *persistentcache.Peer, taskPieceCount int32) []*persistentcache.Peer {
+func (e *evaluator) EvaluatePersistentCacheParents(parents []*persistentcache.Peer, child *persistentcache.Peer, taskPieceCount uint32) []*persistentcache.Peer {
 	return []*persistentcache.Peer{&persistentcache.Peer{}}
 }
 

--- a/scheduler/scheduling/mocks/scheduling_mock.go
+++ b/scheduler/scheduling/mocks/scheduling_mock.go
@@ -88,19 +88,19 @@ func (mr *MockSchedulingMockRecorder) FindParentAndCandidateParents(arg0, arg1, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindParentAndCandidateParents", reflect.TypeOf((*MockScheduling)(nil).FindParentAndCandidateParents), arg0, arg1, arg2)
 }
 
-// FindReplicatePersistentCacheParents mocks base method.
-func (m *MockScheduling) FindReplicatePersistentCacheParents(arg0 context.Context, arg1 *persistentcache.Task, arg2 set.SafeSet[string]) ([]*persistentcache.Peer, bool) {
+// FindReplicatePersistentCacheHosts mocks base method.
+func (m *MockScheduling) FindReplicatePersistentCacheHosts(arg0 context.Context, arg1 *persistentcache.Task, arg2 set.SafeSet[string]) ([]*persistentcache.Host, bool) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindReplicatePersistentCacheParents", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]*persistentcache.Peer)
+	ret := m.ctrl.Call(m, "FindReplicatePersistentCacheHosts", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]*persistentcache.Host)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
-// FindReplicatePersistentCacheParents indicates an expected call of FindReplicatePersistentCacheParents.
-func (mr *MockSchedulingMockRecorder) FindReplicatePersistentCacheParents(arg0, arg1, arg2 any) *gomock.Call {
+// FindReplicatePersistentCacheHosts indicates an expected call of FindReplicatePersistentCacheHosts.
+func (mr *MockSchedulingMockRecorder) FindReplicatePersistentCacheHosts(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindReplicatePersistentCacheParents", reflect.TypeOf((*MockScheduling)(nil).FindReplicatePersistentCacheParents), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindReplicatePersistentCacheHosts", reflect.TypeOf((*MockScheduling)(nil).FindReplicatePersistentCacheHosts), arg0, arg1, arg2)
 }
 
 // FindSuccessParent mocks base method.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes changes to the `scheduler/resource/persistentcache` package to add new functionalities and improve existing ones. The most important changes include adding a new method to load hosts randomly, modifying existing methods to use Redis transactions, and updating data types for task attributes.

### New functionalities:
* [`scheduler/resource/persistentcache/host_manager.go`](diffhunk://#diff-cab2c0c5532854f2dd2b4557cc339dd396bccb1ea3a66af3ffc13821da7e3a8dR56-R58): Added `LoadRandom` method to load hosts randomly through the set of Redis. [[1]](diffhunk://#diff-cab2c0c5532854f2dd2b4557cc339dd396bccb1ea3a66af3ffc13821da7e3a8dR56-R58) [[2]](diffhunk://#diff-cab2c0c5532854f2dd2b4557cc339dd396bccb1ea3a66af3ffc13821da7e3a8dR589-R623)
* [`scheduler/resource/persistentcache/peer_manager.go`](diffhunk://#diff-243b8e8011a1eb5e57b015c90ddff263d31ea40d2123fe67763fd114a6486452R54-R56): Added `LoadPersistentAllByTaskID` method to return all persistent peers by task ID. [[1]](diffhunk://#diff-243b8e8011a1eb5e57b015c90ddff263d31ea40d2123fe67763fd114a6486452R54-R56) [[2]](diffhunk://#diff-243b8e8011a1eb5e57b015c90ddff263d31ea40d2123fe67763fd114a6486452R349-R371)
* [`scheduler/scheduling/scheduling.go`](diffhunk://#diff-e2cfa8f2cf20753eb98419b3cf1341b9e6c952aed42b62bc84a65c128af0d1ddL590-R662): Implemented `FindReplicatePersistentCacheHosts` to find replicate persistent cache hosts for a task. [[1]](diffhunk://#diff-e2cfa8f2cf20753eb98419b3cf1341b9e6c952aed42b62bc84a65c128af0d1ddL590-R662) [[2]](diffhunk://#diff-e2cfa8f2cf20753eb98419b3cf1341b9e6c952aed42b62bc84a65c128af0d1ddL629-R696)

### Improvements to existing methods:
* [`scheduler/resource/persistentcache/host_manager.go`](diffhunk://#diff-cab2c0c5532854f2dd2b4557cc339dd396bccb1ea3a66af3ffc13821da7e3a8dL449-R455): Modified `Store` and `Delete` methods to use Redis transactions for better consistency. [[1]](diffhunk://#diff-cab2c0c5532854f2dd2b4557cc339dd396bccb1ea3a66af3ffc13821da7e3a8dL449-R455) [[2]](diffhunk://#diff-cab2c0c5532854f2dd2b4557cc339dd396bccb1ea3a66af3ffc13821da7e3a8dL508-R551)
* [`scheduler/resource/persistentcache/peer_manager.go`](diffhunk://#diff-243b8e8011a1eb5e57b015c90ddff263d31ea40d2123fe67763fd114a6486452L245-R248): Updated `Delete` method to use Redis transactions.

### Data type updates:
* [`scheduler/resource/persistentcache/task.go`](diffhunk://#diff-8a6d4b10329a18c2eebbc44ace5a80c98b9f09483684f74a7d9d6f31be1b8662L80-R86): Changed data types for `PieceLength`, `ContentLength`, and `TotalPieceCount` from `int32`/`int64` to `uint64`/`uint32`. [[1]](diffhunk://#diff-8a6d4b10329a18c2eebbc44ace5a80c98b9f09483684f74a7d9d6f31be1b8662L80-R86) [[2]](diffhunk://#diff-8a6d4b10329a18c2eebbc44ace5a80c98b9f09483684f74a7d9d6f31be1b8662L105-R106)
* [`scheduler/resource/persistentcache/task_manager.go`](diffhunk://#diff-76057be354335f231655112ecad644f6c482e712b67d75ab6ed6fc18894e9cd9L39-R42): Updated related methods to reflect the new data types. [[1]](diffhunk://#diff-76057be354335f231655112ecad644f6c482e712b67d75ab6ed6fc18894e9cd9L39-R42) [[2]](diffhunk://#diff-76057be354335f231655112ecad644f6c482e712b67d75ab6ed6fc18894e9cd9L88-R100) [[3]](diffhunk://#diff-76057be354335f231655112ecad644f6c482e712b67d75ab6ed6fc18894e9cd9L131-R133) [[4]](diffhunk://#diff-76057be354335f231655112ecad644f6c482e712b67d75ab6ed6fc18894e9cd9L142-R150)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
