### PR TITLE
feat: add swagger annotations for open API router

### DIFF
--- a/api/manager/docs.go
+++ b/api/manager/docs.go
@@ -20,7 +20,7 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
-        "/applications": {
+        "/api/v1/applications": {
             "get": {
                 "description": "Get Applications",
                 "consumes": [
@@ -116,7 +116,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/applications/{id}": {
+        "/api/v1/applications/{id}": {
             "get": {
                 "description": "Get Application by id",
                 "consumes": [
@@ -241,7 +241,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/buckets": {
+        "/api/v1/buckets": {
             "get": {
                 "description": "Get Buckets",
                 "consumes": [
@@ -314,7 +314,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/buckets/{id}": {
+        "/api/v1/buckets/{id}": {
             "get": {
                 "description": "Get Bucket by id",
                 "consumes": [
@@ -391,7 +391,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/clusters": {
+        "/api/v1/clusters": {
             "get": {
                 "description": "Get Clusters",
                 "consumes": [
@@ -487,7 +487,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/clusters/{id}": {
+        "/api/v1/clusters/{id}": {
             "get": {
                 "description": "Get Cluster by id",
                 "consumes": [
@@ -612,7 +612,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/configs": {
+        "/api/v1/configs": {
             "get": {
                 "description": "Get Configs",
                 "consumes": [
@@ -708,7 +708,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/configs/{id}": {
+        "/api/v1/configs/{id}": {
             "get": {
                 "description": "Get Config by id",
                 "consumes": [
@@ -833,36 +833,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/healthy": {
-            "get": {
-                "description": "Get app health",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Health"
-                ],
-                "summary": "Get Health",
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    },
-                    "400": {
-                        "description": "Bad Request"
-                    },
-                    "404": {
-                        "description": "Not Found"
-                    },
-                    "500": {
-                        "description": "Internal Server Error"
-                    }
-                }
-            }
-        },
-        "/jobs": {
+        "/api/v1/jobs": {
             "get": {
                 "description": "Get Jobs",
                 "consumes": [
@@ -915,50 +886,9 @@ const docTemplate = `{
                         "description": "Internal Server Error"
                     }
                 }
-            },
-            "post": {
-                "description": "Create by json config",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Job"
-                ],
-                "summary": "Create Job",
-                "parameters": [
-                    {
-                        "description": "Job",
-                        "name": "Job",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.CreateJobRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_models.Job"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request"
-                    },
-                    "404": {
-                        "description": "Not Found"
-                    },
-                    "500": {
-                        "description": "Internal Server Error"
-                    }
-                }
             }
         },
-        "/jobs/{id}": {
+        "/api/v1/jobs/{id}": {
             "get": {
                 "description": "Get Job by id",
                 "consumes": [
@@ -1083,7 +1013,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/oauth": {
+        "/api/v1/oauth": {
             "get": {
                 "description": "Get Oauths",
                 "consumes": [
@@ -1179,7 +1109,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/oauth/{id}": {
+        "/api/v1/oauth/{id}": {
             "get": {
                 "description": "Get Oauth by id",
                 "consumes": [
@@ -1304,7 +1234,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/peers": {
+        "/api/v1/peers": {
             "get": {
                 "description": "Get Peers",
                 "consumes": [
@@ -1400,7 +1330,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/peers/{id}": {
+        "/api/v1/peers/{id}": {
             "get": {
                 "description": "Get Peer by id",
                 "consumes": [
@@ -1477,7 +1407,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/permissions": {
+        "/api/v1/permissions": {
             "get": {
                 "description": "Get Permissions",
                 "produces": [
@@ -1506,7 +1436,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/personal-access-tokens": {
+        "/api/v1/personal-access-tokens": {
             "get": {
                 "description": "Get PersonalAccessTokens",
                 "consumes": [
@@ -1602,7 +1532,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/personal-access-tokens/{id}": {
+        "/api/v1/personal-access-tokens/{id}": {
             "get": {
                 "description": "Get PersonalAccessToken by id",
                 "consumes": [
@@ -1727,91 +1657,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/preheats": {
-            "post": {
-                "description": "Create by json config",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Preheat"
-                ],
-                "summary": "Create V1 Preheat",
-                "parameters": [
-                    {
-                        "description": "Preheat",
-                        "name": "Preheat",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.CreateV1PreheatRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.CreateV1PreheatResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request"
-                    },
-                    "404": {
-                        "description": "Not Found"
-                    },
-                    "500": {
-                        "description": "Internal Server Error"
-                    }
-                }
-            }
-        },
-        "/preheats/{id}": {
-            "get": {
-                "description": "Get Preheat by id",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Preheat"
-                ],
-                "summary": "Get V1 Preheat",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "id",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.GetV1PreheatResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request"
-                    },
-                    "404": {
-                        "description": "Not Found"
-                    },
-                    "500": {
-                        "description": "Internal Server Error"
-                    }
-                }
-            }
-        },
-        "/roles": {
+        "/api/v1/roles": {
             "get": {
                 "description": "Get roles",
                 "consumes": [
@@ -1872,7 +1718,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/roles/{role}": {
+        "/api/v1/roles/{role}": {
             "get": {
                 "description": "Get Role",
                 "consumes": [
@@ -1940,7 +1786,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/roles/{role}/permissions": {
+        "/api/v1/roles/{role}/permissions": {
             "post": {
                 "description": "Add Permission by json config",
                 "consumes": [
@@ -2026,7 +1872,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/scheduler-clusters": {
+        "/api/v1/scheduler-clusters": {
             "get": {
                 "description": "Get SchedulerClusters",
                 "consumes": [
@@ -2122,7 +1968,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/scheduler-clusters/{id}": {
+        "/api/v1/scheduler-clusters/{id}": {
             "get": {
                 "description": "Get SchedulerCluster by id",
                 "consumes": [
@@ -2247,7 +2093,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/scheduler-clusters/{id}/schedulers/{scheduler_id}": {
+        "/api/v1/scheduler-clusters/{id}/schedulers/{scheduler_id}": {
             "put": {
                 "description": "Add Scheduler to schedulerCluster",
                 "consumes": [
@@ -2292,7 +2138,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/scheduler-features": {
+        "/api/v1/scheduler-features": {
             "get": {
                 "description": "Get Scheduler Features",
                 "consumes": [
@@ -2327,7 +2173,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/schedulers": {
+        "/api/v1/schedulers": {
             "get": {
                 "description": "Get Schedulers",
                 "consumes": [
@@ -2423,7 +2269,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/schedulers/{id}": {
+        "/api/v1/schedulers/{id}": {
             "get": {
                 "description": "Get Scheduler by id",
                 "consumes": [
@@ -2548,7 +2394,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/seed-peer-clusters": {
+        "/api/v1/seed-peer-clusters": {
             "get": {
                 "description": "Get SeedPeerClusters",
                 "consumes": [
@@ -2644,7 +2490,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/seed-peer-clusters/{id}": {
+        "/api/v1/seed-peer-clusters/{id}": {
             "get": {
                 "description": "Get SeedPeerCluster by id",
                 "consumes": [
@@ -2769,7 +2615,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/seed-peer-clusters/{id}/scheduler-clusters/{scheduler_cluster_id}": {
+        "/api/v1/seed-peer-clusters/{id}/scheduler-clusters/{scheduler_cluster_id}": {
             "put": {
                 "description": "Add SchedulerCluster to SeedPeerCluster",
                 "consumes": [
@@ -2814,7 +2660,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/seed-peer-clusters/{id}/seed-peers/{seed_peer_id}": {
+        "/api/v1/seed-peer-clusters/{id}/seed-peers/{seed_peer_id}": {
             "put": {
                 "description": "Add SeedPeer to SeedPeerCluster",
                 "consumes": [
@@ -2859,7 +2705,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/seed-peers": {
+        "/api/v1/seed-peers": {
             "get": {
                 "description": "Get SeedPeers",
                 "consumes": [
@@ -2955,7 +2801,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/seed-peers/{id}": {
+        "/api/v1/seed-peers/{id}": {
             "get": {
                 "description": "Get SeedPeer by id",
                 "consumes": [
@@ -3080,7 +2926,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/user/signin/{name}": {
+        "/api/v1/user/signin/{name}": {
             "get": {
                 "description": "oauth signin by json config",
                 "consumes": [
@@ -3118,7 +2964,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/user/signin/{name}/callback": {
+        "/api/v1/user/signin/{name}/callback": {
             "get": {
                 "description": "oauth signin callback by json config",
                 "tags": [
@@ -3157,7 +3003,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/user/signup": {
+        "/api/v1/user/signup": {
             "post": {
                 "description": "signup by json config",
                 "consumes": [
@@ -3197,7 +3043,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/users": {
+        "/api/v1/users": {
             "get": {
                 "description": "Get Users",
                 "consumes": [
@@ -3252,7 +3098,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/users/{id}": {
+        "/api/v1/users/{id}": {
             "get": {
                 "description": "Get User by id",
                 "consumes": [
@@ -3341,7 +3187,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/users/{id}/reset_password": {
+        "/api/v1/users/{id}/reset_password": {
             "post": {
                 "description": "reset password by json config",
                 "consumes": [
@@ -3385,7 +3231,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/users/{id}/roles": {
+        "/api/v1/users/{id}/roles": {
             "get": {
                 "description": "get roles by json config",
                 "produces": [
@@ -3423,7 +3269,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/users/{id}/roles/{role}": {
+        "/api/v1/users/{id}/roles/{role}": {
             "put": {
                 "description": "add role to user by uri config",
                 "consumes": [
@@ -3498,6 +3344,561 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/healthy": {
+            "get": {
+                "description": "Get app health",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Health"
+                ],
+                "summary": "Get Health",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/oapi/v1/clusters": {
+            "get": {
+                "description": "Get Clusters",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Cluster"
+                ],
+                "summary": "Get Clusters",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "current page",
+                        "name": "page",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "maximum": 50,
+                        "minimum": 2,
+                        "type": "integer",
+                        "default": 10,
+                        "description": "return max item count, default 10, max 50",
+                        "name": "per_page",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.GetClusterResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            },
+            "post": {
+                "description": "Create by json config",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Cluster"
+                ],
+                "summary": "Create Cluster",
+                "parameters": [
+                    {
+                        "description": "Cluster",
+                        "name": "Cluster",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.CreateClusterRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.CreateClusterResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/oapi/v1/clusters/{id}": {
+            "get": {
+                "description": "Get Cluster by id",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Cluster"
+                ],
+                "summary": "Get Cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.GetClusterResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            },
+            "delete": {
+                "description": "Destroy by id",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Cluster"
+                ],
+                "summary": "Destroy Cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            },
+            "patch": {
+                "description": "Update by json config",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Cluster"
+                ],
+                "summary": "Update Cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Cluster",
+                        "name": "Cluster",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.UpdateClusterRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.UpdateClusterResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/oapi/v1/jobs": {
+            "get": {
+                "description": "Get Jobs",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Job"
+                ],
+                "summary": "Get Jobs",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "current page",
+                        "name": "page",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "maximum": 50,
+                        "minimum": 2,
+                        "type": "integer",
+                        "default": 10,
+                        "description": "return max item count, default 10, max 50",
+                        "name": "per_page",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_models.Job"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            },
+            "post": {
+                "description": "Create by json config",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Job"
+                ],
+                "summary": "Create Job",
+                "parameters": [
+                    {
+                        "description": "Job",
+                        "name": "Job",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.CreateJobRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_models.Job"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/oapi/v1/jobs/{id}": {
+            "get": {
+                "description": "Get Job by id",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Job"
+                ],
+                "summary": "Get Job",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_models.Job"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            },
+            "delete": {
+                "description": "Destroy by id",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Job"
+                ],
+                "summary": "Destroy Job",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            },
+            "patch": {
+                "description": "Update by json config",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Job"
+                ],
+                "summary": "Update Job",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Job",
+                        "name": "Job",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.UpdateJobRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_models.Job"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/preheats": {
+            "post": {
+                "description": "Create by json config",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Preheat"
+                ],
+                "summary": "Create V1 Preheat",
+                "parameters": [
+                    {
+                        "description": "Preheat",
+                        "name": "Preheat",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.CreateV1PreheatRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.CreateV1PreheatResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/preheats/{id}": {
+            "get": {
+                "description": "Get Preheat by id",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Preheat"
+                ],
+                "summary": "Get V1 Preheat",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.GetV1PreheatResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
                     },
                     "500": {
                         "description": "Internal Server Error"
@@ -5088,14 +5489,24 @@ const docTemplate = `{
                 }
             }
         }
-    }
+    },
+    "tags": [
+        {
+            "description": "API router (/api/v1)",
+            "name": "api"
+        },
+        {
+            "description": "open API router (/oapi/v1)",
+            "name": "oapi"
+        }
+    ]
 }`
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
 	Version:          "1.0.0",
 	Host:             "localhost:8080",
-	BasePath:         "/api/v1",
+	BasePath:         "/",
 	Schemes:          []string{},
 	Title:            "Dragonfly Manager",
 	Description:      "Dragonfly Manager Server",

--- a/api/manager/swagger.json
+++ b/api/manager/swagger.json
@@ -12,9 +12,9 @@
         "version": "1.0.0"
     },
     "host": "localhost:8080",
-    "basePath": "/api/v1",
+    "basePath": "/",
     "paths": {
-        "/applications": {
+        "/api/v1/applications": {
             "get": {
                 "description": "Get Applications",
                 "consumes": [
@@ -110,7 +110,7 @@
                 }
             }
         },
-        "/applications/{id}": {
+        "/api/v1/applications/{id}": {
             "get": {
                 "description": "Get Application by id",
                 "consumes": [
@@ -235,7 +235,7 @@
                 }
             }
         },
-        "/buckets": {
+        "/api/v1/buckets": {
             "get": {
                 "description": "Get Buckets",
                 "consumes": [
@@ -308,7 +308,7 @@
                 }
             }
         },
-        "/buckets/{id}": {
+        "/api/v1/buckets/{id}": {
             "get": {
                 "description": "Get Bucket by id",
                 "consumes": [
@@ -385,7 +385,7 @@
                 }
             }
         },
-        "/clusters": {
+        "/api/v1/clusters": {
             "get": {
                 "description": "Get Clusters",
                 "consumes": [
@@ -481,7 +481,7 @@
                 }
             }
         },
-        "/clusters/{id}": {
+        "/api/v1/clusters/{id}": {
             "get": {
                 "description": "Get Cluster by id",
                 "consumes": [
@@ -606,7 +606,7 @@
                 }
             }
         },
-        "/configs": {
+        "/api/v1/configs": {
             "get": {
                 "description": "Get Configs",
                 "consumes": [
@@ -702,7 +702,7 @@
                 }
             }
         },
-        "/configs/{id}": {
+        "/api/v1/configs/{id}": {
             "get": {
                 "description": "Get Config by id",
                 "consumes": [
@@ -827,36 +827,7 @@
                 }
             }
         },
-        "/healthy": {
-            "get": {
-                "description": "Get app health",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Health"
-                ],
-                "summary": "Get Health",
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    },
-                    "400": {
-                        "description": "Bad Request"
-                    },
-                    "404": {
-                        "description": "Not Found"
-                    },
-                    "500": {
-                        "description": "Internal Server Error"
-                    }
-                }
-            }
-        },
-        "/jobs": {
+        "/api/v1/jobs": {
             "get": {
                 "description": "Get Jobs",
                 "consumes": [
@@ -909,50 +880,9 @@
                         "description": "Internal Server Error"
                     }
                 }
-            },
-            "post": {
-                "description": "Create by json config",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Job"
-                ],
-                "summary": "Create Job",
-                "parameters": [
-                    {
-                        "description": "Job",
-                        "name": "Job",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.CreateJobRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_models.Job"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request"
-                    },
-                    "404": {
-                        "description": "Not Found"
-                    },
-                    "500": {
-                        "description": "Internal Server Error"
-                    }
-                }
             }
         },
-        "/jobs/{id}": {
+        "/api/v1/jobs/{id}": {
             "get": {
                 "description": "Get Job by id",
                 "consumes": [
@@ -1077,7 +1007,7 @@
                 }
             }
         },
-        "/oauth": {
+        "/api/v1/oauth": {
             "get": {
                 "description": "Get Oauths",
                 "consumes": [
@@ -1173,7 +1103,7 @@
                 }
             }
         },
-        "/oauth/{id}": {
+        "/api/v1/oauth/{id}": {
             "get": {
                 "description": "Get Oauth by id",
                 "consumes": [
@@ -1298,7 +1228,7 @@
                 }
             }
         },
-        "/peers": {
+        "/api/v1/peers": {
             "get": {
                 "description": "Get Peers",
                 "consumes": [
@@ -1394,7 +1324,7 @@
                 }
             }
         },
-        "/peers/{id}": {
+        "/api/v1/peers/{id}": {
             "get": {
                 "description": "Get Peer by id",
                 "consumes": [
@@ -1471,7 +1401,7 @@
                 }
             }
         },
-        "/permissions": {
+        "/api/v1/permissions": {
             "get": {
                 "description": "Get Permissions",
                 "produces": [
@@ -1500,7 +1430,7 @@
                 }
             }
         },
-        "/personal-access-tokens": {
+        "/api/v1/personal-access-tokens": {
             "get": {
                 "description": "Get PersonalAccessTokens",
                 "consumes": [
@@ -1596,7 +1526,7 @@
                 }
             }
         },
-        "/personal-access-tokens/{id}": {
+        "/api/v1/personal-access-tokens/{id}": {
             "get": {
                 "description": "Get PersonalAccessToken by id",
                 "consumes": [
@@ -1721,91 +1651,7 @@
                 }
             }
         },
-        "/preheats": {
-            "post": {
-                "description": "Create by json config",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Preheat"
-                ],
-                "summary": "Create V1 Preheat",
-                "parameters": [
-                    {
-                        "description": "Preheat",
-                        "name": "Preheat",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.CreateV1PreheatRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.CreateV1PreheatResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request"
-                    },
-                    "404": {
-                        "description": "Not Found"
-                    },
-                    "500": {
-                        "description": "Internal Server Error"
-                    }
-                }
-            }
-        },
-        "/preheats/{id}": {
-            "get": {
-                "description": "Get Preheat by id",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Preheat"
-                ],
-                "summary": "Get V1 Preheat",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "id",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.GetV1PreheatResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request"
-                    },
-                    "404": {
-                        "description": "Not Found"
-                    },
-                    "500": {
-                        "description": "Internal Server Error"
-                    }
-                }
-            }
-        },
-        "/roles": {
+        "/api/v1/roles": {
             "get": {
                 "description": "Get roles",
                 "consumes": [
@@ -1866,7 +1712,7 @@
                 }
             }
         },
-        "/roles/{role}": {
+        "/api/v1/roles/{role}": {
             "get": {
                 "description": "Get Role",
                 "consumes": [
@@ -1934,7 +1780,7 @@
                 }
             }
         },
-        "/roles/{role}/permissions": {
+        "/api/v1/roles/{role}/permissions": {
             "post": {
                 "description": "Add Permission by json config",
                 "consumes": [
@@ -2020,7 +1866,7 @@
                 }
             }
         },
-        "/scheduler-clusters": {
+        "/api/v1/scheduler-clusters": {
             "get": {
                 "description": "Get SchedulerClusters",
                 "consumes": [
@@ -2116,7 +1962,7 @@
                 }
             }
         },
-        "/scheduler-clusters/{id}": {
+        "/api/v1/scheduler-clusters/{id}": {
             "get": {
                 "description": "Get SchedulerCluster by id",
                 "consumes": [
@@ -2241,7 +2087,7 @@
                 }
             }
         },
-        "/scheduler-clusters/{id}/schedulers/{scheduler_id}": {
+        "/api/v1/scheduler-clusters/{id}/schedulers/{scheduler_id}": {
             "put": {
                 "description": "Add Scheduler to schedulerCluster",
                 "consumes": [
@@ -2286,7 +2132,7 @@
                 }
             }
         },
-        "/scheduler-features": {
+        "/api/v1/scheduler-features": {
             "get": {
                 "description": "Get Scheduler Features",
                 "consumes": [
@@ -2321,7 +2167,7 @@
                 }
             }
         },
-        "/schedulers": {
+        "/api/v1/schedulers": {
             "get": {
                 "description": "Get Schedulers",
                 "consumes": [
@@ -2417,7 +2263,7 @@
                 }
             }
         },
-        "/schedulers/{id}": {
+        "/api/v1/schedulers/{id}": {
             "get": {
                 "description": "Get Scheduler by id",
                 "consumes": [
@@ -2542,7 +2388,7 @@
                 }
             }
         },
-        "/seed-peer-clusters": {
+        "/api/v1/seed-peer-clusters": {
             "get": {
                 "description": "Get SeedPeerClusters",
                 "consumes": [
@@ -2638,7 +2484,7 @@
                 }
             }
         },
-        "/seed-peer-clusters/{id}": {
+        "/api/v1/seed-peer-clusters/{id}": {
             "get": {
                 "description": "Get SeedPeerCluster by id",
                 "consumes": [
@@ -2763,7 +2609,7 @@
                 }
             }
         },
-        "/seed-peer-clusters/{id}/scheduler-clusters/{scheduler_cluster_id}": {
+        "/api/v1/seed-peer-clusters/{id}/scheduler-clusters/{scheduler_cluster_id}": {
             "put": {
                 "description": "Add SchedulerCluster to SeedPeerCluster",
                 "consumes": [
@@ -2808,7 +2654,7 @@
                 }
             }
         },
-        "/seed-peer-clusters/{id}/seed-peers/{seed_peer_id}": {
+        "/api/v1/seed-peer-clusters/{id}/seed-peers/{seed_peer_id}": {
             "put": {
                 "description": "Add SeedPeer to SeedPeerCluster",
                 "consumes": [
@@ -2853,7 +2699,7 @@
                 }
             }
         },
-        "/seed-peers": {
+        "/api/v1/seed-peers": {
             "get": {
                 "description": "Get SeedPeers",
                 "consumes": [
@@ -2949,7 +2795,7 @@
                 }
             }
         },
-        "/seed-peers/{id}": {
+        "/api/v1/seed-peers/{id}": {
             "get": {
                 "description": "Get SeedPeer by id",
                 "consumes": [
@@ -3074,7 +2920,7 @@
                 }
             }
         },
-        "/user/signin/{name}": {
+        "/api/v1/user/signin/{name}": {
             "get": {
                 "description": "oauth signin by json config",
                 "consumes": [
@@ -3112,7 +2958,7 @@
                 }
             }
         },
-        "/user/signin/{name}/callback": {
+        "/api/v1/user/signin/{name}/callback": {
             "get": {
                 "description": "oauth signin callback by json config",
                 "tags": [
@@ -3151,7 +2997,7 @@
                 }
             }
         },
-        "/user/signup": {
+        "/api/v1/user/signup": {
             "post": {
                 "description": "signup by json config",
                 "consumes": [
@@ -3191,7 +3037,7 @@
                 }
             }
         },
-        "/users": {
+        "/api/v1/users": {
             "get": {
                 "description": "Get Users",
                 "consumes": [
@@ -3246,7 +3092,7 @@
                 }
             }
         },
-        "/users/{id}": {
+        "/api/v1/users/{id}": {
             "get": {
                 "description": "Get User by id",
                 "consumes": [
@@ -3335,7 +3181,7 @@
                 }
             }
         },
-        "/users/{id}/reset_password": {
+        "/api/v1/users/{id}/reset_password": {
             "post": {
                 "description": "reset password by json config",
                 "consumes": [
@@ -3379,7 +3225,7 @@
                 }
             }
         },
-        "/users/{id}/roles": {
+        "/api/v1/users/{id}/roles": {
             "get": {
                 "description": "get roles by json config",
                 "produces": [
@@ -3417,7 +3263,7 @@
                 }
             }
         },
-        "/users/{id}/roles/{role}": {
+        "/api/v1/users/{id}/roles/{role}": {
             "put": {
                 "description": "add role to user by uri config",
                 "consumes": [
@@ -3492,6 +3338,561 @@
                     },
                     "400": {
                         "description": "Bad Request"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/healthy": {
+            "get": {
+                "description": "Get app health",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Health"
+                ],
+                "summary": "Get Health",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/oapi/v1/clusters": {
+            "get": {
+                "description": "Get Clusters",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Cluster"
+                ],
+                "summary": "Get Clusters",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "current page",
+                        "name": "page",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "maximum": 50,
+                        "minimum": 2,
+                        "type": "integer",
+                        "default": 10,
+                        "description": "return max item count, default 10, max 50",
+                        "name": "per_page",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.GetClusterResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            },
+            "post": {
+                "description": "Create by json config",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Cluster"
+                ],
+                "summary": "Create Cluster",
+                "parameters": [
+                    {
+                        "description": "Cluster",
+                        "name": "Cluster",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.CreateClusterRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.CreateClusterResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/oapi/v1/clusters/{id}": {
+            "get": {
+                "description": "Get Cluster by id",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Cluster"
+                ],
+                "summary": "Get Cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.GetClusterResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            },
+            "delete": {
+                "description": "Destroy by id",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Cluster"
+                ],
+                "summary": "Destroy Cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            },
+            "patch": {
+                "description": "Update by json config",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Cluster"
+                ],
+                "summary": "Update Cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Cluster",
+                        "name": "Cluster",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.UpdateClusterRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.UpdateClusterResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/oapi/v1/jobs": {
+            "get": {
+                "description": "Get Jobs",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Job"
+                ],
+                "summary": "Get Jobs",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "current page",
+                        "name": "page",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "maximum": 50,
+                        "minimum": 2,
+                        "type": "integer",
+                        "default": 10,
+                        "description": "return max item count, default 10, max 50",
+                        "name": "per_page",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_models.Job"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            },
+            "post": {
+                "description": "Create by json config",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Job"
+                ],
+                "summary": "Create Job",
+                "parameters": [
+                    {
+                        "description": "Job",
+                        "name": "Job",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.CreateJobRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_models.Job"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/oapi/v1/jobs/{id}": {
+            "get": {
+                "description": "Get Job by id",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Job"
+                ],
+                "summary": "Get Job",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_models.Job"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            },
+            "delete": {
+                "description": "Destroy by id",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Job"
+                ],
+                "summary": "Destroy Job",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            },
+            "patch": {
+                "description": "Update by json config",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Job"
+                ],
+                "summary": "Update Job",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Job",
+                        "name": "Job",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.UpdateJobRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_models.Job"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/preheats": {
+            "post": {
+                "description": "Create by json config",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Preheat"
+                ],
+                "summary": "Create V1 Preheat",
+                "parameters": [
+                    {
+                        "description": "Preheat",
+                        "name": "Preheat",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.CreateV1PreheatRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.CreateV1PreheatResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/preheats/{id}": {
+            "get": {
+                "description": "Get Preheat by id",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Preheat"
+                ],
+                "summary": "Get V1 Preheat",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/d7y_io_dragonfly_v2_manager_types.GetV1PreheatResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
                     },
                     "500": {
                         "description": "Internal Server Error"
@@ -5082,5 +5483,15 @@
                 }
             }
         }
-    }
+    },
+    "tags": [
+        {
+            "description": "API router (/api/v1)",
+            "name": "api"
+        },
+        {
+            "description": "open API router (/oapi/v1)",
+            "name": "oapi"
+        }
+    ]
 }

--- a/api/manager/swagger.yaml
+++ b/api/manager/swagger.yaml
@@ -1,4 +1,4 @@
-basePath: /api/v1
+basePath: /
 definitions:
   d7y_io_dragonfly_v2_manager_models.Application:
     properties:
@@ -1075,7 +1075,7 @@ info:
   title: Dragonfly Manager
   version: 1.0.0
 paths:
-  /applications:
+  /api/v1/applications:
     get:
       consumes:
       - application/json
@@ -1140,7 +1140,7 @@ paths:
       summary: Create Application
       tags:
       - Application
-  /applications/{id}:
+  /api/v1/applications/{id}:
     delete:
       consumes:
       - application/json
@@ -1223,7 +1223,7 @@ paths:
       summary: Update Application
       tags:
       - Application
-  /buckets:
+  /api/v1/buckets:
     get:
       consumes:
       - application/json
@@ -1271,7 +1271,7 @@ paths:
       summary: Create Bucket
       tags:
       - Bucket
-  /buckets/{id}:
+  /api/v1/buckets/{id}:
     delete:
       consumes:
       - application/json
@@ -1322,7 +1322,7 @@ paths:
       summary: Get Bucket
       tags:
       - Bucket
-  /clusters:
+  /api/v1/clusters:
     get:
       consumes:
       - application/json
@@ -1387,7 +1387,7 @@ paths:
       summary: Create Cluster
       tags:
       - Cluster
-  /clusters/{id}:
+  /api/v1/clusters/{id}:
     delete:
       consumes:
       - application/json
@@ -1470,7 +1470,7 @@ paths:
       summary: Update Cluster
       tags:
       - Cluster
-  /configs:
+  /api/v1/configs:
     get:
       consumes:
       - application/json
@@ -1535,7 +1535,7 @@ paths:
       summary: Create Config
       tags:
       - Config
-  /configs/{id}:
+  /api/v1/configs/{id}:
     delete:
       consumes:
       - application/json
@@ -1618,26 +1618,7 @@ paths:
       summary: Update Config
       tags:
       - Config
-  /healthy:
-    get:
-      consumes:
-      - application/json
-      description: Get app health
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-        "400":
-          description: Bad Request
-        "404":
-          description: Not Found
-        "500":
-          description: Internal Server Error
-      summary: Get Health
-      tags:
-      - Health
-  /jobs:
+  /api/v1/jobs:
     get:
       consumes:
       - application/json
@@ -1675,34 +1656,7 @@ paths:
       summary: Get Jobs
       tags:
       - Job
-    post:
-      consumes:
-      - application/json
-      description: Create by json config
-      parameters:
-      - description: Job
-        in: body
-        name: Job
-        required: true
-        schema:
-          $ref: '#/definitions/d7y_io_dragonfly_v2_manager_types.CreateJobRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/d7y_io_dragonfly_v2_manager_models.Job'
-        "400":
-          description: Bad Request
-        "404":
-          description: Not Found
-        "500":
-          description: Internal Server Error
-      summary: Create Job
-      tags:
-      - Job
-  /jobs/{id}:
+  /api/v1/jobs/{id}:
     delete:
       consumes:
       - application/json
@@ -1785,7 +1739,7 @@ paths:
       summary: Update Job
       tags:
       - Job
-  /oauth:
+  /api/v1/oauth:
     get:
       consumes:
       - application/json
@@ -1850,7 +1804,7 @@ paths:
       summary: Create Oauth
       tags:
       - Oauth
-  /oauth/{id}:
+  /api/v1/oauth/{id}:
     delete:
       consumes:
       - application/json
@@ -1933,7 +1887,7 @@ paths:
       summary: Update Oauth
       tags:
       - Oauth
-  /peers:
+  /api/v1/peers:
     get:
       consumes:
       - application/json
@@ -1998,7 +1952,7 @@ paths:
       summary: Create Peer
       tags:
       - Peer
-  /peers/{id}:
+  /api/v1/peers/{id}:
     delete:
       consumes:
       - application/json
@@ -2049,7 +2003,7 @@ paths:
       summary: Get Peer
       tags:
       - Peer
-  /permissions:
+  /api/v1/permissions:
     get:
       description: Get Permissions
       produces:
@@ -2068,7 +2022,7 @@ paths:
       summary: Get Permissions
       tags:
       - Permission
-  /personal-access-tokens:
+  /api/v1/personal-access-tokens:
     get:
       consumes:
       - application/json
@@ -2133,7 +2087,7 @@ paths:
       summary: Create PersonalAccessToken
       tags:
       - PersonalAccessToken
-  /personal-access-tokens/{id}:
+  /api/v1/personal-access-tokens/{id}:
     delete:
       consumes:
       - application/json
@@ -2216,62 +2170,7 @@ paths:
       summary: Update PersonalAccessToken
       tags:
       - PersonalAccessToken
-  /preheats:
-    post:
-      consumes:
-      - application/json
-      description: Create by json config
-      parameters:
-      - description: Preheat
-        in: body
-        name: Preheat
-        required: true
-        schema:
-          $ref: '#/definitions/d7y_io_dragonfly_v2_manager_types.CreateV1PreheatRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/d7y_io_dragonfly_v2_manager_types.CreateV1PreheatResponse'
-        "400":
-          description: Bad Request
-        "404":
-          description: Not Found
-        "500":
-          description: Internal Server Error
-      summary: Create V1 Preheat
-      tags:
-      - Preheat
-  /preheats/{id}:
-    get:
-      consumes:
-      - application/json
-      description: Get Preheat by id
-      parameters:
-      - description: id
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/d7y_io_dragonfly_v2_manager_types.GetV1PreheatResponse'
-        "400":
-          description: Bad Request
-        "404":
-          description: Not Found
-        "500":
-          description: Internal Server Error
-      summary: Get V1 Preheat
-      tags:
-      - Preheat
-  /roles:
+  /api/v1/roles:
     get:
       consumes:
       - application/json
@@ -2311,7 +2210,7 @@ paths:
       summary: Create Role
       tags:
       - Role
-  /roles/{role}:
+  /api/v1/roles/{role}:
     delete:
       consumes:
       - application/json
@@ -2356,7 +2255,7 @@ paths:
       summary: Get Role
       tags:
       - Role
-  /roles/{role}/permissions:
+  /api/v1/roles/{role}/permissions:
     delete:
       consumes:
       - application/json
@@ -2413,7 +2312,7 @@ paths:
       summary: Add Permission For Role
       tags:
       - Role
-  /scheduler-clusters:
+  /api/v1/scheduler-clusters:
     get:
       consumes:
       - application/json
@@ -2478,7 +2377,7 @@ paths:
       summary: Create SchedulerCluster
       tags:
       - SchedulerCluster
-  /scheduler-clusters/{id}:
+  /api/v1/scheduler-clusters/{id}:
     delete:
       consumes:
       - application/json
@@ -2561,7 +2460,7 @@ paths:
       summary: Update SchedulerCluster
       tags:
       - SchedulerCluster
-  /scheduler-clusters/{id}/schedulers/{scheduler_id}:
+  /api/v1/scheduler-clusters/{id}/schedulers/{scheduler_id}:
     put:
       consumes:
       - application/json
@@ -2591,7 +2490,7 @@ paths:
       summary: Add Scheduler to schedulerCluster
       tags:
       - SchedulerCluster
-  /scheduler-features:
+  /api/v1/scheduler-features:
     get:
       consumes:
       - application/json
@@ -2614,7 +2513,7 @@ paths:
       summary: Get Scheudler Features
       tags:
       - Scheduler Feature
-  /schedulers:
+  /api/v1/schedulers:
     get:
       consumes:
       - application/json
@@ -2679,7 +2578,7 @@ paths:
       summary: Create Scheduler
       tags:
       - Scheduler
-  /schedulers/{id}:
+  /api/v1/schedulers/{id}:
     delete:
       consumes:
       - application/json
@@ -2762,7 +2661,7 @@ paths:
       summary: Update Scheduler
       tags:
       - Scheduler
-  /seed-peer-clusters:
+  /api/v1/seed-peer-clusters:
     get:
       consumes:
       - application/json
@@ -2827,7 +2726,7 @@ paths:
       summary: Create SeedPeerCluster
       tags:
       - SeedPeerCluster
-  /seed-peer-clusters/{id}:
+  /api/v1/seed-peer-clusters/{id}:
     delete:
       consumes:
       - application/json
@@ -2910,7 +2809,7 @@ paths:
       summary: Update SeedPeerCluster
       tags:
       - SeedPeerCluster
-  /seed-peer-clusters/{id}/scheduler-clusters/{scheduler_cluster_id}:
+  /api/v1/seed-peer-clusters/{id}/scheduler-clusters/{scheduler_cluster_id}:
     put:
       consumes:
       - application/json
@@ -2940,7 +2839,7 @@ paths:
       summary: Add SchedulerCluster to SeedPeerCluster
       tags:
       - SeedPeerCluster
-  /seed-peer-clusters/{id}/seed-peers/{seed_peer_id}:
+  /api/v1/seed-peer-clusters/{id}/seed-peers/{seed_peer_id}:
     put:
       consumes:
       - application/json
@@ -2970,7 +2869,7 @@ paths:
       summary: Add Instance to SeedPeerCluster
       tags:
       - SeedPeerCluster
-  /seed-peers:
+  /api/v1/seed-peers:
     get:
       consumes:
       - application/json
@@ -3035,7 +2934,7 @@ paths:
       summary: Create SeedPeer
       tags:
       - SeedPeer
-  /seed-peers/{id}:
+  /api/v1/seed-peers/{id}:
     delete:
       consumes:
       - application/json
@@ -3118,7 +3017,7 @@ paths:
       summary: Update SeedPeer
       tags:
       - SeedPeer
-  /user/signin/{name}:
+  /api/v1/user/signin/{name}:
     get:
       consumes:
       - application/json
@@ -3143,7 +3042,7 @@ paths:
       summary: Oauth Signin
       tags:
       - User
-  /user/signin/{name}/callback:
+  /api/v1/user/signin/{name}/callback:
     get:
       description: oauth signin callback by json config
       parameters:
@@ -3169,7 +3068,7 @@ paths:
       summary: Oauth Signin Callback
       tags:
       - Oauth
-  /user/signup:
+  /api/v1/user/signup:
     post:
       consumes:
       - application/json
@@ -3195,7 +3094,7 @@ paths:
       summary: SignUp user
       tags:
       - User
-  /users:
+  /api/v1/users:
     get:
       consumes:
       - application/json
@@ -3233,7 +3132,7 @@ paths:
       summary: Get Users
       tags:
       - User
-  /users/{id}:
+  /api/v1/users/{id}:
     get:
       consumes:
       - application/json
@@ -3292,7 +3191,7 @@ paths:
       summary: Update User
       tags:
       - User
-  /users/{id}/reset_password:
+  /api/v1/users/{id}/reset_password:
     post:
       consumes:
       - application/json
@@ -3321,7 +3220,7 @@ paths:
       summary: Reset Password For User
       tags:
       - User
-  /users/{id}/roles:
+  /api/v1/users/{id}/roles:
     get:
       description: get roles by json config
       parameters:
@@ -3346,7 +3245,7 @@ paths:
       summary: Get User Roles
       tags:
       - User
-  /users/{id}/roles/{role}:
+  /api/v1/users/{id}/roles/{role}:
     delete:
       consumes:
       - application/json
@@ -3401,4 +3300,379 @@ paths:
       summary: Add Role For User
       tags:
       - Users
+  /healthy:
+    get:
+      consumes:
+      - application/json
+      description: Get app health
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad Request
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      summary: Get Health
+      tags:
+      - Health
+  /oapi/v1/clusters:
+    get:
+      consumes:
+      - application/json
+      description: Get Clusters
+      parameters:
+      - default: 0
+        description: current page
+        in: query
+        name: page
+        required: true
+        type: integer
+      - default: 10
+        description: return max item count, default 10, max 50
+        in: query
+        maximum: 50
+        minimum: 2
+        name: per_page
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/d7y_io_dragonfly_v2_manager_types.GetClusterResponse'
+            type: array
+        "400":
+          description: Bad Request
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      summary: Get Clusters
+      tags:
+      - Cluster
+    post:
+      consumes:
+      - application/json
+      description: Create by json config
+      parameters:
+      - description: Cluster
+        in: body
+        name: Cluster
+        required: true
+        schema:
+          $ref: '#/definitions/d7y_io_dragonfly_v2_manager_types.CreateClusterRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/d7y_io_dragonfly_v2_manager_types.CreateClusterResponse'
+        "400":
+          description: Bad Request
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      summary: Create Cluster
+      tags:
+      - Cluster
+  /oapi/v1/clusters/{id}:
+    delete:
+      consumes:
+      - application/json
+      description: Destroy by id
+      parameters:
+      - description: id
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad Request
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      summary: Destroy Cluster
+      tags:
+      - Cluster
+    get:
+      consumes:
+      - application/json
+      description: Get Cluster by id
+      parameters:
+      - description: id
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/d7y_io_dragonfly_v2_manager_types.GetClusterResponse'
+        "400":
+          description: Bad Request
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      summary: Get Cluster
+      tags:
+      - Cluster
+    patch:
+      consumes:
+      - application/json
+      description: Update by json config
+      parameters:
+      - description: id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Cluster
+        in: body
+        name: Cluster
+        required: true
+        schema:
+          $ref: '#/definitions/d7y_io_dragonfly_v2_manager_types.UpdateClusterRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/d7y_io_dragonfly_v2_manager_types.UpdateClusterResponse'
+        "400":
+          description: Bad Request
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      summary: Update Cluster
+      tags:
+      - Cluster
+  /oapi/v1/jobs:
+    get:
+      consumes:
+      - application/json
+      description: Get Jobs
+      parameters:
+      - default: 0
+        description: current page
+        in: query
+        name: page
+        required: true
+        type: integer
+      - default: 10
+        description: return max item count, default 10, max 50
+        in: query
+        maximum: 50
+        minimum: 2
+        name: per_page
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/d7y_io_dragonfly_v2_manager_models.Job'
+            type: array
+        "400":
+          description: Bad Request
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      summary: Get Jobs
+      tags:
+      - Job
+    post:
+      consumes:
+      - application/json
+      description: Create by json config
+      parameters:
+      - description: Job
+        in: body
+        name: Job
+        required: true
+        schema:
+          $ref: '#/definitions/d7y_io_dragonfly_v2_manager_types.CreateJobRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/d7y_io_dragonfly_v2_manager_models.Job'
+        "400":
+          description: Bad Request
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      summary: Create Job
+      tags:
+      - Job
+  /oapi/v1/jobs/{id}:
+    delete:
+      consumes:
+      - application/json
+      description: Destroy by id
+      parameters:
+      - description: id
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad Request
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      summary: Destroy Job
+      tags:
+      - Job
+    get:
+      consumes:
+      - application/json
+      description: Get Job by id
+      parameters:
+      - description: id
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/d7y_io_dragonfly_v2_manager_models.Job'
+        "400":
+          description: Bad Request
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      summary: Get Job
+      tags:
+      - Job
+    patch:
+      consumes:
+      - application/json
+      description: Update by json config
+      parameters:
+      - description: id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Job
+        in: body
+        name: Job
+        required: true
+        schema:
+          $ref: '#/definitions/d7y_io_dragonfly_v2_manager_types.UpdateJobRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/d7y_io_dragonfly_v2_manager_models.Job'
+        "400":
+          description: Bad Request
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      summary: Update Job
+      tags:
+      - Job
+  /preheats:
+    post:
+      consumes:
+      - application/json
+      description: Create by json config
+      parameters:
+      - description: Preheat
+        in: body
+        name: Preheat
+        required: true
+        schema:
+          $ref: '#/definitions/d7y_io_dragonfly_v2_manager_types.CreateV1PreheatRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/d7y_io_dragonfly_v2_manager_types.CreateV1PreheatResponse'
+        "400":
+          description: Bad Request
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      summary: Create V1 Preheat
+      tags:
+      - Preheat
+  /preheats/{id}:
+    get:
+      consumes:
+      - application/json
+      description: Get Preheat by id
+      parameters:
+      - description: id
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/d7y_io_dragonfly_v2_manager_types.GetV1PreheatResponse'
+        "400":
+          description: Bad Request
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      summary: Get V1 Preheat
+      tags:
+      - Preheat
 swagger: "2.0"
+tags:
+- description: API router (/api/v1)
+  name: api
+- description: open API router (/oapi/v1)
+  name: oapi

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -27,7 +27,11 @@ import (
 // @contact.url https://d7y.io
 // @license.name Apache 2.0
 // @host localhost:8080
-// @BasePath /api/v1
+// @BasePath /
+// @tag.name api
+// @tag.description API router (/api/v1)
+// @tag.name oapi
+// @tag.description open API router (/oapi/v1)
 func main() {
 	cmd.Execute()
 }

--- a/manager/handlers/application.go
+++ b/manager/handlers/application.go
@@ -36,7 +36,7 @@ import (
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /applications [post]
+// @Router /api/v1/applications [post]
 func (h *Handlers) CreateApplication(ctx *gin.Context) {
 	var json types.CreateApplicationRequest
 	if err := ctx.ShouldBindJSON(&json); err != nil {
@@ -63,7 +63,7 @@ func (h *Handlers) CreateApplication(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /applications/{id} [delete]
+// @Router /api/v1/applications/{id} [delete]
 func (h *Handlers) DestroyApplication(ctx *gin.Context) {
 	var params types.ApplicationParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -90,7 +90,7 @@ func (h *Handlers) DestroyApplication(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /applications/{id} [patch]
+// @Router /api/v1/applications/{id} [patch]
 func (h *Handlers) UpdateApplication(ctx *gin.Context) {
 	var params types.ApplicationParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -123,7 +123,7 @@ func (h *Handlers) UpdateApplication(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /applications/{id} [get]
+// @Router /api/v1/applications/{id} [get]
 func (h *Handlers) GetApplication(ctx *gin.Context) {
 	var params types.ApplicationParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -151,7 +151,7 @@ func (h *Handlers) GetApplication(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /applications [get]
+// @Router /api/v1/applications [get]
 func (h *Handlers) GetApplications(ctx *gin.Context) {
 	var query types.GetApplicationsQuery
 	if err := ctx.ShouldBindQuery(&query); err != nil {

--- a/manager/handlers/bucket.go
+++ b/manager/handlers/bucket.go
@@ -39,7 +39,7 @@ import (
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /buckets [post]
+// @Router /api/v1/buckets [post]
 func (h *Handlers) CreateBucket(ctx *gin.Context) {
 	var json types.CreateBucketRequest
 	if err := ctx.ShouldBindJSON(&json); err != nil {
@@ -65,7 +65,7 @@ func (h *Handlers) CreateBucket(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /buckets/{id} [delete]
+// @Router /api/v1/buckets/{id} [delete]
 func (h *Handlers) DestroyBucket(ctx *gin.Context) {
 	var params types.BucketParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -91,7 +91,7 @@ func (h *Handlers) DestroyBucket(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /buckets/{id} [get]
+// @Router /api/v1/buckets/{id} [get]
 func (h *Handlers) GetBucket(ctx *gin.Context) {
 	var params types.BucketParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -117,7 +117,7 @@ func (h *Handlers) GetBucket(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /buckets [get]
+// @Router /api/v1/buckets [get]
 func (h *Handlers) GetBuckets(ctx *gin.Context) {
 	buckets, err := h.service.GetBuckets(ctx.Request.Context())
 	if err != nil {

--- a/manager/handlers/cluster.go
+++ b/manager/handlers/cluster.go
@@ -36,7 +36,8 @@ import (
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /clusters [post]
+// @Router /api/v1/clusters [post]
+// @Router /oapi/v1/clusters [post]
 func (h *Handlers) CreateCluster(ctx *gin.Context) {
 	var json types.CreateClusterRequest
 	if err := ctx.ShouldBindJSON(&json); err != nil {
@@ -63,7 +64,8 @@ func (h *Handlers) CreateCluster(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /clusters/{id} [delete]
+// @Router /api/v1/clusters/{id} [delete]
+// @Router /oapi/v1/clusters/{id} [delete]
 func (h *Handlers) DestroyCluster(ctx *gin.Context) {
 	var params types.ClusterParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -90,7 +92,8 @@ func (h *Handlers) DestroyCluster(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /clusters/{id} [patch]
+// @Router /api/v1/clusters/{id} [patch]
+// @Router /oapi/v1/clusters/{id} [patch]
 func (h *Handlers) UpdateCluster(ctx *gin.Context) {
 	var params types.ClusterParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -123,7 +126,8 @@ func (h *Handlers) UpdateCluster(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /clusters/{id} [get]
+// @Router /api/v1/clusters/{id} [get]
+// @Router /oapi/v1/clusters/{id} [get]
 func (h *Handlers) GetCluster(ctx *gin.Context) {
 	var params types.ClusterParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -151,7 +155,8 @@ func (h *Handlers) GetCluster(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /clusters [get]
+// @Router /api/v1/clusters [get]
+// @Router /oapi/v1/clusters [get]
 func (h *Handlers) GetClusters(ctx *gin.Context) {
 	var query types.GetClustersQuery
 	if err := ctx.ShouldBindQuery(&query); err != nil {

--- a/manager/handlers/config.go
+++ b/manager/handlers/config.go
@@ -36,7 +36,7 @@ import (
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /configs [post]
+// @Router /api/v1/configs [post]
 func (h *Handlers) CreateConfig(ctx *gin.Context) {
 	var json types.CreateConfigRequest
 	if err := ctx.ShouldBindJSON(&json); err != nil {
@@ -63,7 +63,7 @@ func (h *Handlers) CreateConfig(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /configs/{id} [delete]
+// @Router /api/v1/configs/{id} [delete]
 func (h *Handlers) DestroyConfig(ctx *gin.Context) {
 	var params types.ConfigParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -90,7 +90,7 @@ func (h *Handlers) DestroyConfig(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /configs/{id} [patch]
+// @Router /api/v1/configs/{id} [patch]
 func (h *Handlers) UpdateConfig(ctx *gin.Context) {
 	var params types.ConfigParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -123,7 +123,7 @@ func (h *Handlers) UpdateConfig(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /configs/{id} [get]
+// @Router /api/v1/configs/{id} [get]
 func (h *Handlers) GetConfig(ctx *gin.Context) {
 	var params types.ConfigParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -151,7 +151,7 @@ func (h *Handlers) GetConfig(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /configs [get]
+// @Router /api/v1/configs [get]
 func (h *Handlers) GetConfigs(ctx *gin.Context) {
 	var query types.GetConfigsQuery
 	if err := ctx.ShouldBindQuery(&query); err != nil {

--- a/manager/handlers/job.go
+++ b/manager/handlers/job.go
@@ -38,7 +38,7 @@ import (
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /jobs [post]
+// @Router /oapi/v1/jobs [post]
 func (h *Handlers) CreateJob(ctx *gin.Context) {
 	var json types.CreateJobRequest
 	if err := ctx.ShouldBindBodyWith(&json, binding.JSON); err != nil {
@@ -132,7 +132,8 @@ func (h *Handlers) CreateJob(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /jobs/{id} [delete]
+// @Router /api/v1/jobs/{id} [delete]
+// @Router /oapi/v1/jobs/{id} [delete]
 func (h *Handlers) DestroyJob(ctx *gin.Context) {
 	var params types.JobParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -159,7 +160,8 @@ func (h *Handlers) DestroyJob(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /jobs/{id} [patch]
+// @Router /api/v1/jobs/{id} [patch]
+// @Router /oapi/v1/jobs/{id} [patch]
 func (h *Handlers) UpdateJob(ctx *gin.Context) {
 	var params types.JobParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -192,7 +194,8 @@ func (h *Handlers) UpdateJob(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /jobs/{id} [get]
+// @Router /api/v1/jobs/{id} [get]
+// @Router /oapi/v1/jobs/{id} [get]
 func (h *Handlers) GetJob(ctx *gin.Context) {
 	var params types.JobParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -220,7 +223,8 @@ func (h *Handlers) GetJob(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /jobs [get]
+// @Router /api/v1/jobs [get]
+// @Router /oapi/v1/jobs [get]
 func (h *Handlers) GetJobs(ctx *gin.Context) {
 	var query types.GetJobsQuery
 	if err := ctx.ShouldBindQuery(&query); err != nil {

--- a/manager/handlers/oauth.go
+++ b/manager/handlers/oauth.go
@@ -36,7 +36,7 @@ import (
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /oauth [post]
+// @Router /api/v1/oauth [post]
 func (h *Handlers) CreateOauth(ctx *gin.Context) {
 	var json types.CreateOauthRequest
 	if err := ctx.ShouldBindJSON(&json); err != nil {
@@ -63,7 +63,7 @@ func (h *Handlers) CreateOauth(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /oauth/{id} [delete]
+// @Router /api/v1/oauth/{id} [delete]
 func (h *Handlers) DestroyOauth(ctx *gin.Context) {
 	var params types.OauthParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -90,7 +90,7 @@ func (h *Handlers) DestroyOauth(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /oauth/{id} [patch]
+// @Router /api/v1/oauth/{id} [patch]
 func (h *Handlers) UpdateOauth(ctx *gin.Context) {
 	var params types.OauthParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -123,7 +123,7 @@ func (h *Handlers) UpdateOauth(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /oauth/{id} [get]
+// @Router /api/v1/oauth/{id} [get]
 func (h *Handlers) GetOauth(ctx *gin.Context) {
 	var params types.OauthParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -151,7 +151,7 @@ func (h *Handlers) GetOauth(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /oauth [get]
+// @Router /api/v1/oauth [get]
 func (h *Handlers) GetOauths(ctx *gin.Context) {
 	var query types.GetOauthsQuery
 	if err := ctx.ShouldBindQuery(&query); err != nil {

--- a/manager/handlers/peer.go
+++ b/manager/handlers/peer.go
@@ -36,7 +36,7 @@ import (
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /peers [post]
+// @Router /api/v1/peers [post]
 func (h *Handlers) CreatePeer(ctx *gin.Context) {
 	var json types.CreatePeerRequest
 	if err := ctx.ShouldBindJSON(&json); err != nil {
@@ -63,7 +63,7 @@ func (h *Handlers) CreatePeer(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /peers/{id} [delete]
+// @Router /api/v1/peers/{id} [delete]
 func (h *Handlers) DestroyPeer(ctx *gin.Context) {
 	var params types.PeerParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -89,7 +89,7 @@ func (h *Handlers) DestroyPeer(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /peers/{id} [get]
+// @Router /api/v1/peers/{id} [get]
 func (h *Handlers) GetPeer(ctx *gin.Context) {
 	var params types.PeerParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -117,7 +117,7 @@ func (h *Handlers) GetPeer(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /peers [get]
+// @Router /api/v1/peers [get]
 func (h *Handlers) GetPeers(ctx *gin.Context) {
 	var query types.GetPeersQuery
 	if err := ctx.ShouldBindQuery(&query); err != nil {

--- a/manager/handlers/permission.go
+++ b/manager/handlers/permission.go
@@ -32,7 +32,7 @@ import (
 // @Success 200 {object} []rbac.Permission
 // @Failure 400
 // @Failure 500
-// @Router /permissions [get]
+// @Router /api/v1/permissions [get]
 func (h *Handlers) GetPermissions(g *gin.Engine) func(ctx *gin.Context) {
 	return func(ctx *gin.Context) {
 		ctx.JSON(http.StatusOK, h.service.GetPermissions(ctx.Request.Context(), g))

--- a/manager/handlers/personal_access_token.go
+++ b/manager/handlers/personal_access_token.go
@@ -36,7 +36,7 @@ import (
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /personal-access-tokens [post]
+// @Router /api/v1/personal-access-tokens [post]
 func (h *Handlers) CreatePersonalAccessToken(ctx *gin.Context) {
 	var json types.CreatePersonalAccessTokenRequest
 	if err := ctx.ShouldBindJSON(&json); err != nil {
@@ -63,7 +63,7 @@ func (h *Handlers) CreatePersonalAccessToken(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /personal-access-tokens/{id} [delete]
+// @Router /api/v1/personal-access-tokens/{id} [delete]
 func (h *Handlers) DestroyPersonalAccessToken(ctx *gin.Context) {
 	var params types.PersonalAccessTokenParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -90,7 +90,7 @@ func (h *Handlers) DestroyPersonalAccessToken(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /personal-access-tokens/{id} [patch]
+// @Router /api/v1/personal-access-tokens/{id} [patch]
 func (h *Handlers) UpdatePersonalAccessToken(ctx *gin.Context) {
 	var params types.PersonalAccessTokenParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -123,7 +123,7 @@ func (h *Handlers) UpdatePersonalAccessToken(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /personal-access-tokens/{id} [get]
+// @Router /api/v1/personal-access-tokens/{id} [get]
 func (h *Handlers) GetPersonalAccessToken(ctx *gin.Context) {
 	var params types.PersonalAccessTokenParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -151,7 +151,7 @@ func (h *Handlers) GetPersonalAccessToken(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /personal-access-tokens [get]
+// @Router /api/v1/personal-access-tokens [get]
 func (h *Handlers) GetPersonalAccessTokens(ctx *gin.Context) {
 	var query types.GetPersonalAccessTokensQuery
 	if err := ctx.ShouldBindQuery(&query); err != nil {

--- a/manager/handlers/role.go
+++ b/manager/handlers/role.go
@@ -35,7 +35,7 @@ import (
 // @Success 200
 // @Failure 400
 // @Failure 500
-// @Router /roles [post]
+// @Router /api/v1/roles [post]
 func (h *Handlers) CreateRole(ctx *gin.Context) {
 	var json types.CreateRoleRequest
 	if err := ctx.ShouldBindJSON(&json); err != nil {
@@ -60,7 +60,7 @@ func (h *Handlers) CreateRole(ctx *gin.Context) {
 // @Success 200
 // @Failure 400
 // @Failure 500
-// @Router /roles/{role} [delete]
+// @Router /api/v1/roles/{role} [delete]
 func (h *Handlers) DestroyRole(ctx *gin.Context) {
 	var params types.RoleParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -88,7 +88,7 @@ func (h *Handlers) DestroyRole(ctx *gin.Context) {
 // @Success 200
 // @Failure 400
 // @Failure 500
-// @Router /roles/{role} [get]
+// @Router /api/v1/roles/{role} [get]
 func (h *Handlers) GetRole(ctx *gin.Context) {
 	var params types.RoleParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -107,7 +107,7 @@ func (h *Handlers) GetRole(ctx *gin.Context) {
 // @Success 200
 // @Failure 400
 // @Failure 500
-// @Router /roles [get]
+// @Router /api/v1/roles [get]
 func (h *Handlers) GetRoles(ctx *gin.Context) {
 	roles := h.service.GetRoles(ctx.Request.Context())
 	ctx.JSON(http.StatusOK, roles)
@@ -123,7 +123,7 @@ func (h *Handlers) GetRoles(ctx *gin.Context) {
 // @Success 200
 // @Failure 400
 // @Failure 500
-// @Router /roles/{role}/permissions [post]
+// @Router /api/v1/roles/{role}/permissions [post]
 func (h *Handlers) AddPermissionForRole(ctx *gin.Context) {
 	var params types.RoleParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -158,7 +158,7 @@ func (h *Handlers) AddPermissionForRole(ctx *gin.Context) {
 // @Success 200
 // @Failure 400
 // @Failure 500
-// @Router /roles/{role}/permissions [delete]
+// @Router /api/v1/roles/{role}/permissions [delete]
 func (h *Handlers) DeletePermissionForRole(ctx *gin.Context) {
 	var params types.RoleParams
 	if err := ctx.ShouldBindUri(&params); err != nil {

--- a/manager/handlers/scheduler.go
+++ b/manager/handlers/scheduler.go
@@ -36,7 +36,7 @@ import (
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /schedulers [post]
+// @Router /api/v1/schedulers [post]
 func (h *Handlers) CreateScheduler(ctx *gin.Context) {
 	var json types.CreateSchedulerRequest
 	if err := ctx.ShouldBindJSON(&json); err != nil {
@@ -63,7 +63,7 @@ func (h *Handlers) CreateScheduler(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /schedulers/{id} [delete]
+// @Router /api/v1/schedulers/{id} [delete]
 func (h *Handlers) DestroyScheduler(ctx *gin.Context) {
 	var params types.SchedulerParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -90,7 +90,7 @@ func (h *Handlers) DestroyScheduler(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /schedulers/{id} [patch]
+// @Router /api/v1/schedulers/{id} [patch]
 func (h *Handlers) UpdateScheduler(ctx *gin.Context) {
 	var params types.SchedulerParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -123,7 +123,7 @@ func (h *Handlers) UpdateScheduler(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /schedulers/{id} [get]
+// @Router /api/v1/schedulers/{id} [get]
 func (h *Handlers) GetScheduler(ctx *gin.Context) {
 	var params types.SchedulerParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -151,7 +151,7 @@ func (h *Handlers) GetScheduler(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /schedulers [get]
+// @Router /api/v1/schedulers [get]
 func (h *Handlers) GetSchedulers(ctx *gin.Context) {
 	var query types.GetSchedulersQuery
 	if err := ctx.ShouldBindQuery(&query); err != nil {

--- a/manager/handlers/scheduler_cluster.go
+++ b/manager/handlers/scheduler_cluster.go
@@ -36,7 +36,7 @@ import (
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /scheduler-clusters [post]
+// @Router /api/v1/scheduler-clusters [post]
 func (h *Handlers) CreateSchedulerCluster(ctx *gin.Context) {
 	var json types.CreateSchedulerClusterRequest
 	if err := ctx.ShouldBindJSON(&json); err != nil {
@@ -63,7 +63,7 @@ func (h *Handlers) CreateSchedulerCluster(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /scheduler-clusters/{id} [delete]
+// @Router /api/v1/scheduler-clusters/{id} [delete]
 func (h *Handlers) DestroySchedulerCluster(ctx *gin.Context) {
 	var params types.SchedulerClusterParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -90,7 +90,7 @@ func (h *Handlers) DestroySchedulerCluster(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /scheduler-clusters/{id} [patch]
+// @Router /api/v1/scheduler-clusters/{id} [patch]
 func (h *Handlers) UpdateSchedulerCluster(ctx *gin.Context) {
 	var params types.SchedulerClusterParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -123,7 +123,7 @@ func (h *Handlers) UpdateSchedulerCluster(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /scheduler-clusters/{id} [get]
+// @Router /api/v1/scheduler-clusters/{id} [get]
 func (h *Handlers) GetSchedulerCluster(ctx *gin.Context) {
 	var params types.SchedulerClusterParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -151,7 +151,7 @@ func (h *Handlers) GetSchedulerCluster(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /scheduler-clusters [get]
+// @Router /api/v1/scheduler-clusters [get]
 func (h *Handlers) GetSchedulerClusters(ctx *gin.Context) {
 	var query types.GetSchedulerClustersQuery
 	if err := ctx.ShouldBindQuery(&query); err != nil {
@@ -181,7 +181,7 @@ func (h *Handlers) GetSchedulerClusters(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /scheduler-clusters/{id}/schedulers/{scheduler_id} [put]
+// @Router /api/v1/scheduler-clusters/{id}/schedulers/{scheduler_id} [put]
 func (h *Handlers) AddSchedulerToSchedulerCluster(ctx *gin.Context) {
 	var params types.AddSchedulerToSchedulerClusterParams
 	if err := ctx.ShouldBindUri(&params); err != nil {

--- a/manager/handlers/scheduler_feature.go
+++ b/manager/handlers/scheduler_feature.go
@@ -34,7 +34,7 @@ import (
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /scheduler-features [get]
+// @Router /api/v1/scheduler-features [get]
 func (h *Handlers) GetSchedulerFeatures(ctx *gin.Context) {
 	features := h.service.GetSchedulerFeatures(ctx.Request.Context())
 	ctx.JSON(http.StatusOK, features)

--- a/manager/handlers/seed_peer.go
+++ b/manager/handlers/seed_peer.go
@@ -36,7 +36,7 @@ import (
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /seed-peers [post]
+// @Router /api/v1/seed-peers [post]
 func (h *Handlers) CreateSeedPeer(ctx *gin.Context) {
 	var json types.CreateSeedPeerRequest
 	if err := ctx.ShouldBindJSON(&json); err != nil {
@@ -63,7 +63,7 @@ func (h *Handlers) CreateSeedPeer(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /seed-peers/{id} [delete]
+// @Router /api/v1/seed-peers/{id} [delete]
 func (h *Handlers) DestroySeedPeer(ctx *gin.Context) {
 	var params types.SeedPeerParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -90,7 +90,7 @@ func (h *Handlers) DestroySeedPeer(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /seed-peers/{id} [patch]
+// @Router /api/v1/seed-peers/{id} [patch]
 func (h *Handlers) UpdateSeedPeer(ctx *gin.Context) {
 	var params types.SeedPeerParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -123,7 +123,7 @@ func (h *Handlers) UpdateSeedPeer(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /seed-peers/{id} [get]
+// @Router /api/v1/seed-peers/{id} [get]
 func (h *Handlers) GetSeedPeer(ctx *gin.Context) {
 	var params types.SeedPeerParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -151,7 +151,7 @@ func (h *Handlers) GetSeedPeer(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /seed-peers [get]
+// @Router /api/v1/seed-peers [get]
 func (h *Handlers) GetSeedPeers(ctx *gin.Context) {
 	var query types.GetSeedPeersQuery
 	if err := ctx.ShouldBindQuery(&query); err != nil {

--- a/manager/handlers/seed_peer_cluster.go
+++ b/manager/handlers/seed_peer_cluster.go
@@ -36,7 +36,7 @@ import (
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /seed-peer-clusters [post]
+// @Router /api/v1/seed-peer-clusters [post]
 func (h *Handlers) CreateSeedPeerCluster(ctx *gin.Context) {
 	var json types.CreateSeedPeerClusterRequest
 	if err := ctx.ShouldBindJSON(&json); err != nil {
@@ -63,7 +63,7 @@ func (h *Handlers) CreateSeedPeerCluster(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /seed-peer-clusters/{id} [delete]
+// @Router /api/v1/seed-peer-clusters/{id} [delete]
 func (h *Handlers) DestroySeedPeerCluster(ctx *gin.Context) {
 	var params types.SeedPeerClusterParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -90,7 +90,7 @@ func (h *Handlers) DestroySeedPeerCluster(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /seed-peer-clusters/{id} [patch]
+// @Router /api/v1/seed-peer-clusters/{id} [patch]
 func (h *Handlers) UpdateSeedPeerCluster(ctx *gin.Context) {
 	var params types.SeedPeerClusterParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -123,7 +123,7 @@ func (h *Handlers) UpdateSeedPeerCluster(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /seed-peer-clusters/{id} [get]
+// @Router /api/v1/seed-peer-clusters/{id} [get]
 func (h *Handlers) GetSeedPeerCluster(ctx *gin.Context) {
 	var params types.SeedPeerClusterParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -151,7 +151,7 @@ func (h *Handlers) GetSeedPeerCluster(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /seed-peer-clusters [get]
+// @Router /api/v1/seed-peer-clusters [get]
 func (h *Handlers) GetSeedPeerClusters(ctx *gin.Context) {
 	var query types.GetSeedPeerClustersQuery
 	if err := ctx.ShouldBindQuery(&query); err != nil {
@@ -181,7 +181,7 @@ func (h *Handlers) GetSeedPeerClusters(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /seed-peer-clusters/{id}/seed-peers/{seed_peer_id} [put]
+// @Router /api/v1/seed-peer-clusters/{id}/seed-peers/{seed_peer_id} [put]
 func (h *Handlers) AddSeedPeerToSeedPeerCluster(ctx *gin.Context) {
 	var params types.AddSeedPeerToSeedPeerClusterParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -208,7 +208,7 @@ func (h *Handlers) AddSeedPeerToSeedPeerCluster(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /seed-peer-clusters/{id}/scheduler-clusters/{scheduler_cluster_id} [put]
+// @Router /api/v1/seed-peer-clusters/{id}/scheduler-clusters/{scheduler_cluster_id} [put]
 func (h *Handlers) AddSchedulerClusterToSeedPeerCluster(ctx *gin.Context) {
 	var params types.AddSchedulerClusterToSeedPeerClusterParams
 	if err := ctx.ShouldBindUri(&params); err != nil {

--- a/manager/handlers/user.go
+++ b/manager/handlers/user.go
@@ -38,7 +38,7 @@ import (
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /users/{id} [patch]
+// @Router /api/v1/users/{id} [patch]
 func (h *Handlers) UpdateUser(ctx *gin.Context) {
 	var params types.UserParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -71,7 +71,7 @@ func (h *Handlers) UpdateUser(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /users/{id} [get]
+// @Router /api/v1/users/{id} [get]
 func (h *Handlers) GetUser(ctx *gin.Context) {
 	var params types.UserParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -99,7 +99,7 @@ func (h *Handlers) GetUser(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /users [get]
+// @Router /api/v1/users [get]
 func (h *Handlers) GetUsers(ctx *gin.Context) {
 	var query types.GetUsersQuery
 	if err := ctx.ShouldBindQuery(&query); err != nil {
@@ -127,7 +127,7 @@ func (h *Handlers) GetUsers(ctx *gin.Context) {
 // @Success 200 {object} models.User
 // @Failure 400
 // @Failure 500
-// @Router /user/signup [post]
+// @Router /api/v1/user/signup [post]
 func (h *Handlers) SignUp(ctx *gin.Context) {
 	var json types.SignUpRequest
 	if err := ctx.ShouldBindJSON(&json); err != nil {
@@ -154,7 +154,7 @@ func (h *Handlers) SignUp(ctx *gin.Context) {
 // @Success 200
 // @Failure 400
 // @Failure 500
-// @Router /users/{id}/reset_password [post]
+// @Router /api/v1/users/{id}/reset_password [post]
 func (h *Handlers) ResetPassword(ctx *gin.Context) {
 	var params types.UserParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -186,7 +186,7 @@ func (h *Handlers) ResetPassword(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /user/signin/{name} [get]
+// @Router /api/v1/user/signin/{name} [get]
 func (h *Handlers) OauthSignin(ctx *gin.Context) {
 	var params types.OauthSigninParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -212,7 +212,7 @@ func (h *Handlers) OauthSignin(ctx *gin.Context) {
 // @Failure 400
 // @Failure 404
 // @Failure 500
-// @Router /user/signin/{name}/callback [get]
+// @Router /api/v1/user/signin/{name}/callback [get]
 func (h *Handlers) OauthSigninCallback(j *jwt.GinJWTMiddleware) func(*gin.Context) {
 	return func(ctx *gin.Context) {
 		var params types.OauthSigninCallbackParams
@@ -246,7 +246,7 @@ func (h *Handlers) OauthSigninCallback(j *jwt.GinJWTMiddleware) func(*gin.Contex
 // @Success 200 {object} []string
 // @Failure 400
 // @Failure 500
-// @Router /users/{id}/roles [get]
+// @Router /api/v1/users/{id}/roles [get]
 func (h *Handlers) GetRolesForUser(ctx *gin.Context) {
 	var params types.UserParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -273,7 +273,7 @@ func (h *Handlers) GetRolesForUser(ctx *gin.Context) {
 // @Success 200
 // @Failure 400
 // @Failure 500
-// @Router /users/{id}/roles/{role} [put]
+// @Router /api/v1/users/{id}/roles/{role} [put]
 func (h *Handlers) AddRoleToUser(ctx *gin.Context) {
 	var params types.AddRoleForUserParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
@@ -302,7 +302,7 @@ func (h *Handlers) AddRoleToUser(ctx *gin.Context) {
 // @Success 200
 // @Failure 400
 // @Failure 500
-// @Router /users/{id}/roles/{role} [delete]
+// @Router /api/v1/users/{id}/roles/{role} [delete]
 func (h *Handlers) DeleteRoleForUser(ctx *gin.Context) {
 	var params types.DeleteRoleForUserParams
 	if err := ctx.ShouldBindUri(&params); err != nil {


### PR DESCRIPTION
Update swagger annotations to support multiple API route groups.

## Description

This PR fixes an issue in Swagger documentation generation where the Swagger annotation incorrectly defined the BasePath as `/api/v1`, while in reality the Dragonfly Manager service provides two sets of API routes: `/api/v1` and `/oapi/v1`.

Specifically, the changes include:

1. Changed the `@BasePath` in `cmd/manager/main.go` from `/api/v1` to `/`
2. Added `@tag.name` and `@tag.description` annotations to describe the two API route groups
3. Modified the `@Router` annotations in handler files to use absolute paths instead of relative paths
4. Added dual route path annotations for handlers used in both `/api/v1` and `/oapi/v1` route groups (such as job and cluster handlers)

## Related Issue

close https://github.com/dragonflyoss/dragonfly/issues/3884

## Motivation and Context

The previous Swagger configuration only reflected APIs under the `/api/v1` route, causing APIs under the `/oapi/v1` route to be either invisible or incorrectly pathed in the Swagger documentation. This change ensures that the Swagger documentation properly displays all API endpoints of the Dragonfly Manager.

This is important for API users and developers as they need complete and accurate API documentation to use Dragonfly's APIs correctly. This change improves the completeness and accuracy of the documentation, making it easier for API consumers to understand and utilize all available functionality in Dragonfly.

## Screenshots

Before:
![af359355f4d28f27d015ee8d9be2b700](https://github.com/user-attachments/assets/7193d263-34f2-4f6d-a436-31f948360a22)

After:
<img width="194" alt="image" src="https://github.com/user-attachments/assets/d60e3620-8482-4881-87d6-c789e3f2753a" />

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.