### PR TITLE
fix: add the authorization for get configs API

### DIFF
--- a/manager/router/router.go
+++ b/manager/router/router.go
@@ -204,11 +204,11 @@ func Init(cfg *config.Config, logDir string, service service.Service, database *
 	bucket.GET("", h.GetBuckets)
 
 	// Config.
-	config := apiv1.Group("/configs")
-	config.POST("", jwt.MiddlewareFunc(), rbac, h.CreateConfig)
-	config.DELETE(":id", jwt.MiddlewareFunc(), rbac, h.DestroyConfig)
-	config.PATCH(":id", jwt.MiddlewareFunc(), rbac, h.UpdateConfig)
-	config.GET(":id", jwt.MiddlewareFunc(), rbac, h.GetConfig)
+	config := apiv1.Group("/configs", jwt.MiddlewareFunc(), rbac)
+	config.POST("", h.CreateConfig)
+	config.DELETE(":id", h.DestroyConfig)
+	config.PATCH(":id", h.UpdateConfig)
+	config.GET(":id", h.GetConfig)
 	config.GET("", h.GetConfigs)
 
 	// TODO Add auth to the following routes and fix the tests.


### PR DESCRIPTION
This pull request refactors the routing logic for the `/configs` API endpoints in `manager/router/router.go` to simplify middleware handling. The most important change consolidates the `jwt.MiddlewareFunc()` and `rbac` middleware into the group definition, reducing redundancy in individual route declarations.

### Routing refactor:
* Consolidated `jwt.MiddlewareFunc()` and `rbac` middleware into the group definition for `/configs` API endpoints, simplifying the route definitions. Individual routes no longer explicitly include these middleware calls. (`[manager/router/router.goL207-R211](diffhunk://#diff-accc11d77962a73f2df2837787ed0d45a6a0d5ca6a020c3eec7726f447db2d9cL207-R211)`)<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
