### PR TITLE
feat: remove unique index uk_casbin_rule from CasbinRule model to resolve permission issue

### DIFF
--- a/manager/models/casbin_rule.go
+++ b/manager/models/casbin_rule.go
@@ -18,11 +18,11 @@ package models
 
 type CasbinRule struct {
 	ID    uint   `gorm:"primaryKey;autoIncrement;comment:id"`
-	Ptype string `gorm:"type:varchar(100);default:NULL;uniqueIndex:uk_casbin_rule;comment:policy type"`
-	V0    string `gorm:"type:varchar(100);default:NULL;uniqueIndex:uk_casbin_rule;comment:v0"`
-	V1    string `gorm:"type:varchar(100);default:NULL;uniqueIndex:uk_casbin_rule;comment:v1"`
-	V2    string `gorm:"type:varchar(100);default:NULL;uniqueIndex:uk_casbin_rule;comment:v2"`
-	V3    string `gorm:"type:varchar(100);default:NULL;uniqueIndex:uk_casbin_rule;comment:v3"`
-	V4    string `gorm:"type:varchar(100);default:NULL;uniqueIndex:uk_casbin_rule;comment:v4"`
-	V5    string `gorm:"type:varchar(100);default:NULL;uniqueIndex:uk_casbin_rule;comment:v5"`
+	Ptype string `gorm:"type:varchar(100);default:NULL;comment:policy type"`
+	V0    string `gorm:"type:varchar(100);default:NULL;comment:v0"`
+	V1    string `gorm:"type:varchar(100);default:NULL;comment:v1"`
+	V2    string `gorm:"type:varchar(100);default:NULL;comment:v2"`
+	V3    string `gorm:"type:varchar(100);default:NULL;comment:v3"`
+	V4    string `gorm:"type:varchar(100);default:NULL;comment:v4"`
+	V5    string `gorm:"type:varchar(100);default:NULL;comment:v5"`
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request modifies the `CasbinRule` model in `manager/models/casbin_rule.go` to remove the `uniqueIndex:uk_casbin_rule` constraint from several fields. This change simplifies the database schema by eliminating unique indexing on these fields.

Schema changes:

* [`manager/models/casbin_rule.go`](diffhunk://#diff-3ee2d1ebf3c2f39fc7042650d20fa347119dfb726b3198879b6e43bee4b64826L21-R27): Removed the `uniqueIndex:uk_casbin_rule` constraint from the `Ptype`, `V0`, `V1`, `V2`, `V3`, `V4`, and `V5` fields in the `CasbinRule` model.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
