### PR TITLE
docs: update DingTalk group link format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Join the conversation and help the community. We have a number of ways for you t
 - **Developer Group**: <dragonfly-developers@googlegroups.com>
 - **Maintainer Group**: <dragonfly-maintainers@googlegroups.com>
 - **Twitter**: [@dragonfly_oss](https://twitter.com/dragonfly_oss)
-- **DingTalk**: [22880028764](https://qr.dingtalk.com/action/joingroup?code=v1,k1,pkV9IbsSyDusFQdByPSK3HfCG61ZCLeb8b/lpQ3uUqI=&_dt_no_comment=1&origin=11)
+- **DingTalk Group**: `22880028764`
 
 and you can also seek the main community information in the [community repository](https://github.com/dragonflyoss/community).
 In this repository, you can find the [community meeting minutes, community meeting notes, and more](https://github.com/dragonflyoss/community/tree/master/meetings).


### PR DESCRIPTION
- Adjust DingTalk group reference to use consistent formatting
- Ensure clarity for community contact information

<!--- Provide a general summary of your changes in the Title above -->

## Description

Update the Dingtalk Group Description without links, because links can expire, but group numbers don't.

## Related Issue

https://github.com/dragonflyoss/dragonfly/issues/4298

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
