### PR TITLE
fix: update peer and task manager methods to use correct key format

### DIFF
--- a/scheduler/resource/persistentcache/task_manager_mock.go
+++ b/scheduler/resource/persistentcache/task_manager_mock.go
@@ -84,19 +84,19 @@ func (mr *MockTaskManagerMockRecorder) LoadAll(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadAll", reflect.TypeOf((*MockTaskManager)(nil).LoadAll), arg0)
 }
 
-// LoadCorrentReplicaCount mocks base method.
-func (m *MockTaskManager) LoadCorrentReplicaCount(arg0 context.Context, arg1 string) (uint64, error) {
+// LoadCurrentReplicaCount mocks base method.
+func (m *MockTaskManager) LoadCurrentReplicaCount(arg0 context.Context, arg1 string) (uint64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoadCorrentReplicaCount", arg0, arg1)
+	ret := m.ctrl.Call(m, "LoadCurrentReplicaCount", arg0, arg1)
 	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// LoadCorrentReplicaCount indicates an expected call of LoadCorrentReplicaCount.
-func (mr *MockTaskManagerMockRecorder) LoadCorrentReplicaCount(arg0, arg1 any) *gomock.Call {
+// LoadCurrentReplicaCount indicates an expected call of LoadCurrentReplicaCount.
+func (mr *MockTaskManagerMockRecorder) LoadCurrentReplicaCount(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadCorrentReplicaCount", reflect.TypeOf((*MockTaskManager)(nil).LoadCorrentReplicaCount), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadCurrentReplicaCount", reflect.TypeOf((*MockTaskManager)(nil).LoadCurrentReplicaCount), arg0, arg1)
 }
 
 // LoadCurrentPersistentReplicaCount mocks base method.

--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -1856,7 +1856,7 @@ func (v *V2) handleRegisterPersistentCachePeerRequest(ctx context.Context, strea
 			return status.Error(codes.Internal, err.Error())
 		}
 
-		currentReplicaCount, err := v.persistentCacheResource.TaskManager().LoadCorrentReplicaCount(ctx, taskID)
+		currentReplicaCount, err := v.persistentCacheResource.TaskManager().LoadCurrentReplicaCount(ctx, taskID)
 		if err != nil {
 			// Collect RegisterPersistentCachePeerFailureCount metrics.
 			metrics.RegisterPersistentCachePeerFailureCount.WithLabelValues(peer.Host.Type.Name()).Inc()
@@ -2051,7 +2051,7 @@ func (v *V2) handleReschedulePersistentCachePeerRequest(ctx context.Context, str
 		return status.Error(codes.Internal, err.Error())
 	}
 
-	currentReplicaCount, err := v.persistentCacheResource.TaskManager().LoadCorrentReplicaCount(ctx, taskID)
+	currentReplicaCount, err := v.persistentCacheResource.TaskManager().LoadCurrentReplicaCount(ctx, taskID)
 	if err != nil {
 		// Collect RegisterPersistentCachePeerFailureCount metrics.
 		metrics.RegisterPersistentCachePeerFailureCount.WithLabelValues(peer.Host.Type.Name()).Inc()
@@ -2314,7 +2314,7 @@ func (v *V2) StatPersistentCachePeer(ctx context.Context, req *schedulerv2.StatP
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	currentReplicaCount, err := v.persistentCacheResource.TaskManager().LoadCorrentReplicaCount(ctx, peer.Task.ID)
+	currentReplicaCount, err := v.persistentCacheResource.TaskManager().LoadCurrentReplicaCount(ctx, peer.Task.ID)
 	if err != nil {
 		log.Errorf("load current replica count failed %s", err.Error())
 		return nil, status.Error(codes.Internal, err.Error())
@@ -2569,7 +2569,7 @@ func (v *V2) UploadPersistentCacheTaskFinished(ctx context.Context, req *schedul
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	currentReplicaCount, err := v.persistentCacheResource.TaskManager().LoadCorrentReplicaCount(ctx, peer.Task.ID)
+	currentReplicaCount, err := v.persistentCacheResource.TaskManager().LoadCurrentReplicaCount(ctx, peer.Task.ID)
 	if err != nil {
 		log.Errorf("load current replica count failed %s", err)
 		return nil, status.Error(codes.Internal, err.Error())
@@ -2769,7 +2769,7 @@ func (v *V2) StatPersistentCacheTask(ctx context.Context, req *schedulerv2.StatP
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	currentReplicaCount, err := v.persistentCacheResource.TaskManager().LoadCorrentReplicaCount(ctx, task.ID)
+	currentReplicaCount, err := v.persistentCacheResource.TaskManager().LoadCurrentReplicaCount(ctx, task.ID)
 	if err != nil {
 		log.Errorf("load current replica count failed %s", err)
 		return nil, status.Error(codes.Internal, err.Error())


### PR DESCRIPTION
## Description

- Changed key formatting in LoadAll methods of peer and task managers to use a prefix with wildcard for scanning.
- Renamed LoadCorrentReplicaCount to LoadCurrentReplicaCount for consistency.
- Added test cases for handling invalid peer and task keys in respective test files.

## Related Issue

https://github.com/dragonflyoss/dragonfly/issues/3892

## Screenshot

![09235e9001e2f4503ebbc1cfcea8e3d8](https://github.com/user-attachments/assets/7006aa49-068a-4ffa-8fe2-ccd9b2ba2a84)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
