### PR TITLE
feat: limit concurrent image distribution jobs and add validation for IPs

### DIFF
--- a/manager/service/job.go
+++ b/manager/service/job.go
@@ -52,7 +52,7 @@ const (
 	DefaultGCJobPollingInterval = 5 * time.Second
 
 	// DefaultGetImageDistributionJobConcurrentCount is the default concurrent count for getting image distribution job.
-	DefaultGetImageDistributionJobConcurrentCount = 30
+	DefaultGetImageDistributionJobConcurrentCount = 12
 )
 
 func (s *service) CreateGCJob(ctx context.Context, json types.CreateGCJobRequest) (*models.Job, error) {

--- a/manager/types/job.go
+++ b/manager/types/job.go
@@ -147,7 +147,7 @@ type PreheatArgs struct {
 	// IPs is a list of specific peer IPs for preheating.
 	// This field has the highest priority: if provided, both 'Count' and 'Percentage' will be ignored.
 	// Applies to 'all_peers' and 'all_seed_peers' scopes.
-	IPs []string `json:"ips" binding:"omitempty"`
+	IPs []string `json:"ips" binding:"omitempty,gte=1,lte=100"`
 
 	// Percentage is the percentage of available peers to preheat.
 	// This field has the lowest priority and is only used if both 'IPs' and 'Count' are not provided.


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request makes adjustments to configuration defaults and validation rules in the job management system. The key changes include reducing the default concurrency for image distribution jobs and adding stricter validation for preheating arguments.

### Configuration Updates:
* [`manager/service/job.go`](diffhunk://#diff-32eba326fa80fbb1d566d606bb6bf6d24c19b9dd24687c2a361c69d9f2c56aeaL55-R55): Reduced the default value for `DefaultGetImageDistributionJobConcurrentCount` from `30` to `12` to optimize resource usage during image distribution jobs.

### Validation Enhancements:
* [`manager/types/job.go`](diffhunk://#diff-d878064c028a450c53f765d31dff1bea45dc8d3346201e65989d98b2fb976d62L150-R150): Added validation constraints to the `IPs` field in the `PreheatArgs` struct, ensuring the list contains between 1 and 100 entries (`gte=1,lte=100`). This prevents invalid or overly large input.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
