### PR TITLE
refactor(math/rand): remove init function for rand.Seed

### DIFF
--- a/pkg/math/rand.go
+++ b/pkg/math/rand.go
@@ -22,10 +22,6 @@ import (
 	"time"
 )
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
-
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 const (
 	letterIdxBits = 6                    // 6 bits to represent a letter index


### PR DESCRIPTION
* See the License for the specific language governing permissions and
rand.Seed is deprecated: As of Go 1.20 there is no reason to call Seed with
a random value. Programs that call Seed with a known value to get
a specific sequence of results should use New(NewSource(seed)) to
obtain a local random generator.