### PR TITLE
docs: fix maintainer links in MAINTAINERS.md and OWNERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,3 +1,3 @@
 # Maintainers
 
-Please refer to the [community maintainers](https://github.com/dragonflyoss/community/blob/master/MAINTAINERS.md).
+Please refer to the [community maintainers](https://github.com/dragonflyoss/community/blob/master/roles/Maintainers.md).

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -8,8 +8,8 @@ This page lists current and emeritus maintainers. This can be used for routing P
 
 ## Maintainers
 
-Please refer to our [community maintainers](https://github.com/dragonflyoss/community/blob/master/MAINTAINERS.md).
+Please refer to our [community maintainers](https://github.com/dragonflyoss/community/blob/master/roles/Maintainers.md).
 
 ## Emeritus maintainers
 
-Please refer to our [community emeritus maintainers](https://github.com/dragonflyoss/community/blob/master/MAINTAINERS.md#emeritus-maintainers).
+Please refer to our [community emeritus maintainers](https://github.com/dragonflyoss/community/blob/master/roles/Maintainers.md#emeritus-maintainers).


### PR DESCRIPTION
Update the URLs pointing to the community maintainers file to the correct path under roles/Maintainers.md in both MAINTAINERS.md and OWNERS.md. This ensures the links direct users to the accurate location for maintainer information.

