### PR TITLE
feat: update machinery to v1.10.14 and adjust Redis config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/docker/docker v28.1.1+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-units v0.4.0
-	github.com/dragonflyoss/machinery v1.10.13
+	github.com/dragonflyoss/machinery v1.10.14
 	github.com/elastic/go-freelru v0.16.0
 	github.com/fsouza/fake-gcs-server v1.52.2
 	github.com/gaius-qi/ping v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -441,8 +441,8 @@ github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1 h1:ZClxb8laGDf5arX
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
-github.com/dragonflyoss/machinery v1.10.13 h1:0iixzz4rn+oDIDHLz8sj5sQ5veTVg+Z1TOVKm2nnWv8=
-github.com/dragonflyoss/machinery v1.10.13/go.mod h1:YUhavio0FVIsY9e3mVrj7weroc08gWm1hiauPDu1S28=
+github.com/dragonflyoss/machinery v1.10.14 h1:VoR+ti+PsradoaVTIBT8rC8afXkEIzBp4G/+5m32Nrc=
+github.com/dragonflyoss/machinery v1.10.14/go.mod h1:YUhavio0FVIsY9e3mVrj7weroc08gWm1hiauPDu1S28=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/internal/job/constants.go
+++ b/internal/job/constants.go
@@ -40,12 +40,12 @@ const (
 // Machinery server configuration.
 const (
 	DefaultResultsExpireIn             = 86400
-	DefaultRedisMaxIdle                = 0
-	DefaultRedisMaxActive              = 300
+	DefaultRedisMaxIdle                = 10
+	DefaultRedisMaxActive              = 50
 	DefaultRedisIdleTimeout            = 30
 	DefaultRedisReadTimeout            = 60
 	DefaultRedisWriteTimeout           = 60
 	DefaultRedisConnectTimeout         = 60
-	DefaultRedisNormalTasksPollPeriod  = 2000
+	DefaultRedisNormalTasksPollPeriod  = 2500
 	DefaultRedisDelayedTasksPollPeriod = 500
 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes updates to dependencies and configuration constants to improve performance and compatibility. The most important changes involve upgrading the `dragonflyoss/machinery` dependency and adjusting Redis-related configuration defaults.

### Dependency Updates:
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L26-R26): Upgraded `github.com/dragonflyoss/machinery` from v1.10.13 to v1.10.14 for compatibility and potential bug fixes.

### Configuration Changes:
* `internal/job/constants.go`: Adjusted Redis configuration defaults:
  - Increased `DefaultRedisMaxIdle` from 0 to 10 and reduced `DefaultRedisMaxActive` from 300 to 50 to optimize connection pooling.
  - Increased `DefaultRedisNormalTasksPollPeriod` from 2000ms to 2500ms for better task polling efficiency.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
