### PR TITLE
chore(.github/workflows/release.yml): add custom SLSA provenance and SPDX file upload to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,12 +64,36 @@ jobs:
   provenance:
     needs: [goreleaser]
     permissions:
-      actions: read # To read the workflow path.
-      id-token: write # To sign the provenance.
-      contents: write # To add assets to a release.
+      id-token: write
+      contents: write
+      actions: read
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
-      upload-tag-name: "${{ needs.goreleaser.outputs.tag_name }}"
-      upload-assets: true # upload to a new release
-      draft-release: true
+
+  upload-provenance:
+    needs: [goreleaser, provenance]
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Download SLSA provenance artifacts
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          name: multiple.intoto.jsonl
+          path: artifacts
+
+      - name: Upload SLSA Provenance Attestation to Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.goreleaser.outputs.tag_name }}
+        run: |
+          set -euxo pipefail
+          ARTIFACT_PATH="artifacts/multiple.intoto.jsonl"
+          gh release upload "$TAG_NAME" "$ARTIFACT_PATH" --clobber


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the GitHub Actions workflow in `.github/workflows/release.yml` to enhance the release process by adding a new job for uploading SLSA provenance attestations and reorganizing permissions for better clarity.

### Enhancements to the release workflow:
* **Reorganized permissions in the `provenance` job**: Adjusted the order of `id-token`, `contents`, and `actions` permissions for better readability.
* **Added a new `upload-provenance` job**: 
  - Introduced a job that depends on `goreleaser` and `provenance` to upload SLSA provenance attestations to the release.
  - Configured the job to use `actions/checkout` and `actions/download-artifact` for downloading artifacts and then uploading them to the release using the GitHub CLI.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
