### PR TITLE
feat: add `load_to_cache` field in preheat request using Open API

### DIFF
--- a/internal/job/types.go
+++ b/internal/job/types.go
@@ -33,6 +33,7 @@ type PreheatRequest struct {
 	CertificateChain    [][]byte          `json:"certificate_chain" validate:"omitempty"`
 	InsecureSkipVerify  bool              `json:"insecure_skip_verify" validate:"omitempty"`
 	Timeout             time.Duration     `json:"timeout" validate:"omitempty"`
+	LoadToCache         bool              `json:"load_to_cache" validate:"omitempty"`
 }
 
 // PreheatResponse defines the response parameters for preheating.

--- a/manager/job/preheat.go
+++ b/manager/job/preheat.go
@@ -136,6 +136,7 @@ func (p *preheat) CreatePreheat(ctx context.Context, schedulers []models.Schedul
 				CertificateChain:    p.certificateChain,
 				InsecureSkipVerify:  p.insecureSkipVerify,
 				Timeout:             json.Timeout,
+				LoadToCache:         json.LoadToCache,
 			},
 		}
 	default:

--- a/manager/types/job.go
+++ b/manager/types/job.go
@@ -137,6 +137,9 @@ type PreheatArgs struct {
 
 	// Timeout is the timeout for preheating, default is 30 minutes.
 	Timeout time.Duration `json:"timeout" binding:"omitempty"`
+
+	// LoadToCache is the flag for preheating content in cache storage.
+	LoadToCache bool `json:"load_to_cache" binding:"omitempty"`
 }
 
 type CreateSyncPeersJobRequest struct {

--- a/scheduler/job/job.go
+++ b/scheduler/job/job.go
@@ -307,6 +307,7 @@ func (j *job) preheatAllSeedPeers(ctx context.Context, taskID string, req *inter
 					RequestHeader:       req.Headers,
 					Timeout:             durationpb.New(req.Timeout),
 					CertificateChain:    req.CertificateChain,
+					LoadToCache:         req.LoadToCache,
 				}})
 			if err != nil {
 				log.Errorf("preheat failed: %s", err.Error())
@@ -448,6 +449,7 @@ func (j *job) preheatAllPeers(ctx context.Context, taskID string, req *internalj
 					RequestHeader:       req.Headers,
 					Timeout:             durationpb.New(req.Timeout),
 					CertificateChain:    req.CertificateChain,
+					LoadToCache:         req.LoadToCache,
 				}})
 			if err != nil {
 				log.Errorf("preheat failed: %s", err.Error())
@@ -590,6 +592,7 @@ func (j *job) preheatV2(ctx context.Context, taskID string, req *internaljob.Pre
 			FilteredQueryParams: filteredQueryParams,
 			RequestHeader:       req.Headers,
 			CertificateChain:    req.CertificateChain,
+			LoadToCache:         req.LoadToCache,
 		}})
 	if err != nil {
 		log.Errorf("preheat failed: %s", err.Error())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

A new `load_to_cache` field has been added to the OpenAPI format to indicate whether to write the downloaded piece content to the user-space cache. This field is a Boolean type. Users can set it to true to cache the content locally to improve subsequent access efficiency. If it is set to false, no caching will be performed.
```
curl --location --request POST 'http://dragonfly-manager:8080/oapi/v1/jobs' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer your_dragonfly_personal_access_token' \
--header 'Authorization: token your_example.com_personal_access_token' \
--data-raw '{
    "type": "preheat",
    "args": {
        "type": "file",
        "url": "https://example.com",
        "scope": "single_seed_peer",
        "scheduler_cluster_ids":[1],
        "load_to_cache": true
    }
}'
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/dragonflyoss/dragonfly/issues/3742

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
### Purpose
This change enhances control over the caching behavior during preheating, allowing for optimization of data retrieval. By using the `LoadToCache` field, users can decide whether to store the downloaded content in cache memory, improving performance for repeated access.

### Changes:
1. Added LoadToCache field:
- In `internal/job/types.go`, a new boolean field LoadToCache has been added to the PreheatRequest struct, indicating whether the content should be cached.
- In `manager/types/job.go`, the PreheatArgs struct now includes the LoadToCache field to handle the preheating caching behavior.
- In `scheduler/job/job.go`, the LoadToCache field is integrated into the preheating job execution, ensuring that the preheating behavior respects the cache flag.
2. Updated Preheat Request Handling:
- In `manager/job/preheat.go`, the CreatePreheat method now passes the LoadToCache flag in the request, ensuring that the cache option is handled during the preheating process.
3. Modified Preheat Job Processing:
- The preheating job functions (`preheatAllSeedPeers`, `preheatAllPeers`, and `preheatV2`) in `scheduler/job/job.go` have been updated to incorporate the LoadToCache field when executing preheating operations.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
