### PR TITLE
feat(scheduler): handle DownloadPieceFinishedRequest and DownloadPieceFailedRequest asynchronously

### DIFF
--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -1746,16 +1746,20 @@ func (v *V2) AnnouncePersistentCachePeer(stream schedulerv2.Scheduler_AnnouncePe
 			downloadPieceFinishedRequest := announcePersistentCachePeerRequest.DownloadPieceFinishedRequest
 
 			log.Info("receive DownloadPieceFinishedRequest")
-			if err := v.handleDownloadPersistentCachePieceFinishedRequest(ctx, req.GetPeerId(), downloadPieceFinishedRequest); err != nil {
-				log.Error(err)
-			}
+			go func() {
+				if err := v.handleDownloadPersistentCachePieceFinishedRequest(context.Background(), req.GetPeerId(), downloadPieceFinishedRequest); err != nil {
+					log.Error(err)
+				}
+			}()
 		case *schedulerv2.AnnouncePersistentCachePeerRequest_DownloadPieceFailedRequest:
 			downloadPieceFailedRequest := announcePersistentCachePeerRequest.DownloadPieceFailedRequest
 
 			log.Info("receive DownloadPieceFailedRequest")
-			if err := v.handleDownloadPersistentCachePieceFailedRequest(ctx, req.GetPeerId(), downloadPieceFailedRequest); err != nil {
-				log.Error(err)
-			}
+			go func() {
+				if err := v.handleDownloadPersistentCachePieceFailedRequest(context.Background(), req.GetPeerId(), downloadPieceFailedRequest); err != nil {
+					log.Error(err)
+				}
+			}()
 		default:
 			msg := fmt.Sprintf("receive unknow request: %#v", announcePersistentCachePeerRequest)
 			log.Error(msg)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes a change to the `scheduler/service/service_v2.go` file to improve the handling of download piece requests by making the request handling asynchronous.

Concurrency improvements:

* [`scheduler/service/service_v2.go`](diffhunk://#diff-53ba821b898fb629c0cdb43d491c544e6b4ffc93aebb1fb05725ede3551de75cL1749-R1762): Modified the `AnnouncePersistentCachePeer` function to handle `DownloadPieceFinishedRequest` and `DownloadPieceFailedRequest` asynchronously using goroutines. This change ensures that the main thread is not blocked while handling these requests.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
