### PR TITLE
refactor: pass context to run gc task

### DIFF
--- a/manager/gc/audit.go
+++ b/manager/gc/audit.go
@@ -17,6 +17,7 @@
 package gc
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 
@@ -57,7 +58,7 @@ type audit struct {
 }
 
 // RunGC implements the gc Runner interface.
-func (a *audit) RunGC() error {
+func (a *audit) RunGC(ctx context.Context) error {
 	ttl, err := a.getTTL()
 	if err != nil {
 		return err

--- a/manager/gc/job.go
+++ b/manager/gc/job.go
@@ -17,6 +17,7 @@
 package gc
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 
@@ -57,7 +58,7 @@ type job struct {
 }
 
 // RunGC implements the gc Runner interface.
-func (j *job) RunGC() error {
+func (j *job) RunGC(ctx context.Context) error {
 	ttl, err := j.getTTL()
 	if err != nil {
 		return err

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -272,7 +272,7 @@ func (s *Server) Serve() error {
 	}()
 
 	// Started gc server.
-	s.gc.Start()
+	s.gc.Start(context.Background())
 	logger.Info("started gc server")
 
 	// Generate GRPC listener.

--- a/pkg/gc/gc_mock.go
+++ b/pkg/gc/gc_mock.go
@@ -10,6 +10,7 @@
 package gc
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
@@ -54,41 +55,41 @@ func (mr *MockGCMockRecorder) Add(arg0 any) *gomock.Call {
 }
 
 // Run mocks base method.
-func (m *MockGC) Run(arg0 string) error {
+func (m *MockGC) Run(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Run", arg0)
+	ret := m.ctrl.Call(m, "Run", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Run indicates an expected call of Run.
-func (mr *MockGCMockRecorder) Run(arg0 any) *gomock.Call {
+func (mr *MockGCMockRecorder) Run(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockGC)(nil).Run), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockGC)(nil).Run), arg0, arg1)
 }
 
 // RunAll mocks base method.
-func (m *MockGC) RunAll() {
+func (m *MockGC) RunAll(arg0 context.Context) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RunAll")
+	m.ctrl.Call(m, "RunAll", arg0)
 }
 
 // RunAll indicates an expected call of RunAll.
-func (mr *MockGCMockRecorder) RunAll() *gomock.Call {
+func (mr *MockGCMockRecorder) RunAll(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunAll", reflect.TypeOf((*MockGC)(nil).RunAll))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunAll", reflect.TypeOf((*MockGC)(nil).RunAll), arg0)
 }
 
 // Start mocks base method.
-func (m *MockGC) Start() {
+func (m *MockGC) Start(arg0 context.Context) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Start")
+	m.ctrl.Call(m, "Start", arg0)
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockGCMockRecorder) Start() *gomock.Call {
+func (mr *MockGCMockRecorder) Start(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockGC)(nil).Start))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockGC)(nil).Start), arg0)
 }
 
 // Stop mocks base method.

--- a/pkg/gc/gc_test.go
+++ b/pkg/gc/gc_test.go
@@ -17,6 +17,7 @@
 package gc
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"testing"
@@ -120,11 +121,11 @@ func TestGC_Run(t *testing.T) {
 
 				gomock.InOrder(
 					ml.EXPECT().Infof(gomock.Any(), gomock.Eq("foo")).Do(func(template any, args ...any) { wg.Done() }).Times(1),
-					mr.EXPECT().RunGC().Do(func() { wg.Done() }).Return(nil).Times(1),
+					mr.EXPECT().RunGC(context.Background()).Do(func(_ context.Context) { wg.Done() }).Return(nil).Times(1),
 					ml.EXPECT().Infof(gomock.Any(), gomock.Eq("foo")).Do(func(template any, args ...any) { wg.Done() }).Times(1),
 				)
 
-				if err := gc.Run(id); err != nil {
+				if err := gc.Run(context.Background(), id); err != nil {
 					t.Error(err)
 				}
 			},
@@ -144,12 +145,12 @@ func TestGC_Run(t *testing.T) {
 				err := errors.New("bar")
 				gomock.InOrder(
 					ml.EXPECT().Infof(gomock.Any(), gomock.Eq("foo")).Do(func(template any, args ...any) { wg.Done() }).Times(1),
-					mr.EXPECT().RunGC().Do(func() { wg.Done() }).Return(err).Times(1),
+					mr.EXPECT().RunGC(context.Background()).Do(func(_ context.Context) { wg.Done() }).Return(err).Times(1),
 					ml.EXPECT().Errorf(gomock.Any(), gomock.Eq("foo"), gomock.Eq(err)).Do(func(template any, args ...any) { wg.Done() }).Times(1),
 					ml.EXPECT().Infof(gomock.Any(), gomock.Eq("foo")).Do(func(template any, args ...any) { wg.Done() }).Times(1),
 				)
 
-				if err := gc.Run(id); err != nil {
+				if err := gc.Run(context.Background(), id); err != nil {
 					t.Error(err)
 				}
 			},
@@ -163,7 +164,7 @@ func TestGC_Run(t *testing.T) {
 			},
 			run: func(gc GC, id string, ml *MockLogger, mr *MockRunner, t *testing.T) {
 				assert := assert.New(t)
-				assert.EqualError(gc.Run("bar"), "can not find task bar")
+				assert.EqualError(gc.Run(context.Background(), "bar"), "can not find task bar")
 			},
 		},
 	}
@@ -215,11 +216,11 @@ func TestGC_RunAll(t *testing.T) {
 
 				gomock.InOrder(
 					ml.EXPECT().Infof(gomock.Any(), gomock.Eq("foo")).Do(func(template any, args ...any) { wg.Done() }).Times(1),
-					mr.EXPECT().RunGC().Do(func() { wg.Done() }).Return(nil).Times(1),
+					mr.EXPECT().RunGC(context.Background()).Do(func(_ context.Context) { wg.Done() }).Return(nil).Times(1),
 					ml.EXPECT().Infof(gomock.Any(), gomock.Eq("foo")).Do(func(template any, args ...any) { wg.Done() }).Times(1),
 				)
 
-				gc.RunAll()
+				gc.RunAll(context.Background())
 			},
 		},
 		{
@@ -242,12 +243,12 @@ func TestGC_RunAll(t *testing.T) {
 				err := errors.New("baz")
 				gomock.InOrder(
 					ml.EXPECT().Infof(gomock.Any(), gomock.Eq("foo")).Do(func(template any, args ...any) { wg.Done() }).Times(1),
-					mr.EXPECT().RunGC().Do(func() { wg.Done() }).Return(err).Times(1),
+					mr.EXPECT().RunGC(context.Background()).Do(func(_ context.Context) { wg.Done() }).Return(err).Times(1),
 					ml.EXPECT().Errorf(gomock.Any(), gomock.Eq("foo"), gomock.Eq(err)).Do(func(template any, args ...any) { wg.Done() }).Times(1),
 					ml.EXPECT().Infof(gomock.Any(), gomock.Eq("foo")).Do(func(template any, args ...any) { wg.Done() }).Times(1),
 				)
 
-				gc.RunAll()
+				gc.RunAll(context.Background())
 			},
 		},
 	}
@@ -297,6 +298,6 @@ func TestGC_Start(t *testing.T) {
 		wg.Done()
 	}).Times(1)
 
-	gc.Start()
+	gc.Start(context.Background())
 	gc.Stop()
 }

--- a/pkg/gc/runner_mock.go
+++ b/pkg/gc/runner_mock.go
@@ -10,6 +10,7 @@
 package gc
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
@@ -40,15 +41,15 @@ func (m *MockRunner) EXPECT() *MockRunnerMockRecorder {
 }
 
 // RunGC mocks base method.
-func (m *MockRunner) RunGC() error {
+func (m *MockRunner) RunGC(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunGC")
+	ret := m.ctrl.Call(m, "RunGC", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RunGC indicates an expected call of RunGC.
-func (mr *MockRunnerMockRecorder) RunGC() *gomock.Call {
+func (mr *MockRunnerMockRecorder) RunGC(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunGC", reflect.TypeOf((*MockRunner)(nil).RunGC))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunGC", reflect.TypeOf((*MockRunner)(nil).RunGC), arg0)
 }

--- a/pkg/gc/task.go
+++ b/pkg/gc/task.go
@@ -19,12 +19,13 @@
 package gc
 
 import (
+	"context"
 	"errors"
 	"time"
 )
 
 type Runner interface {
-	RunGC() error
+	RunGC(context.Context) error
 }
 
 // Task is an struct used to run GC instance.

--- a/scheduler/resource/persistentcache/host_manager.go
+++ b/scheduler/resource/persistentcache/host_manager.go
@@ -57,7 +57,7 @@ type HostManager interface {
 	LoadRandom(context.Context, int, set.SafeSet[string]) ([]*Host, error)
 
 	// RunGC runs garbage collection.
-	RunGC() error
+	RunGC(context.Context) error
 }
 
 // hostManager contains content for host manager.
@@ -783,8 +783,8 @@ func (h *hostManager) LoadRandom(ctx context.Context, n int, blocklist set.SafeS
 }
 
 // RunGC runs garbage collection.
-func (h *hostManager) RunGC() error {
-	hosts, err := h.LoadAll(context.Background())
+func (h *hostManager) RunGC(ctx context.Context) error {
+	hosts, err := h.LoadAll(ctx)
 	if err != nil {
 		logger.Error("load all hosts failed")
 		return err
@@ -796,7 +796,7 @@ func (h *hostManager) RunGC() error {
 		elapsed := time.Since(host.UpdatedAt)
 		if host.AnnounceInterval > 0 && elapsed > host.AnnounceInterval*2 {
 			host.Log.Info("host has been reclaimed")
-			if err := h.Delete(context.Background(), host.ID); err != nil {
+			if err := h.Delete(ctx, host.ID); err != nil {
 				host.Log.Errorf("delete host failed: %v", err)
 			}
 		}

--- a/scheduler/resource/persistentcache/host_manager_mock.go
+++ b/scheduler/resource/persistentcache/host_manager_mock.go
@@ -101,17 +101,17 @@ func (mr *MockHostManagerMockRecorder) LoadRandom(arg0, arg1, arg2 any) *gomock.
 }
 
 // RunGC mocks base method.
-func (m *MockHostManager) RunGC() error {
+func (m *MockHostManager) RunGC(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunGC")
+	ret := m.ctrl.Call(m, "RunGC", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RunGC indicates an expected call of RunGC.
-func (mr *MockHostManagerMockRecorder) RunGC() *gomock.Call {
+func (mr *MockHostManagerMockRecorder) RunGC(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunGC", reflect.TypeOf((*MockHostManager)(nil).RunGC))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunGC", reflect.TypeOf((*MockHostManager)(nil).RunGC), arg0)
 }
 
 // Store mocks base method.

--- a/scheduler/resource/persistentcache/host_manager_test.go
+++ b/scheduler/resource/persistentcache/host_manager_test.go
@@ -798,7 +798,7 @@ func TestHostManager_RunGC(t *testing.T) {
 				rdb: rdb,
 			}
 
-			err := h.RunGC()
+			err := h.RunGC(context.Background())
 			if tt.expectErr {
 				assert.Error(t, err)
 			} else {

--- a/scheduler/resource/standard/host_manager.go
+++ b/scheduler/resource/standard/host_manager.go
@@ -19,6 +19,7 @@
 package standard
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -59,7 +60,7 @@ type HostManager interface {
 	LoadAll() []*Host
 
 	// Try to reclaim host.
-	RunGC() error
+	RunGC(context.Context) error
 }
 
 // hostManager contains content for host manager.
@@ -163,7 +164,7 @@ func (h *hostManager) LoadRandom(n int, blocklist set.SafeSet[string]) []*Host {
 }
 
 // RunGC tries to reclaim host.
-func (h *hostManager) RunGC() error {
+func (h *hostManager) RunGC(ctx context.Context) error {
 	h.Map.Range(func(_, value any) bool {
 		host, ok := value.(*Host)
 		if !ok {

--- a/scheduler/resource/standard/host_manager_mock.go
+++ b/scheduler/resource/standard/host_manager_mock.go
@@ -10,6 +10,7 @@
 package standard
 
 import (
+	context "context"
 	reflect "reflect"
 
 	set "d7y.io/dragonfly/v2/pkg/container/set"
@@ -123,17 +124,17 @@ func (mr *MockHostManagerMockRecorder) Range(f any) *gomock.Call {
 }
 
 // RunGC mocks base method.
-func (m *MockHostManager) RunGC() error {
+func (m *MockHostManager) RunGC(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunGC")
+	ret := m.ctrl.Call(m, "RunGC", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RunGC indicates an expected call of RunGC.
-func (mr *MockHostManagerMockRecorder) RunGC() *gomock.Call {
+func (mr *MockHostManagerMockRecorder) RunGC(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunGC", reflect.TypeOf((*MockHostManager)(nil).RunGC))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunGC", reflect.TypeOf((*MockHostManager)(nil).RunGC), arg0)
 }
 
 // Store mocks base method.

--- a/scheduler/resource/standard/host_manager_test.go
+++ b/scheduler/resource/standard/host_manager_test.go
@@ -17,6 +17,7 @@
 package standard
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"testing"
@@ -442,7 +443,7 @@ func TestHostManager_RunGC(t *testing.T) {
 				assert := assert.New(t)
 				hostManager.Store(mockHost)
 				mockHost.StorePeer(mockPeer)
-				err := hostManager.RunGC()
+				err := hostManager.RunGC(context.Background())
 				assert.NoError(err)
 
 				host, loaded := hostManager.Load(mockHost.ID)
@@ -461,7 +462,7 @@ func TestHostManager_RunGC(t *testing.T) {
 				mockHost.StorePeer(mockPeer)
 				mockHost.PeerCount.Add(0)
 				mockHost.ConcurrentUploadCount.Add(1)
-				err := hostManager.RunGC()
+				err := hostManager.RunGC(context.Background())
 				assert.NoError(err)
 
 				host, loaded := hostManager.Load(mockHost.ID)
@@ -480,7 +481,7 @@ func TestHostManager_RunGC(t *testing.T) {
 					mockRawSeedHost.ID, mockRawSeedHost.IP, mockRawSeedHost.Hostname,
 					mockRawSeedHost.Port, mockRawSeedHost.DownloadPort, mockRawSeedHost.Type)
 				hostManager.Store(mockSeedHost)
-				err := hostManager.RunGC()
+				err := hostManager.RunGC(context.Background())
 				assert.NoError(err)
 
 				host, loaded := hostManager.Load(mockSeedHost.ID)
@@ -498,7 +499,7 @@ func TestHostManager_RunGC(t *testing.T) {
 				mockHost.AnnounceInterval = 1 * time.Microsecond
 				hostManager.Store(mockHost)
 				mockHost.StorePeer(mockPeer)
-				err := hostManager.RunGC()
+				err := hostManager.RunGC(context.Background())
 				assert.NoError(err)
 
 				mockHost.Peers.Range(func(_, value any) bool {

--- a/scheduler/resource/standard/peer_manager_mock.go
+++ b/scheduler/resource/standard/peer_manager_mock.go
@@ -10,6 +10,7 @@
 package standard
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
@@ -94,17 +95,17 @@ func (mr *MockPeerManagerMockRecorder) Range(f any) *gomock.Call {
 }
 
 // RunGC mocks base method.
-func (m *MockPeerManager) RunGC() error {
+func (m *MockPeerManager) RunGC(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunGC")
+	ret := m.ctrl.Call(m, "RunGC", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RunGC indicates an expected call of RunGC.
-func (mr *MockPeerManagerMockRecorder) RunGC() *gomock.Call {
+func (mr *MockPeerManagerMockRecorder) RunGC(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunGC", reflect.TypeOf((*MockPeerManager)(nil).RunGC))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunGC", reflect.TypeOf((*MockPeerManager)(nil).RunGC), arg0)
 }
 
 // Store mocks base method.

--- a/scheduler/resource/standard/peer_manager_test.go
+++ b/scheduler/resource/standard/peer_manager_test.go
@@ -17,6 +17,7 @@
 package standard
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"testing"
@@ -339,7 +340,7 @@ func TestPeerManager_RunGC(t *testing.T) {
 				assert := assert.New(t)
 				peerManager.Store(mockPeer)
 				mockPeer.FSM.SetState(PeerStateSucceeded)
-				err := peerManager.RunGC()
+				err := peerManager.RunGC(context.Background())
 				assert.NoError(err)
 
 				peer, loaded := peerManager.Load(mockPeer.ID)
@@ -362,14 +363,14 @@ func TestPeerManager_RunGC(t *testing.T) {
 				assert := assert.New(t)
 				peerManager.Store(mockPeer)
 				mockPeer.Host.DisableShared = true
-				err := peerManager.RunGC()
+				err := peerManager.RunGC(context.Background())
 				assert.NoError(err)
 
 				peer, loaded := peerManager.Load(mockPeer.ID)
 				assert.Equal(loaded, true)
 				assert.Equal(peer.FSM.Current(), PeerStateLeave)
 
-				err = peerManager.RunGC()
+				err = peerManager.RunGC(context.Background())
 				assert.NoError(err)
 
 				_, loaded = peerManager.Load(mockPeer.ID)
@@ -391,14 +392,14 @@ func TestPeerManager_RunGC(t *testing.T) {
 				assert := assert.New(t)
 				peerManager.Store(mockPeer)
 				mockPeer.FSM.SetState(PeerStateRunning)
-				err := peerManager.RunGC()
+				err := peerManager.RunGC(context.Background())
 				assert.NoError(err)
 
 				peer, loaded := peerManager.Load(mockPeer.ID)
 				assert.Equal(loaded, true)
 				assert.Equal(peer.FSM.Current(), PeerStateLeave)
 
-				err = peerManager.RunGC()
+				err = peerManager.RunGC(context.Background())
 				assert.NoError(err)
 
 				_, loaded = peerManager.Load(mockPeer.ID)
@@ -420,14 +421,14 @@ func TestPeerManager_RunGC(t *testing.T) {
 				assert := assert.New(t)
 				peerManager.Store(mockPeer)
 				mockPeer.FSM.SetState(PeerStateBackToSource)
-				err := peerManager.RunGC()
+				err := peerManager.RunGC(context.Background())
 				assert.NoError(err)
 
 				peer, loaded := peerManager.Load(mockPeer.ID)
 				assert.Equal(loaded, true)
 				assert.Equal(peer.FSM.Current(), PeerStateLeave)
 
-				err = peerManager.RunGC()
+				err = peerManager.RunGC(context.Background())
 				assert.NoError(err)
 
 				_, loaded = peerManager.Load(mockPeer.ID)
@@ -449,14 +450,14 @@ func TestPeerManager_RunGC(t *testing.T) {
 				assert := assert.New(t)
 				peerManager.Store(mockPeer)
 				mockPeer.FSM.SetState(PeerStateSucceeded)
-				err := peerManager.RunGC()
+				err := peerManager.RunGC(context.Background())
 				assert.NoError(err)
 
 				peer, loaded := peerManager.Load(mockPeer.ID)
 				assert.Equal(loaded, true)
 				assert.Equal(peer.FSM.Current(), PeerStateLeave)
 
-				err = peerManager.RunGC()
+				err = peerManager.RunGC(context.Background())
 				assert.NoError(err)
 
 				_, loaded = peerManager.Load(mockPeer.ID)
@@ -478,14 +479,14 @@ func TestPeerManager_RunGC(t *testing.T) {
 				assert := assert.New(t)
 				peerManager.Store(mockPeer)
 				mockPeer.FSM.SetState(PeerStateSucceeded)
-				err := peerManager.RunGC()
+				err := peerManager.RunGC(context.Background())
 				assert.NoError(err)
 
 				peer, loaded := peerManager.Load(mockPeer.ID)
 				assert.Equal(loaded, true)
 				assert.Equal(peer.FSM.Current(), PeerStateLeave)
 
-				err = peerManager.RunGC()
+				err = peerManager.RunGC(context.Background())
 				assert.NoError(err)
 
 				_, loaded = peerManager.Load(mockPeer.ID)
@@ -507,7 +508,7 @@ func TestPeerManager_RunGC(t *testing.T) {
 				assert := assert.New(t)
 				peerManager.Store(mockPeer)
 				mockPeer.FSM.SetState(PeerStateFailed)
-				err := peerManager.RunGC()
+				err := peerManager.RunGC(context.Background())
 				assert.NoError(err)
 
 				peer, loaded := peerManager.Load(mockPeer.ID)
@@ -532,7 +533,7 @@ func TestPeerManager_RunGC(t *testing.T) {
 				mockPeer.FSM.SetState(PeerStateSucceeded)
 				mockPeer.Task.DeletePeer(mockPeer.ID)
 
-				err := peerManager.RunGC()
+				err := peerManager.RunGC(context.Background())
 				assert.NoError(err)
 
 				_, loaded := peerManager.Load(mockPeer.ID)
@@ -559,7 +560,7 @@ func TestPeerManager_RunGC(t *testing.T) {
 					mockPeer.Task.StorePeer(peer)
 				}
 
-				err := peerManager.RunGC()
+				err := peerManager.RunGC(context.Background())
 				assert.NoError(err)
 
 				_, loaded := peerManager.Load(mockPeer.ID)

--- a/scheduler/resource/standard/task_manager.go
+++ b/scheduler/resource/standard/task_manager.go
@@ -19,6 +19,7 @@
 package standard
 
 import (
+	"context"
 	"sync"
 
 	pkggc "d7y.io/dragonfly/v2/pkg/gc"
@@ -51,7 +52,7 @@ type TaskManager interface {
 	Range(f func(any, any) bool)
 
 	// Try to reclaim task.
-	RunGC() error
+	RunGC(context.Context) error
 }
 
 // taskManager contains content for task manager.
@@ -113,7 +114,7 @@ func (t *taskManager) Range(f func(key, value any) bool) {
 }
 
 // Try to reclaim task.
-func (t *taskManager) RunGC() error {
+func (t *taskManager) RunGC(ctx context.Context) error {
 	t.Map.Range(func(_, value any) bool {
 		task, ok := value.(*Task)
 		if !ok {

--- a/scheduler/resource/standard/task_manager_mock.go
+++ b/scheduler/resource/standard/task_manager_mock.go
@@ -10,6 +10,7 @@
 package standard
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
@@ -94,17 +95,17 @@ func (mr *MockTaskManagerMockRecorder) Range(f any) *gomock.Call {
 }
 
 // RunGC mocks base method.
-func (m *MockTaskManager) RunGC() error {
+func (m *MockTaskManager) RunGC(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunGC")
+	ret := m.ctrl.Call(m, "RunGC", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RunGC indicates an expected call of RunGC.
-func (mr *MockTaskManagerMockRecorder) RunGC() *gomock.Call {
+func (mr *MockTaskManagerMockRecorder) RunGC(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunGC", reflect.TypeOf((*MockTaskManager)(nil).RunGC))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunGC", reflect.TypeOf((*MockTaskManager)(nil).RunGC), arg0)
 }
 
 // Store mocks base method.

--- a/scheduler/resource/standard/task_manager_test.go
+++ b/scheduler/resource/standard/task_manager_test.go
@@ -17,6 +17,7 @@
 package standard
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"testing"
@@ -313,7 +314,7 @@ func TestTaskManager_RunGC(t *testing.T) {
 			expect: func(t *testing.T, taskManager TaskManager, mockTask *Task, mockPeer *Peer) {
 				assert := assert.New(t)
 				taskManager.Store(mockTask)
-				err := taskManager.RunGC()
+				err := taskManager.RunGC(context.Background())
 				assert.NoError(err)
 				_, loaded := taskManager.Load(mockTask.ID)
 				assert.Equal(loaded, false)
@@ -328,7 +329,7 @@ func TestTaskManager_RunGC(t *testing.T) {
 				assert := assert.New(t)
 				taskManager.Store(mockTask)
 				mockTask.StorePeer(mockPeer)
-				err := taskManager.RunGC()
+				err := taskManager.RunGC(context.Background())
 				assert.NoError(err)
 
 				task, loaded := taskManager.Load(mockTask.ID)

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -235,7 +235,7 @@ func (s *Server) Serve() error {
 	}()
 
 	// Serve GC.
-	s.gc.Start()
+	s.gc.Start(context.Background())
 	logger.Info("gc start successfully")
 
 	// Serve Job.


### PR DESCRIPTION
This pull request introduces changes to the garbage collection (GC) system across multiple files to add support for `context.Context`. The updates ensure that GC operations are context-aware, allowing for better control and cancellation of long-running tasks. Below are the most important changes grouped by theme.

### Core GC System Updates:
* Updated the `GC` interface in `pkg/gc/gc.go` to include `context.Context` as a parameter for methods like `Run`, `RunAll`, `Start`, and their implementations. This ensures all GC operations are context-aware. [[1]](diffhunk://#diff-ab4510a5b43b75ecc8656c954f48b486a78fff7c141823159c63c256aa4df20cL33-R40) [[2]](diffhunk://#diff-ab4510a5b43b75ecc8656c954f48b486a78fff7c141823159c63c256aa4df20cL86-R109) [[3]](diffhunk://#diff-ab4510a5b43b75ecc8656c954f48b486a78fff7c141823159c63c256aa4df20cL123-R138)
* Modified the `Runner` interface in `pkg/gc/task.go` to include `context.Context` in the `RunGC` method.

### Integration with GC Consumers:
* Updated `RunGC` methods in `manager/gc/audit.go`, `manager/gc/job.go`, and `manager/manager.go` to accept `context.Context` as a parameter. [[1]](diffhunk://#diff-f6991c9ca09a3884ff8508562a8f6b5400dbf2b88eddd3df6ac28ec404957dedL60-R61) [[2]](diffhunk://#diff-f072844f925732f5f4176bbe063a9a4b83acbfd8bc34d011f4338f18d3a8c7a8L60-R61) [[3]](diffhunk://#diff-f679b61276b44dc3f4712950536707c0389ee4c536fc29837c0202c6e81c1bbfL275-R275)
* Refactored `HostManager` interfaces and implementations in `scheduler/resource/persistentcache/host_manager.go` and `scheduler/resource/standard/host_manager.go` to pass `context.Context` during GC operations. [[1]](diffhunk://#diff-cab2c0c5532854f2dd2b4557cc339dd396bccb1ea3a66af3ffc13821da7e3a8dL60-R60) [[2]](diffhunk://#diff-cab2c0c5532854f2dd2b4557cc339dd396bccb1ea3a66af3ffc13821da7e3a8dL786-R787) [[3]](diffhunk://#diff-e84ba6d14eb1fc15eb33c775b2b730f3d0b9ac197ccdeb60318eeaeed4e0fefeL62-R63) [[4]](diffhunk://#diff-e84ba6d14eb1fc15eb33c775b2b730f3d0b9ac197ccdeb60318eeaeed4e0fefeL166-R167)

### Mock and Test Updates:
* Updated mock implementations in `pkg/gc/gc_mock.go`, `pkg/gc/runner_mock.go`, `scheduler/resource/persistentcache/host_manager_mock.go`, and `scheduler/resource/standard/host_manager_mock.go` to include `context.Context` in mocked `RunGC` and related methods. [[1]](diffhunk://#diff-7ad7c7f2745eb8c035fe817294f2873e796f55703faec78e35809587dac2fe7fL57-R92) [[2]](diffhunk://#diff-045d7cbab45594e7149e031174a920c8f76b886f3529b22af21827c9fcd356afL43-R54) [[3]](diffhunk://#diff-9f2bcde58d88aef8ed164db2edfeffd30ef97b558442cabfa44667a3c056db63L104-R114) [[4]](diffhunk://#diff-dece41a20c146a4c6122f71fe58ab4e8b525533981dd5cd700d11372d0ec7765L126-R137)
* Adjusted test cases in `pkg/gc/gc_test.go`, `scheduler/resource/persistentcache/host_manager_test.go`, and `scheduler/resource/standard/host_manager_test.go` to pass `context.Background()` to GC-related methods. [[1]](diffhunk://#diff-241c46783ee202aad3d087cfdb3545fe90341765c91bd4960c3774c3b127c465L123-R128) [[2]](diffhunk://#diff-27887d44eb06aef772c55d766bf7f4f2f13753b5ef281c3785b2478a100f0780L801-R801) [[3]](diffhunk://#diff-cb7d43d2e11d6ee638107ac352fd666fbdab9f30c1e3bb9ca77c395b2cd2fdfaL445-R446)

These changes improve the flexibility and robustness of the GC system by enabling context propagation, which is critical for modern concurrent applications.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
