### PR TITLE
docs: update community links in project documentation

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -2,9 +2,12 @@
 
 This page lists current and emeritus maintainers. This can be used for routing PRs, discussions, questions and overall coordination.
 
-- See [GOVERNANCE.md](GOVERNANCE.md) that describes governance guidelines and maintainer responsibilities..
-- See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) about contributors and maintainers standards in the community.
-- See [CONTRIBUTING.md](CONTRIBUTING.md) for general contributing guidelines.
+- See [GOVERNANCE.md](https://github.com/dragonflyoss/community/blob/master/GOVERNANCE.md)
+  that describes governance guidelines and maintainer responsibilities.
+- See [CODE_OF_CONDUCT.md](https://github.com/dragonflyoss/community/blob/master/CODE_OF_CONDUCT.md)
+  about contributors and maintainers standards in the community.
+- See [CONTRIBUTING.md](https://github.com/dragonflyoss/community/blob/master/CONTRIBUTING.md)
+  for general contributing guidelines.
 
 ## Maintainers
 


### PR DESCRIPTION
## Description

- Revise links to community resources in CODE_OF_CONDUCT.md
- Update contributing guidelines link in CONTRIBUTING.md
- Correct governance reference in GOVERNANCE.md
- Enhance maintainer info with role details in MAINTAINERS.md
- Streamline owner information and links in OWNERS.md

## Related Issue

https://github.com/dragonflyoss/community/issues/97

## Motivation and Context

We need to clean up the governance documents because they contain redundant jumps and cross-references.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
