### PR TITLE
feat: support HTTPS protocol for otel

### DIFF
--- a/cmd/dependency/base/option.go
+++ b/cmd/dependency/base/option.go
@@ -32,6 +32,9 @@ type TracingConfig struct {
 	// Endpoint is the endpoint to report tracing log, example: "localhost:4317".
 	Endpoint string `yaml:"endpoint" mapstructure:"endpoint"`
 
+	// Path is the path to the tracing server, example: "/v1/traces" if the protocol is "http" or "https".
+	Path string `yaml:"path" mapstructure:"path"`
+
 	// ServiceName is the name of the service for tracing.
 	ServiceName string `yaml:"service-name" mapstructure:"service-name"`
 

--- a/cmd/dependency/dependency.go
+++ b/cmd/dependency/dependency.go
@@ -151,9 +151,13 @@ func initJaegerTracer(ctx context.Context, tracingConfig base.TracingConfig) (fu
 	)
 
 	switch tracingConfig.Protocol {
-	case "http", "https":
-		addr := fmt.Sprintf("%s://%s", tracingConfig.Protocol, tracingConfig.Endpoint)
-		exporter, err = otlptracehttp.New(ctx, otlptracehttp.WithEndpointURL(addr), otlptracehttp.WithInsecure())
+	case "http":
+		exporter, err = otlptracehttp.New(ctx, otlptracehttp.WithEndpoint(tracingConfig.Endpoint), otlptracehttp.WithURLPath(tracingConfig.Path), otlptracehttp.WithInsecure())
+		if err != nil {
+			return nil, fmt.Errorf("could not create HTTP trace exporter: %w", err)
+		}
+	case "https":
+		exporter, err = otlptracehttp.New(ctx, otlptracehttp.WithEndpoint(tracingConfig.Endpoint), otlptracehttp.WithURLPath(tracingConfig.Path))
 		if err != nil {
 			return nil, fmt.Errorf("could not create HTTP trace exporter: %w", err)
 		}

--- a/deploy/docker-compose/template/client.template.yaml
+++ b/deploy/docker-compose/template/client.template.yaml
@@ -212,8 +212,3 @@ metrics:
     port: 4002
   # # ip is the listen ip of the metrics server.
   # ip: ""
-
-# # tracing is the tracing configuration for dfdaemon.
-# tracing:
-#   # addr is the address to report tracing log.
-#   addr: ""

--- a/deploy/docker-compose/template/manager.template.yaml
+++ b/deploy/docker-compose/template/manager.template.yaml
@@ -164,7 +164,3 @@ console: false
 
 # Listen port for pprof, default is -1 (means disabled).
 pprofPort: -1
-
-tracing:
-  # Jaeger endpoint url, like: http://jaeger.dragonfly.svc:4317.
-  addr: ''

--- a/deploy/docker-compose/template/scheduler.template.yaml
+++ b/deploy/docker-compose/template/scheduler.template.yaml
@@ -180,7 +180,3 @@ console: false
 
 # Listen port for pprof, default is -1 (means disabled).
 pprofPort: -1
-
-tracing:
-  # Jaeger endpoint url, like: http://jaeger.dragonfly.svc:4317.
-  addr: ''

--- a/deploy/docker-compose/template/seed-client.template.yaml
+++ b/deploy/docker-compose/template/seed-client.template.yaml
@@ -195,8 +195,3 @@ metrics:
     port: 4012
   # # ip is the listen ip of the metrics server.
   # ip: ""
-
-# # tracing is the tracing configuration for dfdaemon.
-# tracing:
-#   # addr is the address to report tracing log.
-#   addr: ""

--- a/manager/config/config.go
+++ b/manager/config/config.go
@@ -408,6 +408,7 @@ func New() *Config {
 			Console:   false,
 			PProfPort: -1,
 			Tracing: base.TracingConfig{
+				Path:        "/v1/traces",
 				ServiceName: types.ManagerName,
 			},
 		},

--- a/scheduler/config/config.go
+++ b/scheduler/config/config.go
@@ -323,6 +323,7 @@ func New() *Config {
 			Console:   false,
 			PProfPort: -1,
 			Tracing: base.TracingConfig{
+				Path:        "/v1/traces",
 				ServiceName: types.SchedulerName,
 			},
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces updates to the tracing configuration across multiple components in the codebase. The key changes include adding a `Path` field to the `TracingConfig` struct, modifying the initialization logic for HTTP and HTTPS tracing exporters to support the new `Path` field, and removing outdated tracing configuration sections from various Docker Compose templates.

### Updates to tracing configuration:

* **Added `Path` field to `TracingConfig`:** Introduced a new `Path` field in the `TracingConfig` struct to specify the URL path for the tracing server (e.g., `/v1/traces`). (`cmd/dependency/base/option.go`, [cmd/dependency/base/option.goR35-R37](diffhunk://#diff-fe8a3936e9c6af18d24c9ee30eceb0a250c0cd608014ccf890b90c226e10ba63R35-R37))

* **Updated tracing exporter initialization:** Modified the `initJaegerTracer` function to utilize the new `Path` field for HTTP and HTTPS tracing protocols. This ensures the correct URL path is used when creating the trace exporter. (`cmd/dependency/dependency.go`, [cmd/dependency/dependency.goL154-R160](diffhunk://#diff-3950f049f495b4c8f37427cc77a764da5c5b4e9f33ac41ab45ced60bea085196L154-R160))

### Cleanup in Docker Compose templates:

* **Removed outdated tracing configurations:** Eliminated unused tracing configuration sections from the client, manager, scheduler, and seed-client Docker Compose templates to streamline the configuration files. (`deploy/docker-compose/template/client.template.yaml`, [[1]](diffhunk://#diff-7eafc0d242243c7242afd56d770e5493e773112d999d4ab7b1321cfd90590efbL215-L219); `deploy/docker-compose/template/manager.template.yaml`, [[2]](diffhunk://#diff-87a1c1cbd45e7162050e96b76d33e4c95802fef3d653688b7bfcea5c31d53725L167-L170); `deploy/docker-compose/template/scheduler.template.yaml`, [[3]](diffhunk://#diff-3019b15576b946225450883a3f73cc89298a9a4ea27b8d71f553572d3d32fd61L183-L186); `deploy/docker-compose/template/seed-client.template.yaml`, [[4]](diffhunk://#diff-5e43b1c71af0df4d8183b1f6c85947894c519215800d9a3d1b3bd5e62cddcadaL198-L202)

### Default tracing path in configurations:

* **Set default tracing path:** Added the default `Path` value (`/v1/traces`) to the tracing configuration in both the manager and scheduler components. (`manager/config/config.go`, [[1]](diffhunk://#diff-38f5db6313cbf867355d056890ad5ca0f1b952eebef92eb70abbafeb1b655c15R411); `scheduler/config/config.go`, [[2]](diffhunk://#diff-0c784f71367ad0e2181f892a3fe4ba3529290443b5f3573bfdbd1b231de96a5eR326)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
