### PR TITLE
feat: enhance PAT validation in middleware

### DIFF
--- a/manager/middlewares/personal_access_token.go
+++ b/manager/middlewares/personal_access_token.go
@@ -17,14 +17,23 @@
 package middlewares
 
 import (
+	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-http-utils/headers"
 	"gorm.io/gorm"
 
+	logger "d7y.io/dragonfly/v2/internal/dflog"
 	"d7y.io/dragonfly/v2/manager/models"
+	"d7y.io/dragonfly/v2/manager/types"
+)
+
+var (
+	oapiResourceRegexp = regexp.MustCompile(`^/oapi/v[0-9]+/([-_a-zA-Z]*)[/.*]*`)
 )
 
 func PersonalAccessToken(gdb *gorm.DB) gin.HandlerFunc {
@@ -42,7 +51,9 @@ func PersonalAccessToken(gdb *gorm.DB) gin.HandlerFunc {
 
 		// Check if the personal access token is valid.
 		personalAccessToken := tokenFields[1]
-		if err := gdb.WithContext(c).Where("token = ?", personalAccessToken).First(&models.PersonalAccessToken{}).Error; err != nil {
+		var token models.PersonalAccessToken
+		if err := gdb.WithContext(c).Where("token = ?", personalAccessToken).First(&token).Error; err != nil {
+			logger.Errorf("Invalid personal access token attempt: %s, error: %v", c.Request.URL.Path, err)
 			c.JSON(http.StatusUnauthorized, ErrorResponse{
 				Message: http.StatusText(http.StatusUnauthorized),
 			})
@@ -50,6 +61,68 @@ func PersonalAccessToken(gdb *gorm.DB) gin.HandlerFunc {
 			return
 		}
 
+		// Check if the token is active.
+		if token.State != models.PersonalAccessTokenStateActive {
+			logger.Errorf("Inactive token used: %s, token name: %s, user_id: %d", c.Request.URL.Path, token.Name, token.UserID)
+			c.JSON(http.StatusForbidden, ErrorResponse{
+				Message: "Token is inactive",
+			})
+			c.Abort()
+			return
+		}
+
+		// Check if the token has expired.
+		if time.Now().After(token.ExpiredAt) {
+			logger.Errorf("Expired token used: %s, token name: %s, user_id: %d, expired: %v",
+				c.Request.URL.Path, token.Name, token.UserID, token.ExpiredAt)
+			c.JSON(http.StatusForbidden, ErrorResponse{
+				Message: "Token has expired",
+			})
+			c.Abort()
+			return
+		}
+
+		// Check if the token's scopes include the required resource type.
+		hasScope := false
+		resourceType := getAPIResourceType(c.Request.URL.Path)
+		for _, scope := range token.Scopes {
+			if scope == resourceType {
+				hasScope = true
+				break
+			}
+		}
+
+		if !hasScope {
+			logger.Errorf("Insufficient scope token used: %s, token name: %s, user_id: %d, required: %s, available: %v",
+				c.Request.URL.Path, token.Name, token.UserID, resourceType, token.Scopes)
+			c.JSON(http.StatusForbidden, ErrorResponse{
+				Message: fmt.Sprintf("Token doesn't have permission to access this resource. Required scope: %s", resourceType),
+			})
+			c.Abort()
+			return
+		}
+
 		c.Next()
+	}
+}
+
+// getAPIResourceType extracts the resource type from the path.
+// For example: /oapi/v1/jobs -> job, /oapi/v1/clusters -> cluster.
+func getAPIResourceType(path string) string {
+	matches := oapiResourceRegexp.FindStringSubmatch(path)
+	if len(matches) != 2 {
+		return ""
+	}
+
+	resource := strings.ToLower(matches[1])
+	switch resource {
+	case "jobs":
+		return types.PersonalAccessTokenScopeJob
+	case "clusters":
+		return types.PersonalAccessTokenScopeCluster
+	case "preheats":
+		return types.PersonalAccessTokenScopePreheat
+	default:
+		return resource
 	}
 }


### PR DESCRIPTION
Enhance Personal Access Token middleware with scope validation.

## Description

This PR enhances the Personal Access Token middleware with comprehensive validation features:

- Add detailed error logging for security audit purposes
- Add token state validation to ensure only active tokens are accepted
- Implement token expiration checking to reject expired tokens
- Add scope-based authorization to restrict access based on resource types

## Related Issue

close https://github.com/dragonflyoss/dragonfly/issues/3883

## Motivation and Context

This change significantly improves the security of the API by ensuring that personal access tokens are properly validated before granting access. The previous implementation only verified token existence without checking its state, expiration, or permissions.

The scope-based validation ensures that tokens can only access resources they are explicitly authorized for, following the principle of least privilege. This prevents token misuse and provides better security isolation between different API resources.

The enhanced logging also improves security auditing capabilities by recording detailed information about token validation failures, which is essential for detecting potential security incidents.

## Screenshots

<img width="658" alt="{3115A52B-6CAA-454F-B5AB-DEB7F95B9AD6}" src="https://github.com/user-attachments/assets/11b7d8ab-13f5-45c0-99ad-151411e7af7a" />

**Accessing `Cluster` Open API with Bearer Token，got `403 forbidden`：**
<img width="707" alt="image" src="https://github.com/user-attachments/assets/1acc3169-ae5b-4d9a-bee8-1e15febf34f9" />

**Accessing `Job` Open API with Bearer Token，got `200 OK`：**
<img width="710" alt="{867A29F0-25B7-4FFB-8F3C-499198F5C54C}" src="https://github.com/user-attachments/assets/c2a13156-b088-412f-9467-c5dfc1996fb9" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
