### PR TITLE
fix: replace builds with ids in config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -139,8 +139,7 @@ nfpms:
     license: "Apache 2.0"
     homepage: https://d7y.io
     bindir: /usr/bin
-    builds:
-      - dfget
+    ids: [dfget]
     formats:
       - rpm
       - deb
@@ -185,8 +184,7 @@ nfpms:
     license: "Apache 2.0"
     homepage: https://d7y.io
     bindir: /usr/bin
-    builds:
-      - dfcache
+    ids: [dfcache]
     formats:
       - rpm
       - deb
@@ -229,8 +227,7 @@ nfpms:
     license: "Apache 2.0"
     homepage: https://d7y.io
     bindir: /usr/bin
-    builds:
-      - dfstore
+    ids: [dfstore]
     formats:
       - rpm
       - deb


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes changes to the `.goreleaser.yml` file to update the `nfpms` section by replacing the `builds` key with the `ids` key for specific entries. The most important changes are as follows:

* Changed `nfpms` entry for `dfget` to use `ids` instead of `builds`. (`.goreleaser.yml` [.goreleaser.ymlL142-R142](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L142-R142))
* Changed `nfpms` entry for `dfcache` to use `ids` instead of `builds`. (`.goreleaser.yml` [.goreleaser.ymlL188-R187](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L188-R187))
* Changed `nfpms` entry for `dfstore` to use `ids` instead of `builds`. (`.goreleaser.yml` [.goreleaser.ymlL232-R230](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L232-R230))
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
