### PR TITLE
chore(.github/workflows): change rules of the stale actions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,13 +17,15 @@ jobs:
         id: stale
         with:
           delete-branch: true
-          days-before-close: 60
+          days-before-close: 7
           days-before-stale: 90
+          days-before-pr-close: 7
+          days-before-pr-stale: 120
           stale-issue-label: "stale"
           exempt-issue-labels: bug,wip,on-hold
           exempt-pr-labels: bug,wip,on-hold
           exempt-all-milestones: true
           stale-issue-message: 'This issue is stale because it has been open 90 days with no activity.'
-          stale-pr-message: 'This PR is stale because it has been open 90 days with no activity.'
-          close-issue-message: 'This issue was closed because it has been stalled for 60 days with no activity.'
-          close-pr-message: 'This PR was closed because it has been stalled for 60 days with no activity.'
+          close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
+          stale-pr-message: 'This PR is stale because it has been open 120 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 7 days with no activity.'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the configuration for the stale workflow in `.github/workflows/stale.yml`. The changes adjust the timing and messaging for marking issues and pull requests as stale or closed.

### Changes to stale workflow configuration:

* Reduced the `days-before-close` for issues from 60 days to 7 days and added `days-before-pr-close` with the same 7-day threshold.
* Adjusted the `days-before-stale` for pull requests to 120 days and added specific stale and close messages for pull requests.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
