### PR TITLE
feat: add the audit gc

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -170,6 +170,11 @@ func New(cfg *config.Config, d dfpath.Dfpath) (*Server, error) {
 		return nil, err
 	}
 
+	// Register audit gc task.
+	if err := s.gc.Add(gc.NewAuditGCTask(db.DB)); err != nil {
+		return nil, err
+	}
+
 	// Initialize REST server.
 	restService := service.New(cfg, db, cache, job, enforcer, objectStorage)
 	router, err := router.Init(cfg, d.LogDir(), restService, db, enforcer, s.jobRateLimiter, EmbedFolder(assets, assetsTargetPath))


### PR DESCRIPTION
This pull request introduces a new garbage collection (GC) task for cleaning up audit records in the Dragonfly Manager. The most important changes include adding the `audit` GC task implementation, registering it with the GC scheduler, and defining default configurations for this task.

### New Audit GC Task Implementation:

* **Added `audit` GC task**: Implemented a new GC task in `manager/gc/audit.go` to periodically delete outdated audit records. The task includes configurations for batch size, interval, and timeout, and uses a `RunGC` method to perform the cleanup. It also integrates a job recorder to log GC results.

### Integration with GC Scheduler:

* **Registered the `audit` GC task**: Updated the `manager/manager.go` file to register the new `audit` GC task with the GC scheduler during server initialization.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

https://github.com/dragonflyoss/dragonfly/issues/3811
https://github.com/dragonflyoss/dragonfly/issues/3938

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
