### PR TITLE
feat: add log for searcher plugin

### DIFF
--- a/manager/searcher/searcher.go
+++ b/manager/searcher/searcher.go
@@ -94,7 +94,7 @@ type searcher struct{}
 func New(pluginDir string) Searcher {
 	s, err := LoadPlugin(pluginDir)
 	if err != nil {
-		logger.Info("use default searcher")
+		logger.Warnf("use default searcher because of loading searcher plugin failed: %v", err)
 		return &searcher{}
 	}
 
@@ -257,11 +257,8 @@ func calculateMultiElementAffinityScore(dst, src string) float64 {
 	elementLen = math.Min(len(dstElements), len(srcElements))
 
 	// Maximum element length is 5.
-	if elementLen > maxElementLen {
-		elementLen = maxElementLen
-	}
-
-	for i := 0; i < elementLen; i++ {
+	elementLen = min(elementLen, maxElementLen)
+	for i := range elementLen {
 		if !strings.EqualFold(dstElements[i], srcElements[i]) {
 			break
 		}

--- a/pkg/rpc/scheduler/server/server.go
+++ b/pkg/rpc/scheduler/server/server.go
@@ -42,10 +42,10 @@ import (
 
 const (
 	// DefaultQPS is default qps of grpc server.
-	DefaultQPS = 20 * 1000
+	DefaultQPS = 1000
 
 	// DefaultBurst is default burst of grpc server.
-	DefaultBurst = 30 * 1000
+	DefaultBurst = 1000
 
 	// DefaultMaxConnectionIdle is default max connection idle of grpc keepalive.
 	DefaultMaxConnectionIdle = 10 * time.Minute


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes several changes to improve error logging, optimize code, and adjust default settings. The most important changes are summarized below:

Enhancements to logging:

* [`manager/searcher/searcher.go`](diffhunk://#diff-c57b43f4b362cffd77ed7a2270b57f37a85ec0341b53f2a4ff3413de35d67cd6L97-R97): Updated the logging statement to use `logger.Warnf` instead of `logger.Info` when loading the searcher plugin fails, providing more context about the error.

Code optimization:

* [`manager/searcher/searcher.go`](diffhunk://#diff-c57b43f4b362cffd77ed7a2270b57f37a85ec0341b53f2a4ff3413de35d67cd6L260-R261): Simplified the `calculateMultiElementAffinityScore` function by replacing a conditional block with a single `min` function and modifying the loop to use `range`.

Adjustments to default settings:

* [`pkg/rpc/scheduler/server/server.go`](diffhunk://#diff-410002dd12096c9e570b6307bb563fecb2aae41aec71c6a766d0b8f2da4cfe42L45-R48): Reduced the default QPS and burst values for the gRPC server from 20,000 and 30,000 to 1,000, respectively.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
