### PR TITLE
test(e2e/v2): add transfer-from-dfdaemon option for dfget test case

### DIFF
--- a/test/e2e/v2/dfget_test.go
+++ b/test/e2e/v2/dfget_test.go
@@ -267,6 +267,102 @@ var _ = Describe("Download Using Dfget", func() {
 		})
 	})
 
+	Context("1MiB file and set transfer-from-dfdaemon", func() {
+		var (
+			testFile *util.File
+			err      error
+		)
+
+		BeforeEach(func() {
+			testFile, err = util.GetFileServer().GenerateFile(util.FileSize1MiB)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(testFile).NotTo(BeNil())
+		})
+
+		AfterEach(func() {
+			err = util.GetFileServer().DeleteFile(testFile.GetInfo())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("download should be ok", Label("dfget", "download", "transfer-from-dfdaemon"), func() {
+			clientPod, err := util.ClientExec()
+			fmt.Println(err)
+			Expect(err).NotTo(HaveOccurred())
+
+			out, err := clientPod.Command("sh", "-c", fmt.Sprintf("dfget %s --disable-back-to-source --transfer-from-dfdaemon --output %s", testFile.GetDownloadURL(), testFile.GetOutputPath())).CombinedOutput()
+			fmt.Println(string(out), err)
+			Expect(err).NotTo(HaveOccurred())
+
+			sha256sum, err := util.CalculateSha256ByTaskID([]*util.PodExec{clientPod}, testFile.GetTaskID())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(testFile.GetSha256()).To(Equal(sha256sum))
+
+			sha256sum, err = util.CalculateSha256ByOutput([]*util.PodExec{clientPod}, testFile.GetOutputPath())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(testFile.GetSha256()).To(Equal(sha256sum))
+
+			time.Sleep(1 * time.Second)
+			seedClientPods := make([]*util.PodExec, 3)
+			for i := 0; i < 3; i++ {
+				seedClientPods[i], err = util.SeedClientExec(i)
+				fmt.Println(err)
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			sha256sum, err = util.CalculateSha256ByTaskID(seedClientPods, testFile.GetTaskID())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(testFile.GetSha256()).To(Equal(sha256sum))
+		})
+	})
+
+	Context("10MiB file and set transfer-from-dfdaemon", func() {
+		var (
+			testFile *util.File
+			err      error
+		)
+
+		BeforeEach(func() {
+			testFile, err = util.GetFileServer().GenerateFile(util.FileSize10MiB)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(testFile).NotTo(BeNil())
+		})
+
+		AfterEach(func() {
+			err = util.GetFileServer().DeleteFile(testFile.GetInfo())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("download should be ok", Label("dfget", "download", "transfer-from-dfdaemon"), func() {
+			clientPod, err := util.ClientExec()
+			fmt.Println(err)
+			Expect(err).NotTo(HaveOccurred())
+
+			out, err := clientPod.Command("sh", "-c", fmt.Sprintf("dfget %s --disable-back-to-source --transfer-from-dfdaemon --output %s", testFile.GetDownloadURL(), testFile.GetOutputPath())).CombinedOutput()
+			fmt.Println(string(out), err)
+			Expect(err).NotTo(HaveOccurred())
+
+			sha256sum, err := util.CalculateSha256ByTaskID([]*util.PodExec{clientPod}, testFile.GetTaskID())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(testFile.GetSha256()).To(Equal(sha256sum))
+
+			sha256sum, err = util.CalculateSha256ByOutput([]*util.PodExec{clientPod}, testFile.GetOutputPath())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(testFile.GetSha256()).To(Equal(sha256sum))
+
+			time.Sleep(1 * time.Second)
+			seedClientPods := make([]*util.PodExec, 3)
+			for i := 0; i < 3; i++ {
+				seedClientPods[i], err = util.SeedClientExec(i)
+				fmt.Println(err)
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			sha256sum, err = util.CalculateSha256ByTaskID(seedClientPods, testFile.GetTaskID())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(testFile.GetSha256()).To(Equal(sha256sum))
+		})
+	})
+
 	Context("1MiB file and set application to d7y", func() {
 		var (
 			testFile *util.File


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces new test contexts for downloading files using `dfget` with the `transfer-from-dfdaemon` option in the `test/e2e/v2/dfget_test.go` file. The changes include adding tests for 1MiB and 10MiB file downloads.

New test contexts for `dfget`:

* Added context for downloading a 1MiB file using `dfget` with `transfer-from-dfdaemon` option. This includes setup and teardown steps, as well as validation of the downloaded file's SHA256 checksum.
* Added context for downloading a 10MiB file using `dfget` with `transfer-from-dfdaemon` option. This includes setup and teardown steps, as well as validation of the downloaded file's SHA256 checksum.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
