### PR TITLE
fix: revert the remove of ip and port in mamager rpc server

### DIFF
--- a/manager/rpcserver/manager_server_v2.go
+++ b/manager/rpcserver/manager_server_v2.go
@@ -238,6 +238,8 @@ func (s *managerServerV2) UpdateSeedPeer(ctx context.Context, req *managerv2.Upd
 	seedPeer := models.SeedPeer{}
 	if err := s.db.WithContext(ctx).First(&seedPeer, models.SeedPeer{
 		Hostname:          req.Hostname,
+		IP:                req.Ip,
+		Port:              req.Port,
 		SeedPeerClusterID: uint(req.SeedPeerClusterId),
 	}).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -450,6 +452,8 @@ func (s *managerServerV2) UpdateScheduler(ctx context.Context, req *managerv2.Up
 	scheduler := models.Scheduler{}
 	if err := s.db.WithContext(ctx).First(&scheduler, models.Scheduler{
 		Hostname:           req.Hostname,
+		IP:                 req.Ip,
+		Port:               req.Port,
 		SchedulerClusterID: uint(req.SchedulerClusterId),
 	}).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {


### PR DESCRIPTION
This pull request updates the `managerServerV2` RPC server to include additional fields (`IP` and `Port`) when querying for `SeedPeer` and `Scheduler` records. These changes ensure more precise matching of records in the database.

Enhancements to database queries:

* [`manager/rpcserver/manager_server_v2.go`](diffhunk://#diff-d6cc9560b22b902b815a8aabd758bb6f6127891f1ddb666f462088228a6a860cR241-R242): Updated the `UpdateSeedPeer` method to include `IP` and `Port` in the query criteria for retrieving `SeedPeer` records.
* [`manager/rpcserver/manager_server_v2.go`](diffhunk://#diff-d6cc9560b22b902b815a8aabd758bb6f6127891f1ddb666f462088228a6a860cR455-R456): Updated the `UpdateScheduler` method to include `IP` and `Port` in the query criteria for retrieving `Scheduler` records.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
