### PR TITLE
feat(manager): an empty permissions list grants all permissions

### DIFF
--- a/manager/job/preheat.go
+++ b/manager/job/preheat.go
@@ -27,7 +27,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"regexp"
 	"time"
 
 	machineryv1tasks "github.com/RichardKnop/machinery/v1/tasks"
@@ -72,9 +71,6 @@ var defaultHTTPTransport = &http.Transport{
 	MaxConnsPerHost:     50,
 	IdleConnTimeout:     120 * time.Second,
 }
-
-// accessURLPattern is the pattern of access url.
-var accessURLPattern, _ = regexp.Compile("^(.*)://(.*)/v2/(.*)/manifests/(.*)")
 
 // Preheat is an interface for preheat job.
 type Preheat interface {

--- a/manager/job/types.go
+++ b/manager/job/types.go
@@ -3,7 +3,11 @@ package job
 import (
 	"errors"
 	"fmt"
+	"regexp"
 )
+
+// accessURLRegexp is the regular expression for parsing access url.
+var accessURLRegexp, _ = regexp.Compile("^(.*)://(.*)/v2/(.*)/manifests/(.*)")
 
 // preheatImage is image information for preheat.
 type preheatImage struct {
@@ -23,7 +27,7 @@ func (p *preheatImage) blobsURL(digest string) string {
 
 // parseManifestURL parses manifest url.
 func parseManifestURL(url string) (*preheatImage, error) {
-	r := accessURLPattern.FindStringSubmatch(url)
+	r := accessURLRegexp.FindStringSubmatch(url)
 	if len(r) != 5 {
 		return nil, errors.New("parse access url failed")
 	}

--- a/manager/service/personal_access_token.go
+++ b/manager/service/personal_access_token.go
@@ -27,6 +27,10 @@ import (
 )
 
 func (s *service) CreatePersonalAccessToken(ctx context.Context, json types.CreatePersonalAccessTokenRequest) (*models.PersonalAccessToken, error) {
+	if len(json.Scopes) == 0 {
+		json.Scopes = types.DefaultPersonalAccessTokenScopes
+	}
+
 	personalAccessToken := models.PersonalAccessToken{
 		Name:      json.Name,
 		BIO:       json.BIO,
@@ -58,6 +62,10 @@ func (s *service) DestroyPersonalAccessToken(ctx context.Context, id uint) error
 }
 
 func (s *service) UpdatePersonalAccessToken(ctx context.Context, id uint, json types.UpdatePersonalAccessTokenRequest) (*models.PersonalAccessToken, error) {
+	if len(json.Scopes) == 0 {
+		json.Scopes = types.DefaultPersonalAccessTokenScopes
+	}
+
 	personalAccessToken := models.PersonalAccessToken{}
 	if err := s.db.WithContext(ctx).Preload("User").First(&personalAccessToken, id).Updates(models.PersonalAccessToken{
 		BIO:       json.BIO,

--- a/manager/types/persional_access_token.go
+++ b/manager/types/persional_access_token.go
@@ -19,14 +19,16 @@ package types
 import "time"
 
 const (
-	// PersonalAccessTokenScopePreheat represents the personal access token whose scope is preheat.
-	PersonalAccessTokenScopePreheat = "preheat"
-
 	// PersonalAccessTokenScopeJob represents the personal access token whose scope is job.
 	PersonalAccessTokenScopeJob = "job"
 
 	// PersonalAccessTokenScopeCluster represents the personal access token whose scope is cluster.
 	PersonalAccessTokenScopeCluster = "cluster"
+)
+
+var (
+	// DefaultPersonalAccessTokenScopes represents the default scopes of personal access token.
+	DefaultPersonalAccessTokenScopes = []string{PersonalAccessTokenScopeJob, PersonalAccessTokenScopeCluster}
 )
 
 type CreatePersonalAccessTokenRequest struct {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes several changes to improve the handling of personal access tokens, refactor regular expressions, and update submodule references. The most important changes include moving the regular expression for access URLs, refactoring the personal access token middleware for better permission handling, and setting default scopes for personal access tokens.

### Improvements to handling of personal access tokens:

* [`manager/middlewares/personal_access_token.go`](diffhunk://#diff-95dbb8ce3388da41ed4e95157980238ab0caf637204862ab8a2a05ce21e5cf0aR36-R37): Refactored the middleware to introduce `hasPermission` and `requiredPermission` functions, improving the handling of token permissions and error logging. [[1]](diffhunk://#diff-95dbb8ce3388da41ed4e95157980238ab0caf637204862ab8a2a05ce21e5cf0aR36-R37) [[2]](diffhunk://#diff-95dbb8ce3388da41ed4e95157980238ab0caf637204862ab8a2a05ce21e5cf0aR50) [[3]](diffhunk://#diff-95dbb8ce3388da41ed4e95157980238ab0caf637204862ab8a2a05ce21e5cf0aL56-R108) [[4]](diffhunk://#diff-95dbb8ce3388da41ed4e95157980238ab0caf637204862ab8a2a05ce21e5cf0aL109-R153)
* [`manager/service/personal_access_token.go`](diffhunk://#diff-f1770796138097161acdb313eb0551a8cef88208204c5496c7c1803cd72dfe9eR30-R33): Added default scopes to personal access tokens if none are provided during creation or update. [[1]](diffhunk://#diff-f1770796138097161acdb313eb0551a8cef88208204c5496c7c1803cd72dfe9eR30-R33) [[2]](diffhunk://#diff-f1770796138097161acdb313eb0551a8cef88208204c5496c7c1803cd72dfe9eR65-R68)
* [`manager/types/personal_access_token.go`](diffhunk://#diff-9f6d4fef352d36f823aa196755a49723b0af03d0ac58abf861ec8c447c9a5b3eL22-R33): Removed the `PersonalAccessTokenScopePreheat` constant and introduced `DefaultPersonalAccessTokenScopes`.

### Refactoring of regular expressions:

* [`manager/job/preheat.go`](diffhunk://#diff-5a00f4fe6f1601c2b6f1aa2eb189af8a7916ac80391f80db18d401411481ef14L30): Removed the `accessURLPattern` regular expression. [[1]](diffhunk://#diff-5a00f4fe6f1601c2b6f1aa2eb189af8a7916ac80391f80db18d401411481ef14L30) [[2]](diffhunk://#diff-5a00f4fe6f1601c2b6f1aa2eb189af8a7916ac80391f80db18d401411481ef14L76-L78)
* [`manager/job/types.go`](diffhunk://#diff-082584d2fecaa8fcac856c876b2e36eb9f9ae464ae7742c023999eea25ef2833R6-R11): Moved the regular expression for access URLs to this file and renamed it to `accessURLRegexp`. [[1]](diffhunk://#diff-082584d2fecaa8fcac856c876b2e36eb9f9ae464ae7742c023999eea25ef2833R6-R11) [[2]](diffhunk://#diff-082584d2fecaa8fcac856c876b2e36eb9f9ae464ae7742c023999eea25ef2833L26-R30)
* [`manager/middlewares/personal_access_token.go`](diffhunk://#diff-95dbb8ce3388da41ed4e95157980238ab0caf637204862ab8a2a05ce21e5cf0aR36-R37): Added `oapiResourceRegexp` for extracting resource types from paths.

### Submodule update:

* [`client-rs`](diffhunk://#diff-84558f39216002fac1c3d61169fea29ee720b962a90c14d2f81a13e0ee6742bfL1-R1): Updated the submodule reference to a new commit.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
