### PR TITLE
feat: replicate the persistent cache task when delete host

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	cloud.google.com/go/storage v1.50.0
-	d7y.io/api/v2 v2.1.18
+	d7y.io/api/v2 v2.1.23
 	github.com/MysteriousPotato/go-lockable v1.0.0
 	github.com/RichardKnop/machinery v1.10.8
 	github.com/Showmax/go-fqdn v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ cloud.google.com/go/storage v1.50.0 h1:3TbVkzTooBvnZsk7WaAQfOsNrdoM8QHusXA1cpk6Q
 cloud.google.com/go/storage v1.50.0/go.mod h1:l7XeiD//vx5lfqE3RavfmU9yvk5Pp0Zhcv482poyafY=
 cloud.google.com/go/trace v1.11.2 h1:4ZmaBdL8Ng/ajrgKqY5jfvzqMXbrDcBsUGXOT9aqTtI=
 cloud.google.com/go/trace v1.11.2/go.mod h1:bn7OwXd4pd5rFuAnTrzBuoZ4ax2XQeG3qNgYmfCy0Io=
-d7y.io/api/v2 v2.1.18 h1:5fpA94N7CihRdQxWPzUFx3qO7ScY76d0R2oxBtOt9PE=
-d7y.io/api/v2 v2.1.18/go.mod h1:zPZ7m8yC1LZH9VR4ACcvrphhPIVKSS2c3QHG+PRSixU=
+d7y.io/api/v2 v2.1.23 h1:adUXI1QHNxWG38iwtefZN3j7DysGkHIc3/UmOYFJBgw=
+d7y.io/api/v2 v2.1.23/go.mod h1:zPZ7m8yC1LZH9VR4ACcvrphhPIVKSS2c3QHG+PRSixU=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0/go.mod h1:uGG2W01BaETf0Ozp+QxxKJdMBNRWPdstHG0Fmdwn1/U=

--- a/pkg/rpc/dfdaemon/client/client_v2.go
+++ b/pkg/rpc/dfdaemon/client/client_v2.go
@@ -140,6 +140,9 @@ type V2 interface {
 	// DownloadPersistentCacheTask downloads persistent cache task from p2p network.
 	DownloadPersistentCacheTask(context.Context, *dfdaemonv2.DownloadPersistentCacheTaskRequest, ...grpc.CallOption) (dfdaemonv2.DfdaemonUpload_DownloadPersistentCacheTaskClient, error)
 
+	// UpdatePersistentCacheTask updates persistent cache task information.
+	UpdatePersistentCacheTask(context.Context, *dfdaemonv2.UpdatePersistentCacheTaskRequest, ...grpc.CallOption) error
+
 	// StatPersistentCacheTask stats persistent cache task information.
 	StatPersistentCacheTask(context.Context, *dfdaemonv2.StatPersistentCacheTaskRequest, ...grpc.CallOption) (*commonv2.PersistentCacheTask, error)
 
@@ -210,6 +213,15 @@ func (v *v2) DeleteTask(ctx context.Context, req *dfdaemonv2.DeleteTaskRequest, 
 // DownloadPersistentCacheTask downloads persistent cache task from p2p network.
 func (v *v2) DownloadPersistentCacheTask(ctx context.Context, req *dfdaemonv2.DownloadPersistentCacheTaskRequest, opts ...grpc.CallOption) (dfdaemonv2.DfdaemonUpload_DownloadPersistentCacheTaskClient, error) {
 	return v.DfdaemonUploadClient.DownloadPersistentCacheTask(ctx, req, opts...)
+}
+
+// UpdatePersistentCacheTask updates persistent cache task information.
+func (v *v2) UpdatePersistentCacheTask(ctx context.Context, req *dfdaemonv2.UpdatePersistentCacheTaskRequest, opts ...grpc.CallOption) error {
+	ctx, cancel := context.WithTimeout(ctx, contextTimeout)
+	defer cancel()
+
+	_, err := v.DfdaemonUploadClient.UpdatePersistentCacheTask(ctx, req, opts...)
+	return err
 }
 
 // StatPersistentCacheTask stats persistent cache task information.

--- a/pkg/rpc/dfdaemon/client/mocks/client_v2_mock.go
+++ b/pkg/rpc/dfdaemon/client/mocks/client_v2_mock.go
@@ -214,3 +214,22 @@ func (mr *MockV2MockRecorder) SyncPieces(arg0, arg1 any, arg2 ...any) *gomock.Ca
 	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncPieces", reflect.TypeOf((*MockV2)(nil).SyncPieces), varargs...)
 }
+
+// UpdatePersistentCacheTask mocks base method.
+func (m *MockV2) UpdatePersistentCacheTask(arg0 context.Context, arg1 *dfdaemon.UpdatePersistentCacheTaskRequest, arg2 ...grpc.CallOption) error {
+	m.ctrl.T.Helper()
+	varargs := []any{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdatePersistentCacheTask", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdatePersistentCacheTask indicates an expected call of UpdatePersistentCacheTask.
+func (mr *MockV2MockRecorder) UpdatePersistentCacheTask(arg0, arg1 any, arg2 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePersistentCacheTask", reflect.TypeOf((*MockV2)(nil).UpdatePersistentCacheTask), varargs...)
+}

--- a/scheduler/resource/persistentcache/peer.go
+++ b/scheduler/resource/persistentcache/peer.go
@@ -110,6 +110,7 @@ func NewPeer(id, state string, persistent bool, finishedPieces *bitset.BitSet, b
 	cost time.Duration, createdAt, updatedAt time.Time, log *logger.SugaredLoggerOnWith) *Peer {
 	p := &Peer{
 		ID:             id,
+		Persistent:     persistent,
 		FinishedPieces: finishedPieces,
 		Task:           task,
 		Host:           host,

--- a/scheduler/resource/persistentcache/peer_manager_mock.go
+++ b/scheduler/resource/persistentcache/peer_manager_mock.go
@@ -142,6 +142,36 @@ func (mr *MockPeerManagerMockRecorder) LoadAllByTaskID(arg0, arg1 any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadAllByTaskID", reflect.TypeOf((*MockPeerManager)(nil).LoadAllByTaskID), arg0, arg1)
 }
 
+// LoadAllIDsByHostID mocks base method.
+func (m *MockPeerManager) LoadAllIDsByHostID(arg0 context.Context, arg1 string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LoadAllIDsByHostID", arg0, arg1)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LoadAllIDsByHostID indicates an expected call of LoadAllIDsByHostID.
+func (mr *MockPeerManagerMockRecorder) LoadAllIDsByHostID(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadAllIDsByHostID", reflect.TypeOf((*MockPeerManager)(nil).LoadAllIDsByHostID), arg0, arg1)
+}
+
+// LoadAllIDsByTaskID mocks base method.
+func (m *MockPeerManager) LoadAllIDsByTaskID(arg0 context.Context, arg1 string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LoadAllIDsByTaskID", arg0, arg1)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LoadAllIDsByTaskID indicates an expected call of LoadAllIDsByTaskID.
+func (mr *MockPeerManagerMockRecorder) LoadAllIDsByTaskID(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadAllIDsByTaskID", reflect.TypeOf((*MockPeerManager)(nil).LoadAllIDsByTaskID), arg0, arg1)
+}
+
 // LoadPersistentAllByTaskID mocks base method.
 func (m *MockPeerManager) LoadPersistentAllByTaskID(arg0 context.Context, arg1 string) ([]*Peer, error) {
 	m.ctrl.T.Helper()

--- a/scheduler/resource/standard/seed_peer_client_mock.go
+++ b/scheduler/resource/standard/seed_peer_client_mock.go
@@ -318,3 +318,22 @@ func (mr *MockSeedPeerClientMockRecorder) SyncPieces(arg0, arg1 any, arg2 ...any
 	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncPieces", reflect.TypeOf((*MockSeedPeerClient)(nil).SyncPieces), varargs...)
 }
+
+// UpdatePersistentCacheTask mocks base method.
+func (m *MockSeedPeerClient) UpdatePersistentCacheTask(arg0 context.Context, arg1 *dfdaemon.UpdatePersistentCacheTaskRequest, arg2 ...grpc.CallOption) error {
+	m.ctrl.T.Helper()
+	varargs := []any{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdatePersistentCacheTask", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdatePersistentCacheTask indicates an expected call of UpdatePersistentCacheTask.
+func (mr *MockSeedPeerClientMockRecorder) UpdatePersistentCacheTask(arg0, arg1 any, arg2 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePersistentCacheTask", reflect.TypeOf((*MockSeedPeerClient)(nil).UpdatePersistentCacheTask), varargs...)
+}

--- a/scheduler/scheduling/mocks/scheduling_mock.go
+++ b/scheduler/scheduling/mocks/scheduling_mock.go
@@ -89,12 +89,13 @@ func (mr *MockSchedulingMockRecorder) FindParentAndCandidateParents(arg0, arg1, 
 }
 
 // FindReplicatePersistentCacheHosts mocks base method.
-func (m *MockScheduling) FindReplicatePersistentCacheHosts(arg0 context.Context, arg1 *persistentcache.Task, arg2 set.SafeSet[string]) ([]*persistentcache.Host, bool) {
+func (m *MockScheduling) FindReplicatePersistentCacheHosts(arg0 context.Context, arg1 *persistentcache.Task, arg2 set.SafeSet[string]) ([]*persistentcache.Peer, []*persistentcache.Host, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindReplicatePersistentCacheHosts", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]*persistentcache.Host)
-	ret1, _ := ret[1].(bool)
-	return ret0, ret1
+	ret0, _ := ret[0].([]*persistentcache.Peer)
+	ret1, _ := ret[1].([]*persistentcache.Host)
+	ret2, _ := ret[2].(bool)
+	return ret0, ret1, ret2
 }
 
 // FindReplicatePersistentCacheHosts indicates an expected call of FindReplicatePersistentCacheHosts.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes changes to the persistent cache task management and scheduling logic, as well as updates to mock implementations and dependency versions. The most important changes focus on adding new methods for updating persistent cache tasks, improving the handling of peer states, and refining the scheduling logic.

### Persistent Cache Task Management:

* Added `UpdatePersistentCacheTask` method to `V2` interface and its implementation in `client_v2.go` to update persistent cache task information. [[1]](diffhunk://#diff-4941d744e2734dadec552334f209d76d28196a136dc78a0fa26dceb837b45db2R143-R145) [[2]](diffhunk://#diff-4941d744e2734dadec552334f209d76d28196a136dc78a0fa26dceb837b45db2R218-R226)
* Modified `peer_manager.go` to correctly set task joint-set TTL and handle peer deletion more robustly by using the task ID instead of host ID. [[1]](diffhunk://#diff-243b8e8011a1eb5e57b015c90ddff263d31ea40d2123fe67763fd114a6486452L217-R217) [[2]](diffhunk://#diff-243b8e8011a1eb5e57b015c90ddff263d31ea40d2123fe67763fd114a6486452L229-R229) [[3]](diffhunk://#diff-243b8e8011a1eb5e57b015c90ddff263d31ea40d2123fe67763fd114a6486452R241-R245) [[4]](diffhunk://#diff-243b8e8011a1eb5e57b015c90ddff263d31ea40d2123fe67763fd114a6486452L254-R260) [[5]](diffhunk://#diff-243b8e8011a1eb5e57b015c90ddff263d31ea40d2123fe67763fd114a6486452L264-R280)

### Scheduling Logic:

* Updated `FindReplicatePersistentCacheHosts` method to return both cached and non-cached replicate hosts, improving the scheduling process for persistent cache tasks. [[1]](diffhunk://#diff-57a5631c6b71a1f49b322c274a294614f37aa19dedf4eaf7356e6fda8e5e7474L92-R98) [[2]](diffhunk://#diff-e2cfa8f2cf20753eb98419b3cf1341b9e6c952aed42b62bc84a65c128af0d1ddL65-R67) [[3]](diffhunk://#diff-e2cfa8f2cf20753eb98419b3cf1341b9e6c952aed42b62bc84a65c128af0d1ddL592-R612) [[4]](diffhunk://#diff-e2cfa8f2cf20753eb98419b3cf1341b9e6c952aed42b62bc84a65c128af0d1ddL617-R633) [[5]](diffhunk://#diff-e2cfa8f2cf20753eb98419b3cf1341b9e6c952aed42b62bc84a65c128af0d1ddL638-R642) [[6]](diffhunk://#diff-e2cfa8f2cf20753eb98419b3cf1341b9e6c952aed42b62bc84a65c128af0d1ddL654-R664) [[7]](diffhunk://#diff-e2cfa8f2cf20753eb98419b3cf1341b9e6c952aed42b62bc84a65c128af0d1ddL761-R765)

### Mock Implementations:

* Added mock methods for `UpdatePersistentCacheTask` in `client_v2_mock.go` and `seed_peer_client_mock.go`. [[1]](diffhunk://#diff-bd61556771b1e0ec86c0702a043388e871a71fdabbb8ae057fb0e8bad4838f8bR217-R235) [[2]](diffhunk://#diff-f03f09f83aef6e993401cf833ed4ae144e7b0ec63337195acdb8899b2e79df39R321-R339)
* Added new mock methods for loading peer IDs by host and task in `peer_manager_mock.go`.

### Dependency Updates:

* Updated `d7y.io/api/v2` dependency version from `v2.1.18` to `v2.1.21` in `go.mod`.

### Peer State Handling:

* Enhanced peer state handling in `service_v2.go` to set peer state to failed if various peer operations fail, ensuring more accurate state tracking.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
