### PR TITLE
fix: correct the task id of job gc

### DIFF
--- a/manager/gc/job.go
+++ b/manager/gc/job.go
@@ -80,7 +80,7 @@ func (j *job) RunGC(ctx context.Context) error {
 		taskID = id
 	} else {
 		// Use the default task ID if taskID is not provided. (applied to background periodic execution scenarios)
-		taskID = AuditGCTaskID
+		taskID = JobGCTaskID
 	}
 
 	if err = j.recorder.Init(userID, taskID, args); err != nil {


### PR DESCRIPTION
This pull request makes a small but important change to the `RunGC` method in `manager/gc/job.go`. The change updates the default task ID used in background periodic execution scenarios to ensure it aligns with the correct identifier.

* [`manager/gc/job.go`](diffhunk://#diff-f072844f925732f5f4176bbe063a9a4b83acbfd8bc34d011f4338f18d3a8c7a8L83-R83): Replaced `AuditGCTaskID` with `JobGCTaskID` as the default task ID in the `RunGC` method.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
