### PR TITLE
chore: bump client-rs to v1.0.1

### DIFF
--- a/.github/workflows/compatibility-e2e.yml
+++ b/.github/workflows/compatibility-e2e.yml
@@ -31,22 +31,22 @@ jobs:
         include:
           - module: manager
             image: manager
-            image-tag: v2.2.4
+            image-tag: v2.3.0
             chart-name: manager
             skip: "Rate Limit | preheat files in cache"
           - module: scheduler
             image: scheduler
-            image-tag: v2.2.4
+            image-tag: v2.3.0
             chart-name: scheduler
             skip: "Rate Limit | preheat files in cache"
           - module: client
             image: client
-            image-tag: v1.0.0
+            image-tag: v1.0.1
             chart-name: client
             skip: "Rate Limit"
           - module: seed-client
             image: client
-            image-tag: v1.0.0
+            image-tag: v1.0.1
             chart-name: seed-client
             skip: "Rate Limit"
 

--- a/deploy/docker-compose/template/client.template.yaml
+++ b/deploy/docker-compose/template/client.template.yaml
@@ -30,7 +30,7 @@ download:
   # rateLimit is the default rate limit of the download speed in KiB/MiB/GiB per second, default is 10GiB/s.
   rateLimit: 10GiB
   # pieceTimeout is the timeout for downloading a piece from source.
-  pieceTimeout: 60s
+  pieceTimeout: 40s
   # concurrentPieceCount is the number of concurrent pieces to download.
   concurrentPieceCount: 10
 

--- a/deploy/docker-compose/template/seed-client.template.yaml
+++ b/deploy/docker-compose/template/seed-client.template.yaml
@@ -30,7 +30,7 @@ download:
   # rateLimit is the default rate limit of the download speed in KiB/MiB/GiB per second, default is 10GiB/s.
   rateLimit: 10GiB
   # pieceTimeout is the timeout for downloading a piece from source.
-  pieceTimeout: 30s
+  pieceTimeout: 40s
   # concurrentPieceCount is the number of concurrent pieces to download.
   concurrentPieceCount: 10
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes updates to dependency versions for improved compatibility and functionality. The changes primarily focus on updating image tags in the workflow configuration and updating the `client-rs` submodule reference.

### Dependency Updates:

* [`.github/workflows/compatibility-e2e.yml`](diffhunk://#diff-62915ee251a22234e796dacb74a6371d13312594faf822c06da355b816b846e9L34-R49): Updated image tags for `manager`, `scheduler`, `client`, and `seed-client` modules to newer versions (`v2.3.0` for `manager` and `scheduler`, `v1.0.1` for `client` and `seed-client`) to reflect the latest releases.

* [`client-rs`](diffhunk://#diff-84558f39216002fac1c3d61169fea29ee720b962a90c14d2f81a13e0ee6742bfL1-R1): Updated the submodule reference to a newer commit (`1a60b934e2efb48b3bc6bcdb6f317803b07d4e50`) for improved compatibility and functionality.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
