### PR TITLE
fix(peer/peertask_conductor): correct error handling in storeTinyPeer…

### DIFF
--- a/client/daemon/peer/peertask_conductor.go
+++ b/client/daemon/peer/peertask_conductor.go
@@ -658,8 +658,9 @@ func (pt *peerTaskConductor) storeTinyPeerTask() {
 		return
 	}
 	if n != contentLength {
-		pt.Errorf("write tiny data storage failed, want: %d, wrote: %d", contentLength, n)
-		pt.cancel(commonv1.Code_ClientError, err.Error())
+		resson := fmt.Sprintf("write tiny data storage failed, want: %d, wrote: %d", contentLength, n)
+		pt.Error(resson)
+		pt.cancel(commonv1.Code_ClientError, resson)
 		return
 	}
 


### PR DESCRIPTION
This pull request includes a minor update to the error handling in the `storeTinyPeerTask` method of the `peerTaskConductor` struct. The change improves error reporting by ensuring that the same error message is logged and passed to the `cancel` method.

Error handling improvement:

* [`client/daemon/peer/peertask_conductor.go`](diffhunk://#diff-e22a946ce6c396f09c823dc75b2f4c31e8ec456904a56461ef9a1cf83ffe8f3dL661-R663): Replaced the inline error message in `pt.cancel` with a formatted string stored in the `resson` variable, ensuring consistency between the logged error and the cancellation reason.

```
err is nil here. err.Error()? maybe it will panic? or empty?
```