### PR TITLE
feat: delete all peers when host leaving

### DIFF
--- a/scheduler/resource/standard/peer_manager.go
+++ b/scheduler/resource/standard/peer_manager.go
@@ -48,6 +48,9 @@ type PeerManager interface {
 	// Delete deletes peer for a key.
 	Delete(string)
 
+	// DeleteAllByHostID deletes all peers by host id.
+	DeleteAllByHostID(string)
+
 	// Range calls f sequentially for each key and value present in the map.
 	// If f returns false, range stops the iteration.
 	Range(f func(any, any) bool)
@@ -142,6 +145,22 @@ func (p *peerManager) Delete(key string) {
 		peer.Task.DeletePeer(key)
 		peer.Host.DeletePeer(key)
 	}
+}
+
+// DeleteAllByHostID deletes all peers by host id.
+func (p *peerManager) DeleteAllByHostID(hostID string) {
+	p.Map.Range(func(_, value any) bool {
+		peer, ok := value.(*Peer)
+		if !ok {
+			return true
+		}
+
+		if peer.Host.ID == hostID {
+			p.Delete(peer.ID)
+		}
+
+		return true
+	})
 }
 
 // Range calls f sequentially for each key and value present in the map.

--- a/scheduler/resource/standard/peer_manager_mock.go
+++ b/scheduler/resource/standard/peer_manager_mock.go
@@ -52,6 +52,18 @@ func (mr *MockPeerManagerMockRecorder) Delete(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockPeerManager)(nil).Delete), arg0)
 }
 
+// DeleteAllByHostID mocks base method.
+func (m *MockPeerManager) DeleteAllByHostID(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "DeleteAllByHostID", arg0)
+}
+
+// DeleteAllByHostID indicates an expected call of DeleteAllByHostID.
+func (mr *MockPeerManagerMockRecorder) DeleteAllByHostID(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAllByHostID", reflect.TypeOf((*MockPeerManager)(nil).DeleteAllByHostID), arg0)
+}
+
 // Load mocks base method.
 func (m *MockPeerManager) Load(arg0 string) (*Peer, bool) {
 	m.ctrl.T.Helper()

--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -445,25 +445,10 @@ func (v *V2) StatPeer(ctx context.Context, req *schedulerv2.StatPeerRequest) (*c
 
 // DeletePeer releases peer in scheduler.
 func (v *V2) DeletePeer(_ctx context.Context, req *schedulerv2.DeletePeerRequest) error {
-	// Context use background to avoid the context canceled by the client and
-	// the peer deletion operation is not completed.
-	ctx := context.Background()
 	log := logger.WithTaskAndPeerID(req.GetTaskId(), req.GetPeerId())
 	log.Infof("delete peer request: %#v", req)
 
-	peer, loaded := v.resource.PeerManager().Load(req.GetPeerId())
-	if !loaded {
-		msg := fmt.Sprintf("peer %s not found", req.GetPeerId())
-		log.Error(msg)
-		return status.Error(codes.NotFound, msg)
-	}
-
-	if err := peer.FSM.Event(ctx, standard.PeerEventLeave); err != nil {
-		err = fmt.Errorf("peer fsm event failed: %w", err)
-		peer.Log.Error(err)
-		return status.Error(codes.FailedPrecondition, err.Error())
-	}
-
+	v.resource.PeerManager().Delete(req.GetPeerId())
 	return nil
 }
 
@@ -533,9 +518,6 @@ func (v *V2) StatTask(ctx context.Context, req *schedulerv2.StatTaskRequest) (*c
 
 // DeleteTask releases task in scheduler.
 func (v *V2) DeleteTask(_ctx context.Context, req *schedulerv2.DeleteTaskRequest) error {
-	// Context use background to avoid the context canceled by the client and
-	// the task deletion operation is not completed.
-	ctx := context.Background()
 	log := logger.WithHostAndTaskID(req.GetHostId(), req.GetTaskId())
 	log.Infof("delete task request: %#v", req)
 
@@ -554,11 +536,7 @@ func (v *V2) DeleteTask(_ctx context.Context, req *schedulerv2.DeleteTaskRequest
 		}
 
 		if peer.Task.ID == req.GetTaskId() {
-			if err := peer.FSM.Event(ctx, standard.PeerEventLeave); err != nil {
-				err = fmt.Errorf("peer fsm event failed: %w", err)
-				peer.Log.Error(err)
-				return true
-			}
+			v.resource.PeerManager().Delete(peer.ID)
 		}
 
 		return true
@@ -1046,15 +1024,15 @@ func (v *V2) DeleteHost(_ctx context.Context, req *schedulerv2.DeleteHostRequest
 	log := logger.WithHostID(req.GetHostId())
 	log.Infof("delete host request: %#v", req)
 
-	host, loaded := v.resource.HostManager().Load(req.GetHostId())
+	_, loaded := v.resource.HostManager().Load(req.GetHostId())
 	if !loaded {
 		msg := fmt.Sprintf("host %s not found", req.GetHostId())
 		log.Error(msg)
 		return status.Error(codes.NotFound, msg)
 	}
 
-	// Leave peers in host.
-	host.LeavePeers()
+	// Delete all peers belong to the host.
+	v.resource.PeerManager().DeleteAllByHostID(req.GetHostId())
 
 	// Delete host in scheduler.
 	v.resource.HostManager().Delete(req.GetHostId())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request refactors how peers are deleted when leaving a task or host in the scheduler service. The main change is to simplify the peer removal logic by directly deleting peers from the `PeerManager`, rather than relying on peer state or host methods. This affects both the implementation and the corresponding unit tests, and introduces a new method for bulk deleting peers by host ID.

### Peer deletion logic refactor

* The `LeaveTask` method in `service_v1.go` now deletes the peer directly from the `PeerManager`, removing previous logic that checked peer state and triggered FSM events. This also simplifies error handling, as it no longer returns errors for missing peers or FSM failures.
* The `LeaveHost` method now deletes all peers associated with the host by calling the new `DeleteAllByHostID` method on `PeerManager`, instead of invoking `LeavePeers` on the host.

### PeerManager interface and implementation changes

* Added a new method `DeleteAllByHostID` to the `PeerManager` interface and implemented it to remove all peers belonging to a given host ID. [[1]](diffhunk://#diff-8e41b05dbea1179e5ffbe0a74b85b4b830f2fb132131c7dd157a8968782acc05R51-R53) [[2]](diffhunk://#diff-8e41b05dbea1179e5ffbe0a74b85b4b830f2fb132131c7dd157a8968782acc05R150-R165)
* Updated the `PeerManager` mocks to support the new `DeleteAllByHostID` method for testing purposes.

### Unit test updates

* Refactored `LeaveTask` and `LeaveHost` unit tests to match the new peer deletion logic: tests now expect no error when deleting a peer, regardless of its state or existence, and use the new bulk deletion method for hosts. Redundant peer state transition checks were removed. [[1]](diffhunk://#diff-01fa425ac7b15d47a9063091304edf2a821e67eb28c1ba591eb93abba3f9fe9eL1591-R1617) [[2]](diffhunk://#diff-01fa425ac7b15d47a9063091304edf2a821e67eb28c1ba591eb93abba3f9fe9eL1631-L1758) [[3]](diffhunk://#diff-01fa425ac7b15d47a9063091304edf2a821e67eb28c1ba591eb93abba3f9fe9eL1779-R1652) [[4]](diffhunk://#diff-01fa425ac7b15d47a9063091304edf2a821e67eb28c1ba591eb93abba3f9fe9eL2213-R2091) [[5]](diffhunk://#diff-01fa425ac7b15d47a9063091304edf2a821e67eb28c1ba591eb93abba3f9fe9eL2231-R2109) [[6]](diffhunk://#diff-01fa425ac7b15d47a9063091304edf2a821e67eb28c1ba591eb93abba3f9fe9eL2246-R2128)
* Added new tests for the `DeleteAllByHostID` method to ensure it correctly deletes peers by host ID and handles non-existent host IDs gracefully.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
