### PR TITLE
feat: add gc task to clean up inactive seed peers

### DIFF
--- a/manager/gc/seed_peer.go
+++ b/manager/gc/seed_peer.go
@@ -1,0 +1,111 @@
+/*
+ *     Copyright 2025 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gc
+
+import (
+	"context"
+	"time"
+
+	"gorm.io/gorm"
+
+	logger "d7y.io/dragonfly/v2/internal/dflog"
+	"d7y.io/dragonfly/v2/manager/models"
+	pkggc "d7y.io/dragonfly/v2/pkg/gc"
+)
+
+const (
+	// DefaultSeedPeerGCBatchSize is the default batch size for deleting seed peers.
+	DefaultSeedPeerGCBatchSize = 5000
+
+	// DefaultSeedPeerTTL is the default TTL for seed peer.
+	DefaultSeedPeerGCTTL = time.Minute * 30
+
+	// DefaultSeedPeerGCInterval is the default interval for running seed peer GC.
+	DefaultSeedPeerGCInterval = time.Hour * 1
+
+	// DefaultSeedPeerGCTimeout is the default timeout for running seed peer GC.
+	DefaultSeedPeerGCTimeout = time.Hour * 1
+
+	// SeedPeerGCTaskID is the ID of the seed peer GC task.
+	SeedPeerGCTaskID = "seed_peer"
+)
+
+// NewSeedPeerGCTask returns a new seed peer GC task.
+func NewSeedPeerGCTask(db *gorm.DB) pkggc.Task {
+	return pkggc.Task{
+		ID:       SeedPeerGCTaskID,
+		Interval: DefaultSeedPeerGCInterval,
+		Timeout:  DefaultSeedPeerGCTimeout,
+		Runner:   &seedPeer{db: db, recorder: newJobRecorder(db)},
+	}
+}
+
+// seedPeer is the struct for cleaning up inactive seed peers which implements the gc Runner interface.
+type seedPeer struct {
+	db       *gorm.DB
+	recorder *jobRecorder
+}
+
+// RunGC implements the gc Runner interface.
+func (s *seedPeer) RunGC(ctx context.Context) error {
+	args := models.JSONMap{
+		"type":       SeedPeerGCTaskID,
+		"ttl":        DefaultSeedPeerGCTTL,
+		"batch_size": DefaultSeedPeerGCBatchSize,
+	}
+
+	var userID uint
+	if id, ok := ctx.Value(pkggc.ContextKeyUserID).(uint); ok {
+		userID = id
+	}
+
+	var taskID string
+	if id, ok := ctx.Value(pkggc.ContextKeyTaskID).(string); ok {
+		taskID = id
+	} else {
+		// Use the default task ID if taskID is not provided. (applied to background periodic execution scenarios)
+		taskID = SeedPeerGCTaskID
+	}
+
+	if err := s.recorder.Init(userID, taskID, args); err != nil {
+		return err
+	}
+
+	var gcResult Result
+	defer func() {
+		if err := s.recorder.Record(gcResult); err != nil {
+			logger.Errorf("failed to record seed peer GC result: %v", err)
+		}
+	}()
+
+	for {
+		result := s.db.Where("updated_at < ?", time.Now().Add(-DefaultSeedPeerGCTTL)).Where("state = ?", models.SeedPeerStateInactive).Limit(DefaultSeedPeerGCBatchSize).Unscoped().Delete(&models.SeedPeer{})
+		if result.Error != nil {
+			gcResult.Error = result.Error
+			return result.Error
+		}
+
+		if result.RowsAffected == 0 {
+			break
+		}
+
+		gcResult.Purged += result.RowsAffected
+		logger.Infof("gc seed peer deleted %d inactive seed peers", result.RowsAffected)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This pull request introduces a new garbage collection (GC) task for cleaning up inactive seed peers, refactors the GC task registration process for better maintainability, and updates a submodule reference. Below is a summary of the most important changes:

### New Seed Peer GC Task Implementation:
* Added a new GC task in `manager/gc/seed_peer.go` to clean up inactive seed peers. This includes constants for default configurations (e.g., TTL, batch size, interval) and a `RunGC` method to perform the cleanup using database operations.

### Refactoring of GC Task Registration:
* Refactored the GC task registration in `manager/manager.go` by introducing a new `registerGCTasks` function. This consolidates the registration logic for all GC tasks, including the new seed peer GC task. [[1]](diffhunk://#diff-f679b61276b44dc3f4712950536707c0389ee4c536fc29837c0202c6e81c1bbfL171-L185) [[2]](diffhunk://#diff-f679b61276b44dc3f4712950536707c0389ee4c536fc29837c0202c6e81c1bbfR230-R253)

### Submodule Update:
* Updated the `client-rs` submodule reference to a new commit (`7cf69832a842a683a01c9c3ff9aed354bb72ff8e`).

### Dependency Addition:
* Added the `gorm.io/gorm` package to the imports in `manager/manager.go` to support database operations for the new GC task.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Completed task of https://github.com/dragonflyoss/dragonfly/issues/3733

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
