### PR TITLE
fix: set the pat to context for audit

### DIFF
--- a/manager/middlewares/personal_access_token.go
+++ b/manager/middlewares/personal_access_token.go
@@ -66,6 +66,9 @@ func PersonalAccessToken(gdb *gorm.DB) gin.HandlerFunc {
 			return
 		}
 
+		// Set the personal access token in the context for audit purposes.
+		c.Set("pat", &token)
+
 		// Check if the token is active.
 		if token.State != models.PersonalAccessTokenStateActive {
 			logger.Errorf("inactive token used: %s, token name: %s, user_id: %d", c.Request.URL.Path, token.Name, token.UserID)
@@ -111,7 +114,6 @@ func PersonalAccessToken(gdb *gorm.DB) gin.HandlerFunc {
 			return
 		}
 
-		c.Set("pat", &token)
 		c.Next()
 	}
 }


### PR DESCRIPTION
This pull request refactors the `PersonalAccessToken` middleware in `manager/middlewares/personal_access_token.go` to improve the handling of the personal access token within the request context. The key change involves moving the context-setting logic for the token to an earlier point in the function for better auditability.

### Middleware improvements:

* [`manager/middlewares/personal_access_token.go`](diffhunk://#diff-95dbb8ce3388da41ed4e95157980238ab0caf637204862ab8a2a05ce21e5cf0aR69-R71): Moved the `c.Set("pat", &token)` call to an earlier point in the `PersonalAccessToken` function, ensuring the personal access token is set in the context immediately after it is retrieved. This change supports better audit logging and context management. [[1]](diffhunk://#diff-95dbb8ce3388da41ed4e95157980238ab0caf637204862ab8a2a05ce21e5cf0aR69-R71) [[2]](diffhunk://#diff-95dbb8ce3388da41ed4e95157980238ab0caf637204862ab8a2a05ce21e5cf0aL114)<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
