### PR TITLE
feat: add headers for tracing

### DIFF
--- a/cmd/dependency/base/option.go
+++ b/cmd/dependency/base/option.go
@@ -29,4 +29,6 @@ type TracingConfig struct {
 	Addr string `yaml:"addr" mapstructure:"addr"`
 	// ServiceName is the name of the service for tracing.
 	ServiceName string `yaml:"service-name" mapstructure:"service-name"`
+	// Headers are additional headers to be sent with tracing requests.
+	Headers map[string]string `yaml:"headers" mapstructure:"headers"`
 }

--- a/cmd/dependency/dependency.go
+++ b/cmd/dependency/dependency.go
@@ -150,7 +150,7 @@ func initJaegerTracer(ctx context.Context, tracingConfig base.TracingConfig) (fu
 		return nil, fmt.Errorf("could not create gRPC connection to collector: %w", err)
 	}
 
-	exporter, err := otlptracegrpc.New(ctx, otlptracegrpc.WithGRPCConn(conn))
+	exporter, err := otlptracegrpc.New(ctx, otlptracegrpc.WithGRPCConn(conn), otlptracegrpc.WithHeaders(tracingConfig.Headers))
 	if err != nil {
 		return nil, fmt.Errorf("could not create trace exporter: %w", err)
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces support for custom headers in tracing requests by extending the tracing configuration and updating the tracer initialization logic. The most important changes include adding a new `Headers` field to the `TracingConfig` struct and utilizing this field in the Jaeger tracer setup.

### Enhancements to tracing configuration:

* [`cmd/dependency/base/option.go`](diffhunk://#diff-fe8a3936e9c6af18d24c9ee30eceb0a250c0cd608014ccf890b90c226e10ba63R32-R33): Added a new `Headers` field to the `TracingConfig` struct to allow specifying additional headers for tracing requests.

### Updates to tracer initialization:

* [`cmd/dependency/dependency.go`](diffhunk://#diff-3950f049f495b4c8f37427cc77a764da5c5b4e9f33ac41ab45ced60bea085196L153-R153): Modified the `initJaegerTracer` function to pass the custom headers from the `TracingConfig.Headers` field to the trace exporter using `otlptracegrpc.WithHeaders`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
