### PR TITLE
Tune dragonfly to Remove Old Entries & Use Longtext to fit larger warming jobs

### DIFF
--- a/manager/models/models.go
+++ b/manager/models/models.go
@@ -88,7 +88,7 @@ func (m JSONMap) GormDataType() string {
 }
 
 func (JSONMap) GormDBDataType(db *gorm.DB, field *schema.Field) string {
-	return "text"
+	return "longtext"
 }
 
 type Array []string
@@ -137,5 +137,5 @@ func (Array) GormDataType() string {
 }
 
 func (Array) GormDBDataType(db *gorm.DB, field *schema.Field) string {
-	return "text"
+	return "longtext"
 }

--- a/manager/rpcserver/manager_server_v2.go
+++ b/manager/rpcserver/manager_server_v2.go
@@ -237,9 +237,9 @@ func (s *managerServerV2) UpdateSeedPeer(ctx context.Context, req *managerv2.Upd
 	log := logger.WithHostnameAndIP(req.Hostname, req.Ip)
 	seedPeer := models.SeedPeer{}
 	if err := s.db.WithContext(ctx).First(&seedPeer, models.SeedPeer{
-		Hostname:          req.Hostname,
-		IP:                req.Ip,
-		Port:              req.Port,
+		Hostname: req.Hostname,
+		// IP:                req.Ip,
+		// Port:              req.Port,
 		SeedPeerClusterID: uint(req.SeedPeerClusterId),
 	}).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -451,9 +451,9 @@ func (s *managerServerV2) UpdateScheduler(ctx context.Context, req *managerv2.Up
 	log := logger.WithHostnameAndIP(req.Hostname, req.Ip)
 	scheduler := models.Scheduler{}
 	if err := s.db.WithContext(ctx).First(&scheduler, models.Scheduler{
-		Hostname:           req.Hostname,
-		IP:                 req.Ip,
-		Port:               req.Port,
+		Hostname: req.Hostname,
+		// IP:                 req.Ip, // k8s pods will not have stable IPs. I need it to update the existing record...
+		// Port:               req.Port, // same with port
 		SchedulerClusterID: uint(req.SchedulerClusterId),
 	}).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/manager/rpcserver/manager_server_v2.go
+++ b/manager/rpcserver/manager_server_v2.go
@@ -237,9 +237,7 @@ func (s *managerServerV2) UpdateSeedPeer(ctx context.Context, req *managerv2.Upd
 	log := logger.WithHostnameAndIP(req.Hostname, req.Ip)
 	seedPeer := models.SeedPeer{}
 	if err := s.db.WithContext(ctx).First(&seedPeer, models.SeedPeer{
-		Hostname: req.Hostname,
-		// IP:                req.Ip,
-		// Port:              req.Port,
+		Hostname:          req.Hostname,
 		SeedPeerClusterID: uint(req.SeedPeerClusterId),
 	}).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -451,9 +449,7 @@ func (s *managerServerV2) UpdateScheduler(ctx context.Context, req *managerv2.Up
 	log := logger.WithHostnameAndIP(req.Hostname, req.Ip)
 	scheduler := models.Scheduler{}
 	if err := s.db.WithContext(ctx).First(&scheduler, models.Scheduler{
-		Hostname: req.Hostname,
-		// IP:                 req.Ip, // k8s pods will not have stable IPs. I need it to update the existing record...
-		// Port:               req.Port, // same with port
+		Hostname:           req.Hostname,
 		SchedulerClusterID: uint(req.SchedulerClusterId),
 	}).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {


### PR DESCRIPTION
* use longtext to fit larger clusters

* fix scheduler and seed-client register logic

<!--- Provide a general summary of your changes in the Title above -->

## Description

This change updates the manager peer & scheduler registration logic to use more stable fields, ie. host names as opposed to IPs which can change when a pod is rescheduled.

Also use longtext instead of just text so that warming jobs don't fail in large clusters. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Maybe https://github.com/dragonflyoss/client/issues/1116

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Pod IPs will change. Pods will be rescheduled to other nodes, etc. When manager returns list of schedulers, it grabs the list in order. Thus it will ALWAYS return a stale scheduler / seed client address. The scheduler/seed reregistration SHOULD over rid the OLD entries.

Additionally jobs may be larger in pieces. This won't fit in text. Fit it in longtext instead.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
