### PR TITLE
feat: add --log-level support for manager and scheduler

### DIFF
--- a/build/package/nfpm/config/dfget.yaml
+++ b/build/package/nfpm/config/dfget.yaml
@@ -26,6 +26,7 @@ scheduler:
 
 # when enabled, pprof will be enabled,
 verbose: true
+log-level: debug
 console: false
 
 # current host info used for scheduler

--- a/cmd/dependency/base/option.go
+++ b/cmd/dependency/base/option.go
@@ -19,6 +19,7 @@ package base
 type Options struct {
 	Console   bool          `yaml:"console" mapstructure:"console"`
 	Verbose   bool          `yaml:"verbose" mapstructure:"verbose"`
+	LogLevel  string        `yaml:"log-level" mapstructure:"log-level"`
 	PProfPort int           `yaml:"pprof-port" mapstructure:"pprof-port"`
 	Tracing   TracingConfig `yaml:"tracing" mapstructure:"tracing"`
 }

--- a/cmd/dependency/dependency.go
+++ b/cmd/dependency/dependency.go
@@ -72,6 +72,7 @@ func InitCommandAndConfig(cmd *cobra.Command, useConfigFile bool, config any) {
 		flags := cmd.PersistentFlags()
 		flags.Bool("console", false, "whether logger output records to the stdout")
 		flags.Bool("verbose", false, "whether logger use debug level")
+		flags.String("log-level", "", "use specific log level(debug, info, warn, error), take precedence over verbose flag")
 		flags.Int("pprof-port", -1, "listen port for pprof, 0 represents random port")
 		flags.String("config", "", fmt.Sprintf("the path of configuration file with yaml extension name, default is %s, it can also be set by env var: %s", filepath.Join(dfpath.DefaultConfigDir, rootName+".yaml"), strings.ToUpper(rootName+"_config")))
 

--- a/cmd/dfcache/cmd/root.go
+++ b/cmd/dfcache/cmd/root.go
@@ -142,7 +142,7 @@ func runDfcacheSubcmd(ctx context.Context, cmdName string, args []string) error 
 		MaxBackups: dfcacheConfig.LogMaxBackups}
 
 	// Initialize logger
-	if err := logger.InitDfcache(dfcacheConfig.Console, d.LogDir(), rotateConfig); err != nil {
+	if err := logger.InitDfcache(dfcacheConfig.Verbose, dfcacheConfig.LogLevel, d.LogDir(), rotateConfig); err != nil {
 		return fmt.Errorf("init client dfcache logger: %w", err)
 	}
 	logger.Infof("version:\n%s", version.Version())

--- a/cmd/dfget/cmd/daemon.go
+++ b/cmd/dfget/cmd/daemon.go
@@ -47,8 +47,8 @@ var (
 var daemonCmd = &cobra.Command{
 	Use:   "daemon",
 	Short: "start the client daemon of dragonfly",
-	Long: `client daemon is mainly responsible for transmitting blocks between peers 
-and putting the completed file into the specified target path. at the same time, 
+	Long: `client daemon is mainly responsible for transmitting blocks between peers
+and putting the completed file into the specified target path. at the same time,
 it supports container engine, wget and other downloading tools through proxy function.`,
 	Args:               cobra.NoArgs,
 	DisableAutoGenTag:  true,
@@ -80,7 +80,7 @@ it supports container engine, wget and other downloading tools through proxy fun
 			MaxBackups: cfg.LogMaxBackups}
 
 		// Initialize logger
-		if err := logger.InitDaemon(cfg.Verbose, cfg.Console, d.LogDir(), rotateConfig); err != nil {
+		if err := logger.InitDaemon(cfg.Verbose, cfg.LogLevel, cfg.Console, d.LogDir(), rotateConfig); err != nil {
 			return fmt.Errorf("init client daemon logger: %w", err)
 		}
 		logger.RedirectStdoutAndStderr(cfg.Console, path.Join(d.LogDir(), types.DaemonName))

--- a/cmd/dfget/cmd/root.go
+++ b/cmd/dfget/cmd/root.go
@@ -94,7 +94,7 @@ var rootCmd = &cobra.Command{
 			MaxBackups: dfgetConfig.LogMaxBackups}
 
 		// Initialize logger
-		if err := logger.InitDfget(dfgetConfig.Verbose, dfgetConfig.Console, d.LogDir(), rotateConfig); err != nil {
+		if err := logger.InitDfget(dfgetConfig.Verbose, dfgetConfig.LogLevel, dfgetConfig.Console, d.LogDir(), rotateConfig); err != nil {
 			return fmt.Errorf("init client dfget logger: %w", err)
 		}
 

--- a/cmd/manager/cmd/root.go
+++ b/cmd/manager/cmd/root.go
@@ -41,7 +41,7 @@ var (
 var rootCmd = &cobra.Command{
 	Use:   "manager",
 	Short: "The central manager of dragonfly.",
-	Long: `manager is a long-running process and is mainly responsible 
+	Long: `manager is a long-running process and is mainly responsible
 for managing schedulers and seed peers, offering http apis and portal, etc.`,
 	Args:              cobra.NoArgs,
 	DisableAutoGenTag: true,
@@ -72,7 +72,7 @@ for managing schedulers and seed peers, offering http apis and portal, etc.`,
 			MaxBackups: cfg.Server.LogMaxBackups}
 
 		// Initialize logger.
-		if err := logger.InitManager(cfg.Verbose, cfg.Console, d.LogDir(), rotateConfig); err != nil {
+		if err := logger.InitManager(cfg.Verbose, cfg.LogLevel, cfg.Console, d.LogDir(), rotateConfig); err != nil {
 			return fmt.Errorf("init manager logger: %w", err)
 		}
 		logger.RedirectStdoutAndStderr(cfg.Console, path.Join(d.LogDir(), types.ManagerName))

--- a/cmd/scheduler/cmd/root.go
+++ b/cmd/scheduler/cmd/root.go
@@ -41,7 +41,7 @@ var (
 var rootCmd = &cobra.Command{
 	Use:   "scheduler",
 	Short: "the scheduler of dragonfly",
-	Long: `Scheduler is a long-running process which receives and manages download tasks from the dfdaemon, notify the seed peer to return to the source, 
+	Long: `Scheduler is a long-running process which receives and manages download tasks from the dfdaemon, notify the seed peer to return to the source,
 generate and maintain a P2P network during the download process, and push suitable download nodes to the dfdaemon`,
 	Args:              cobra.NoArgs,
 	DisableAutoGenTag: true,
@@ -72,7 +72,7 @@ generate and maintain a P2P network during the download process, and push suitab
 			MaxBackups: cfg.Server.LogMaxBackups}
 
 		// Initialize logger.
-		if err := logger.InitScheduler(cfg.Verbose, cfg.Console, d.LogDir(), rotateConfig); err != nil {
+		if err := logger.InitScheduler(cfg.Verbose, cfg.LogLevel, cfg.Console, d.LogDir(), rotateConfig); err != nil {
 			return fmt.Errorf("init scheduler logger: %w", err)
 		}
 		logger.RedirectStdoutAndStderr(cfg.Console, path.Join(d.LogDir(), types.SchedulerName))

--- a/deploy/docker-compose/template/manager.template.yaml
+++ b/deploy/docker-compose/template/manager.template.yaml
@@ -165,6 +165,9 @@ console: false
 # Whether to enable debug level logger and enable pprof.
 verbose: true
 
+# Use specific log level(debug, info, warn, error), take precedence over verbose flag.
+# log-level: debug
+
 # Listen port for pprof, only valid when the verbose option is true, default is -1.
 pprof-port: -1
 

--- a/deploy/docker-compose/template/scheduler.template.yaml
+++ b/deploy/docker-compose/template/scheduler.template.yaml
@@ -181,6 +181,9 @@ console: false
 # Whether to enable debug level logger and enable pprof.
 verbose: true
 
+# Use specific log level(debug, info, warn, error), take precedence over verbose flag.
+# log-level: debug
+
 # Listen port for pprof, only valid when the verbose option is true, default is -1.
 pprof-port: -1
 

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -34,7 +34,7 @@ func SetGrpcLevel(level zapcore.Level) {
 }
 
 // SetupDaemon sets daemon log config: path, console
-func SetupDaemon(logDir string, verbose bool, console bool, rotateConfig logger.LogRotateConfig) error {
+func SetupDaemon(logDir string, verbose bool, logLevel string, console bool, rotateConfig logger.LogRotateConfig) error {
 	var options []dfpath.Option
 	if logDir != "" {
 		options = append(options, dfpath.WithLogDir(logDir))
@@ -45,5 +45,5 @@ func SetupDaemon(logDir string, verbose bool, console bool, rotateConfig logger.
 		return err
 	}
 
-	return logger.InitDaemon(verbose, console, d.LogDir(), rotateConfig)
+	return logger.InitDaemon(verbose, logLevel, console, d.LogDir(), rotateConfig)
 }

--- a/scheduler/resource/standard/peer_manager.go
+++ b/scheduler/resource/standard/peer_manager.go
@@ -212,7 +212,7 @@ func (p *peerManager) RunGC(ctx context.Context) error {
 		if elapsed > p.hostTTL {
 			peer.Log.Info("peer elapsed exceeds the host ttl, causing the peer to leave")
 			if err := peer.FSM.Event(ctx, PeerEventLeave); err != nil {
-				peer.Log.Errorf("peer fsm event failed: %s", err.Error())
+				peer.Log.Infof("peer fsm event failed: %s", err.Error())
 				return true
 			}
 


### PR DESCRIPTION
## Description

This change adds `--log-level` option for manager and scheduler, with empty string as default value, so it won't affect existing depoyments. When specify `--log-level` and `--verbose` at the same time, `--log-level` will take precedence.

Note that since cmd and log functionality use shared code, so dfcahe and dfget are also affected.

Config files containing `verbose: true` have been updated, but not those under `testdata/`.

## Related Issue

https://github.com/dragonflyoss/dragonfly/issues/2670

## Motivation and Context

We see a lot of logs in our environment, it would be nice to be able to control log level of manager and scheduler so we can ignore not important logs and reduce log storage cost.

Also, the `peer fsm event failed: event Leave inappropriate because previous transition did not complete` log is too frequent, better to change its level to INFO so it can be ignored.

## Screenshots (if appropriate)

## Types of changes


- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. **I plan to update https://github.com/dragonflyoss/d7y.io/tree/main/docs/reference/commands after this PR is merged.**
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
