### PR TITLE
feat(job): add timeout parameter to job scheduling

### DIFF
--- a/manager/service/job.go
+++ b/manager/service/job.go
@@ -352,6 +352,7 @@ func (s *service) createGetTaskJobsSync(ctx context.Context, layers []internaljo
 					Application:         file.Application,
 					FilteredQueryParams: file.FilteredQueryParams,
 					ConcurrentPeerCount: json.Args.ConcurrentPeerCount,
+					Timeout:             json.Args.Timeout,
 				},
 				SchedulerClusterIDs: json.SchedulerClusterIDs,
 			}, schedulers)
@@ -405,7 +406,7 @@ func (s *service) createGetTaskJobSync(ctx context.Context, json types.CreateGet
 		return nil, err
 	}
 
-	s.pollingJob(context.Background(), internaljob.GetTaskJob, job.ID, job.TaskID, 3, 5, 4)
+	s.pollingJob(context.Background(), internaljob.GetTaskJob, job.ID, job.TaskID, 3, 5, 60)
 	if err := s.db.WithContext(ctx).Preload("SeedPeerClusters").Preload("SchedulerClusters").First(&job, job.ID).Error; err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces minor updates to the job management logic in `manager/service/job.go`, focusing on task job creation and polling behavior.

Job creation and polling updates:

* Added support for passing the `Timeout` parameter from the API request (`json.Args.Timeout`) into the job creation logic, allowing for more flexible control over job execution timeouts.
* Increased the polling interval for the `pollingJob` function when creating a synchronous get-task job, changing the last argument from 4 to 60, which likely extends the polling timeout or interval.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
