### PR TITLE
feat: support query parameters for list audit API

### DIFF
--- a/manager/handlers/audit_test.go
+++ b/manager/handlers/audit_test.go
@@ -123,6 +123,27 @@ func TestHandlers_GetAudits(t *testing.T) {
 				assert.Equal(mockAuditModel, &audits[0])
 			},
 		},
+		{
+			name: "success with query parameters",
+			req:  httptest.NewRequest(http.MethodGet, "/api/v1/audits?page=2&per_page=20&operation=GET&state=SUCCESS", nil),
+			mock: func(ms *mocks.MockServiceMockRecorder) {
+				ms.GetAudits(gomock.Any(), gomock.Eq(types.GetAuditsQuery{
+					Page:      2,
+					PerPage:   20,
+					Operation: "GET",
+					State:     "SUCCESS",
+				})).Return([]models.Audit{*mockAuditModel}, int64(1), nil).Times(1)
+			},
+			expect: func(t *testing.T, w *httptest.ResponseRecorder) {
+				assert := assert.New(t)
+				assert.Equal(http.StatusOK, w.Code)
+				var audits []models.Audit
+				err := json.Unmarshal(w.Body.Bytes(), &audits)
+				assert.NoError(err)
+				assert.Len(audits, 1)
+				assert.Equal(mockAuditModel, &audits[0])
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/manager/service/audit.go
+++ b/manager/service/audit.go
@@ -121,7 +121,15 @@ func (s *service) processAudit() {
 func (s *service) GetAudits(ctx context.Context, q types.GetAuditsQuery) ([]models.Audit, int64, error) {
 	var count int64
 	audits := []models.Audit{}
-	if err := s.db.WithContext(ctx).Scopes(models.Paginate(q.Page, q.PerPage)).Find(&audits).Limit(-1).Offset(-1).Count(&count).Error; err != nil {
+	if err := s.db.WithContext(ctx).Scopes(models.Paginate(q.Page, q.PerPage)).Where(&models.Audit{
+		ActorType:  q.ActorType,
+		ActorName:  q.ActorName,
+		EventType:  q.EventType,
+		Operation:  q.Operation,
+		State:      q.State,
+		Path:       q.Path,
+		StatusCode: q.StatusCode,
+	}).Order("created_at DESC").Find(&audits).Limit(-1).Offset(-1).Count(&count).Error; err != nil {
 		return nil, 0, err
 	}
 

--- a/manager/types/audit.go
+++ b/manager/types/audit.go
@@ -30,6 +30,13 @@ type CreateAuditRequest struct {
 }
 
 type GetAuditsQuery struct {
-	Page    int `form:"page" binding:"omitempty,gte=1"`
-	PerPage int `form:"per_page" binding:"omitempty,gte=1,lte=10000000"`
+	ActorType  string `form:"actor_type" binding:"omitempty,oneof=UNKNOWN USER PAT"`
+	ActorName  string `form:"actor_name" binding:"omitempty"`
+	EventType  string `form:"event_type" binding:"omitempty,oneof=API"`
+	Operation  string `form:"operation" binding:"omitempty"`
+	State      string `form:"state" binding:"omitempty,oneof=SUCCESS FAILURE"`
+	Path       string `form:"path" binding:"omitempty"`
+	StatusCode int    `form:"status_code" binding:"omitempty"`
+	Page       int    `form:"page" binding:"omitempty,gte=1"`
+	PerPage    int    `form:"per_page" binding:"omitempty,gte=1,lte=10000000"`
 }


### PR DESCRIPTION
This pull request enhances the audit functionality by introducing support for query parameters in the `GetAudits` endpoint, improving the filtering and sorting of audit records, and updating the corresponding test cases. Below are the key changes:

### Enhancements to Audit Query Functionality:
* Updated the `GetAuditsQuery` struct in `manager/types/audit.go` to include new fields (`ActorType`, `ActorName`, `EventType`, `Operation`, `State`, `Path`, and `StatusCode`) for filtering audit records. Each field has validation rules for allowed values and formats.
* Modified the `GetAudits` method in `manager/service/audit.go` to apply filtering based on the new query parameters and to sort results by `created_at` in descending order.

### Test Case Updates:
* Added a new test case in `manager/handlers/audit_test.go` to verify the `GetAudits` endpoint's behavior when query parameters are provided. This test ensures correct filtering, pagination, and response structure.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/dragonflyoss/dragonfly/issues/3811

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
