### PR TITLE
fix(manager): fix peer ID logging in loadAllPeersByTaskID

### DIFF
--- a/manager/service/persistent_cache_task.go
+++ b/manager/service/persistent_cache_task.go
@@ -216,7 +216,7 @@ func (s *service) loadAllPeersByTaskID(ctx context.Context, schedulerClusterID u
 	for _, peerID := range peerIDs {
 		peer, err := s.loadPeer(ctx, schedulerClusterID, peerID)
 		if err != nil {
-			logger.Warnf("load peer %s failed: %v", peer.ID, err)
+			logger.Warnf("load peer %s failed: %v", peerID, err)
 			continue
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes a minor change to the `manager/service/persistent_cache_task.go` file. The change corrects the logging statement to use the correct variable for the peer ID.

* [`manager/service/persistent_cache_task.go`](diffhunk://#diff-7eb5cd37cfb63d6f46d2a691550f7a56fd11367e3ad6276fc49e9c974464f854L219-R219): Corrected the logging statement in the `loadAllPeersByTaskID` function to use `peerID` instead of `peer.ID`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
