### PR TITLE
fix: remove the gorm tag for CreatedAt and UpdatedAt

### DIFF
--- a/manager/models/models.go
+++ b/manager/models/models.go
@@ -30,8 +30,8 @@ import (
 
 type BaseModel struct {
 	ID        uint                  `gorm:"primarykey;comment:id" json:"id"`
-	CreatedAt time.Time             `gorm:"column:created_at;type:timestamp;default:current_timestamp;comment:created at" json:"created_at"`
-	UpdatedAt time.Time             `gorm:"column:updated_at;type:timestamp;default:current_timestamp;comment:updated at" json:"updated_at"`
+	CreatedAt time.Time             `json:"created_at"`
+	UpdatedAt time.Time             `json:"updated_at"`
 	IsDel     soft_delete.DeletedAt `gorm:"softDelete:flag;comment:soft delete flag" json:"is_del"`
 }
 


### PR DESCRIPTION
This pull request simplifies the `BaseModel` struct in `manager/models/models.go` by removing redundant GORM tags from the `CreatedAt` and `UpdatedAt` fields.

Code simplification:

* [`manager/models/models.go`](diffhunk://#diff-f0ba3380214024f46eceeacea13b1848d224da336ff53494564553b368a6566eL33-R34): Removed the `gorm` tags specifying column names, types, defaults, and comments for the `CreatedAt` and `UpdatedAt` fields in the `BaseModel` struct, leaving only the `json` tags.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

https://github.com/dragonflyoss/dragonfly/issues/3989

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
