### PR TITLE
refactor: remove legacy job gc config

### DIFF
--- a/manager/config/config.go
+++ b/manager/config/config.go
@@ -304,26 +304,11 @@ type GRPCTLSServerConfig struct {
 }
 
 type JobConfig struct {
-	// GC configuration, used to clean up expired jobs. If the count of the jobs is huge,
-	// it may cause performance problems.
-	GC GCConfig `yaml:"gc" mapstructure:"gc"`
-
 	// Preheat configuration.
 	Preheat PreheatConfig `yaml:"preheat" mapstructure:"preheat"`
 
 	// Sync peers configuration.
 	SyncPeers SyncPeersConfig `yaml:"syncPeers" mapstructure:"syncPeers"`
-}
-
-type GCConfig struct {
-	// Interval is the interval for gc.
-	Interval time.Duration `yaml:"interval" mapstructure:"interval"`
-
-	// TTL is the ttl for job.
-	TTL time.Duration `yaml:"ttl" mapstructure:"ttl"`
-
-	// BatchSize is the batch size when operating gorm database.
-	BatchSize int `yaml:"batchSize" mapstructure:"batchSize"`
 }
 
 type PreheatConfig struct {
@@ -444,11 +429,6 @@ func New() *Config {
 			},
 		},
 		Job: JobConfig{
-			GC: GCConfig{
-				Interval:  DefaultJobGCInterval,
-				TTL:       DefaultJobGCTTL,
-				BatchSize: DefaultJobGCBatchSize,
-			},
 			Preheat: PreheatConfig{
 				RegistryTimeout: DefaultJobPreheatRegistryTimeout,
 				TLS:             PreheatTLSClientConfig{},
@@ -623,18 +603,6 @@ func (cfg *Config) Validate() error {
 
 	if cfg.Cache.Local.TTL == 0 {
 		return errors.New("local requires parameter ttl")
-	}
-
-	if cfg.Job.GC.Interval == 0 {
-		return errors.New("gc requires parameter interval")
-	}
-
-	if cfg.Job.GC.TTL == 0 {
-		return errors.New("gc requires parameter ttl")
-	}
-
-	if cfg.Job.GC.BatchSize == 0 {
-		return errors.New("gc requires parameter batchSize")
 	}
 
 	if cfg.Job.Preheat.RegistryTimeout == 0 {

--- a/manager/config/config_test.go
+++ b/manager/config/config_test.go
@@ -177,11 +177,6 @@ func TestConfig_Load(t *testing.T) {
 			},
 		},
 		Job: JobConfig{
-			GC: GCConfig{
-				Interval:  1 * time.Second,
-				TTL:       1 * time.Second,
-				BatchSize: 100,
-			},
 			Preheat: PreheatConfig{
 				RegistryTimeout: DefaultJobPreheatRegistryTimeout,
 				TLS: PreheatTLSClientConfig{
@@ -734,51 +729,6 @@ func TestConfig_Validate(t *testing.T) {
 			expect: func(t *testing.T, err error) {
 				assert := assert.New(t)
 				assert.EqualError(err, "local requires parameter ttl")
-			},
-		},
-		{
-			name:   "gc requires parameter interval",
-			config: New(),
-			mock: func(cfg *Config) {
-				cfg.Auth.JWT = mockJWTConfig
-				cfg.Database.Type = DatabaseTypeMysql
-				cfg.Database.Mysql = mockMysqlConfig
-				cfg.Database.Redis = mockRedisConfig
-				cfg.Job.GC.Interval = 0
-			},
-			expect: func(t *testing.T, err error) {
-				assert := assert.New(t)
-				assert.EqualError(err, "gc requires parameter interval")
-			},
-		},
-		{
-			name:   "gc requires parameter ttl",
-			config: New(),
-			mock: func(cfg *Config) {
-				cfg.Auth.JWT = mockJWTConfig
-				cfg.Database.Type = DatabaseTypeMysql
-				cfg.Database.Mysql = mockMysqlConfig
-				cfg.Database.Redis = mockRedisConfig
-				cfg.Job.GC.TTL = 0
-			},
-			expect: func(t *testing.T, err error) {
-				assert := assert.New(t)
-				assert.EqualError(err, "gc requires parameter ttl")
-			},
-		},
-		{
-			name:   "gc requires parameter batchSize",
-			config: New(),
-			mock: func(cfg *Config) {
-				cfg.Auth.JWT = mockJWTConfig
-				cfg.Database.Type = DatabaseTypeMysql
-				cfg.Database.Mysql = mockMysqlConfig
-				cfg.Database.Redis = mockRedisConfig
-				cfg.Job.GC.BatchSize = 0
-			},
-			expect: func(t *testing.T, err error) {
-				assert := assert.New(t)
-				assert.EqualError(err, "gc requires parameter batchSize")
 			},
 		},
 		{

--- a/manager/config/constants.go
+++ b/manager/config/constants.go
@@ -87,15 +87,6 @@ const (
 )
 
 const (
-	// DefaultJobGCInterval is the default interval for gc job.
-	DefaultJobGCInterval = 3 * time.Hour
-
-	// DefaultJobGCTTL is the default ttl for job.
-	DefaultJobGCTTL = 6 * time.Hour
-
-	// DefaultJobGCBatchSize is the default batch size for operating on the database in gc job.
-	DefaultJobGCBatchSize = 5000
-
 	// DefaultJobPreheatRegistryTimeout is the default timeout for requesting registry to get token and manifest.
 	DefaultJobPreheatRegistryTimeout = 1 * time.Minute
 


### PR DESCRIPTION
This pull request removes the `GCConfig` struct and its associated configuration, validation, and test cases from the `manager/config` package. The changes simplify the `JobConfig` structure by eliminating the GC-related fields and logic.

### Removal of GC Configuration:

* Removed the `GCConfig` struct and its fields (`Interval`, `TTL`, `BatchSize`) from the `JobConfig` definition in `config.go`. This also includes removing the corresponding YAML and mapstructure tags.
* Deleted the initialization of default GC configuration values in the `New` function.
* Removed GC-related validation logic from the `Validate` method in the `Config` struct.

### Updates to Unit Tests:

* Removed GC configuration initialization from the `TestConfig_Load` test case in `config_test.go`.
* Deleted test cases in `TestConfig_Validate` that were validating GC-specific parameters (`interval`, `ttl`, `batchSize`).<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
