### PR TITLE
feat(client): removing hostname resolution fallback when the IP address check fails

### DIFF
--- a/client/config/dynconfig_manager_test.go
+++ b/client/config/dynconfig_manager_test.go
@@ -217,9 +217,8 @@ func TestDynconfigManager_GetResolveSchedulerAddrs(t *testing.T) {
 			},
 			expect: func(t *testing.T, dynconfig Dynconfig, data *DynconfigData) {
 				assert := assert.New(t)
-				result, err := dynconfig.GetResolveSchedulerAddrs()
-				assert.NoError(err)
-				assert.EqualValues(result, []resolver.Address{{ServerName: "localhost", Addr: "localhost:3000"}})
+				_, err := dynconfig.GetResolveSchedulerAddrs()
+				assert.Error(err)
 			},
 		},
 		{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request makes improvements to the `GetResolveSchedulerAddrs` function in the `dynconfig_manager.go` file by simplifying the health check logic and removing redundant code.

Codebase simplification:

* [`client/config/dynconfig_manager.go`](diffhunk://#diff-2c8daaddbf3bfc3cc93f6a9f39a0b6be67f648f95ea03422161c26c2e7469ae1L128-R130): Removed redundant checks for the scheduler's host address and simplified the logic to only check the scheduler's IP address. This change reduces the complexity and potential duplication in the health check process.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
