### PR TITLE
chore(.github/auto_assign.yml): add assignees for PR

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,11 +1,10 @@
 # Set to true to add reviewers to pull requests
-addReviewers: true
+addReviewers: false
 
 # Set to true to add assignees to pull requests
-addAssignees: author
+addAssignees: true
 
-# A list of reviewers to be added to pull requests (GitHub user name)
-reviewers:
+assignees:
   - gaius-qi
   - yxxhero
   - chlins
@@ -14,5 +13,4 @@ reviewers:
   - hyy0322
   - xujihui1985
 
-# A number of reviewers added to the pull request
-numberOfReviewers: 3
+numberOfAssignees: 3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request modifies the `.github/auto_assign.yml` configuration file to change how reviewers and assignees are handled. The key changes involve disabling automatic addition of reviewers, enabling automatic addition of assignees, and updating related configuration fields.

### Changes to reviewer and assignee configuration:

* Disabled the automatic addition of reviewers to pull requests by setting `addReviewers` to `false`.
* Enabled the automatic addition of assignees to pull requests by setting `addAssignees` to `true`.
* Replaced the `reviewers` list with an `assignees` list, specifying `gaius-qi`, `yxxhero`, and `chlins` as assignees.
* Renamed the `numberOfReviewers` field to `numberOfAssignees` to align with the new configuration, and set its value to `3`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
