### PR TITLE
test(e2e): update config to fix the slow resolution of seed peer address

### DIFF
--- a/.github/workflows/compatibility-e2e.yml
+++ b/.github/workflows/compatibility-e2e.yml
@@ -31,22 +31,22 @@ jobs:
         include:
           - module: manager
             image: manager
-            image-tag: v2.3.1-beta.1
+            image-tag: v2.3.1-rc.1
             chart-name: manager
             skip: "Rate Limit | preheat files in cache"
           - module: scheduler
             image: scheduler
-            image-tag: v2.3.1-beta.1
+            image-tag: v2.3.1-rc.1
             chart-name: scheduler
             skip: "Rate Limit | preheat files in cache"
           - module: client
             image: client
-            image-tag: v1.0.5
+            image-tag: v1.0.6
             chart-name: client
             skip: "Rate Limit"
           - module: seed-client
             image: client
-            image-tag: v1.0.5
+            image-tag: v1.0.6
             chart-name: seed-client
             skip: "Rate Limit"
 

--- a/scheduler/job/job.go
+++ b/scheduler/job/job.go
@@ -172,7 +172,7 @@ func (j *job) preheat(ctx context.Context, data string) (string, error) {
 		return "", err
 	}
 
-	log := logger.WithPreheatJob(req.GroupUUID, req.TaskUUID, append(req.URLs, req.URL))
+	log := logger.WithPreheatJob(req.GroupUUID, req.TaskUUID, req.URLs)
 	log.Infof("[preheat]: preheat %s %d request: %#v", req.URLs, req.PieceLength, req)
 
 	ctx, cancel := context.WithTimeout(ctx, req.Timeout)

--- a/test/testdata/charts/config.yaml
+++ b/test/testdata/charts/config.yaml
@@ -28,7 +28,8 @@ manager:
     server:
       logLevel: debug
     cache:
-      ttl: 5s
+      redis:
+        ttl: 5s
       local:
         ttl: 3s
     job:
@@ -106,9 +107,9 @@ seedClient:
       path: /tmp/artifact
   config:
     dynconfig:
-      refreshInterval: 1s
+      refreshInterval: 5s
     scheduler:
-      announceInterval: 1s
+      announceInterval: 10s
     log:
       level: debug
     proxy:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the configuration settings in the `test/testdata/charts/config.yaml` file to adjust caching and scheduling behavior.

### Configuration Updates:

* **Cache Configuration:**
  - Added a `redis` section under `cache` with a `ttl` (time-to-live) value of 5 seconds. (`[test/testdata/charts/config.yamlR31](diffhunk://#diff-59638ce8a58cd511c9e74c1c823454ba680f03345f727393e4b139b3b237c036R31)`)

* **Seed Client Configuration:**
  - Increased the `dynconfig.refreshInterval` from 1 second to 5 seconds. (`[test/testdata/charts/config.yamlL109-R112](diffhunk://#diff-59638ce8a58cd511c9e74c1c823454ba680f03345f727393e4b139b3b237c036L109-R112)`)
  - Increased the `scheduler.announceInterval` from 1 second to 10 seconds. (`[test/testdata/charts/config.yamlL109-R112](diffhunk://#diff-59638ce8a58cd511c9e74c1c823454ba680f03345f727393e4b139b3b237c036L109-R112)`)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
