### PR TITLE
fix(scheduler): set EnableTaskIdBasedBlobDigest in preheat to match dfdaemon default, fixing preheat cache miss

### DIFF
--- a/pkg/digest/digest.go
+++ b/pkg/digest/digest.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -125,4 +126,26 @@ func SHA256FromStrings(data ...string) string {
 	}
 
 	return hex.EncodeToString(h.Sum(nil))
+}
+
+// blobURLRegex is the regex pattern for OCI blob URLs,
+// e.g. http(s)://<registry>/v2/<repository>/blobs/<digest>.
+var blobURLRegex = regexp.MustCompile(`^(.*)://(.*)/v2/(.*)/blobs/([^?]+)(?:\?.*)?$`)
+
+// IsBlobURL checks whether the url is an OCI blob URL.
+func IsBlobURL(url string) bool {
+	return blobURLRegex.MatchString(url)
+}
+
+// ExtractFromBlobURL extracts the digest from an OCI blob URL.
+// e.g. https://registry.example.com/v2/library/nginx/blobs/sha256:abc123...
+//
+//	returns Digest{Algorithm: "sha256", Encoded: "abc123..."}, nil
+func ExtractFromBlobURL(url string) (*Digest, error) {
+	matches := blobURLRegex.FindStringSubmatch(url)
+	if len(matches) < 5 {
+		return nil, errors.New("invalid blob URL")
+	}
+
+	return Parse(matches[4])
 }

--- a/pkg/digest/digest_test.go
+++ b/pkg/digest/digest_test.go
@@ -130,3 +130,146 @@ func TestDigest_Parse(t *testing.T) {
 func TestDigest_SHA256FromStrings(t *testing.T) {
 	assert.Equal(t, "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", SHA256FromStrings("hello"))
 }
+
+func TestIsBlobURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		url    string
+		expect bool
+	}{
+		{
+			name:   "https blob URL",
+			url:    "https://registry.example.com/v2/library/nginx/blobs/sha256:c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4",
+			expect: true,
+		},
+		{
+			name:   "http blob URL",
+			url:    "http://registry.example.com/v2/library/nginx/blobs/sha256:c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4",
+			expect: true,
+		},
+		{
+			name:   "blob URL with query params",
+			url:    "https://registry.example.com/v2/library/nginx/blobs/sha256:c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4?foo=bar",
+			expect: true,
+		},
+		{
+			name:   "blob URL with nested repository",
+			url:    "https://registry.example.com/v2/org/team/nginx/blobs/sha256:c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4",
+			expect: true,
+		},
+		{
+			name:   "manifest URL is not a blob URL",
+			url:    "https://registry.example.com/v2/library/nginx/manifests/latest",
+			expect: false,
+		},
+		{
+			name:   "tags list URL is not a blob URL",
+			url:    "https://registry.example.com/v2/library/nginx/tags/list",
+			expect: false,
+		},
+		{
+			name:   "plain URL is not a blob URL",
+			url:    "https://example.com/file.tar.gz",
+			expect: false,
+		},
+		{
+			name:   "empty URL is not a blob URL",
+			url:    "",
+			expect: false,
+		},
+		{
+			name:   "v2 API base URL is not a blob URL",
+			url:    "https://registry.example.com/v2/",
+			expect: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expect, IsBlobURL(tc.url))
+		})
+	}
+}
+
+func TestExtractFromBlobURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		url    string
+		expect func(t *testing.T, d *Digest, err error)
+	}{
+		{
+			name: "extract sha256 digest from blob URL",
+			url:  "https://registry.example.com/v2/library/nginx/blobs/sha256:c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4",
+			expect: func(t *testing.T, d *Digest, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Equal(AlgorithmSHA256, d.Algorithm)
+				assert.Equal("c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4", d.Encoded)
+			},
+		},
+		{
+			name: "extract sha256 digest from blob URL with query params",
+			url:  "https://registry.example.com/v2/library/nginx/blobs/sha256:c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4?foo=bar&baz=qux",
+			expect: func(t *testing.T, d *Digest, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Equal(AlgorithmSHA256, d.Algorithm)
+				assert.Equal("c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4", d.Encoded)
+			},
+		},
+		{
+			name: "extract sha256 digest from blob URL with nested repository",
+			url:  "https://registry.example.com/v2/org/team/nginx/blobs/sha256:c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4",
+			expect: func(t *testing.T, d *Digest, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Equal(AlgorithmSHA256, d.Algorithm)
+				assert.Equal("c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4", d.Encoded)
+			},
+		},
+		{
+			name: "extract sha512 digest from blob URL",
+			url:  "https://registry.example.com/v2/library/nginx/blobs/sha512:dc6b68d13b8cf959644b935f1192b02c71aa7a5cf653bd43b4480fa89eec8d4d3f16a2278ec8c3b40ab1fdb233b3173a78fd83590d6f739e0c9e8ff56c282557",
+			expect: func(t *testing.T, d *Digest, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Equal(AlgorithmSHA512, d.Algorithm)
+				assert.Equal("dc6b68d13b8cf959644b935f1192b02c71aa7a5cf653bd43b4480fa89eec8d4d3f16a2278ec8c3b40ab1fdb233b3173a78fd83590d6f739e0c9e8ff56c282557", d.Encoded)
+			},
+		},
+		{
+			name: "invalid URL - not a blob URL",
+			url:  "https://example.com/file.tar.gz",
+			expect: func(t *testing.T, d *Digest, err error) {
+				assert := assert.New(t)
+				assert.Error(err)
+				assert.Nil(d)
+			},
+		},
+		{
+			name: "invalid URL - empty string",
+			url:  "",
+			expect: func(t *testing.T, d *Digest, err error) {
+				assert := assert.New(t)
+				assert.Error(err)
+				assert.Nil(d)
+			},
+		},
+		{
+			name: "invalid URL - manifest URL",
+			url:  "https://registry.example.com/v2/library/nginx/manifests/sha256:c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4",
+			expect: func(t *testing.T, d *Digest, err error) {
+				assert := assert.New(t)
+				assert.Error(err)
+				assert.Nil(d)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := ExtractFromBlobURL(tc.url)
+			tc.expect(t, d, err)
+		})
+	}
+}

--- a/pkg/idgen/task_id.go
+++ b/pkg/idgen/task_id.go
@@ -182,6 +182,18 @@ func TaskIDV2ByContent(content string) string {
 	return pkgdigest.SHA256FromStrings(content)
 }
 
+// TaskIDByBlobDigest generates task id by blob digest.
+// It extracts the digest from the OCI blob URL and returns the encoded value as the task ID,
+// consistent with the Rust client's BlobDigestBased task ID calculation.
+func TaskIDByBlobDigest(url string) string {
+	d, err := pkgdigest.ExtractFromBlobURL(url)
+	if err != nil {
+		return ""
+	}
+
+	return d.Encoded
+}
+
 // PersistentCacheTaskIDByContent generates persistent cache task id by content.
 func PersistentCacheTaskIDByContent(content string) string {
 	return pkgdigest.SHA256FromStrings(content)

--- a/pkg/idgen/task_id_test.go
+++ b/pkg/idgen/task_id_test.go
@@ -241,3 +241,74 @@ func TestPersistentCacheTaskIDbyContent(t *testing.T) {
 		})
 	}
 }
+
+func TestTaskIDByBlobDigest(t *testing.T) {
+	tests := []struct {
+		name   string
+		url    string
+		expect func(t *testing.T, d string)
+	}{
+		{
+			name: "generate taskID from sha256 blob URL",
+			url:  "https://registry.example.com/v2/library/nginx/blobs/sha256:c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4",
+			expect: func(t *testing.T, d string) {
+				assert := assert.New(t)
+				assert.Equal("c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4", d)
+			},
+		},
+		{
+			name: "generate taskID from sha256 blob URL with query params",
+			url:  "https://registry.example.com/v2/library/nginx/blobs/sha256:c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4?foo=bar",
+			expect: func(t *testing.T, d string) {
+				assert := assert.New(t)
+				assert.Equal("c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4", d)
+			},
+		},
+		{
+			name: "generate taskID from sha256 blob URL with nested repository",
+			url:  "https://registry.example.com/v2/org/team/nginx/blobs/sha256:c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4",
+			expect: func(t *testing.T, d string) {
+				assert := assert.New(t)
+				assert.Equal("c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4", d)
+			},
+		},
+		{
+			name: "generate taskID from sha512 blob URL",
+			url:  "https://registry.example.com/v2/library/nginx/blobs/sha512:dc6b68d13b8cf959644b935f1192b02c71aa7a5cf653bd43b4480fa89eec8d4d3f16a2278ec8c3b40ab1fdb233b3173a78fd83590d6f739e0c9e8ff56c282557",
+			expect: func(t *testing.T, d string) {
+				assert := assert.New(t)
+				assert.Equal("dc6b68d13b8cf959644b935f1192b02c71aa7a5cf653bd43b4480fa89eec8d4d3f16a2278ec8c3b40ab1fdb233b3173a78fd83590d6f739e0c9e8ff56c282557", d)
+			},
+		},
+		{
+			name: "same blob digest from different registries produces same taskID",
+			url:  "https://another-registry.example.com/v2/library/nginx/blobs/sha256:c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4",
+			expect: func(t *testing.T, d string) {
+				assert := assert.New(t)
+				assert.Equal("c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4", d)
+			},
+		},
+		{
+			name: "invalid URL returns empty taskID",
+			url:  "https://example.com/file.tar.gz",
+			expect: func(t *testing.T, d string) {
+				assert := assert.New(t)
+				assert.Equal("", d)
+			},
+		},
+		{
+			name: "empty URL returns empty taskID",
+			url:  "",
+			expect: func(t *testing.T, d string) {
+				assert := assert.New(t)
+				assert.Equal("", d)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.expect(t, TaskIDByBlobDigest(tc.url))
+		})
+	}
+}

--- a/scheduler/job/job.go
+++ b/scheduler/job/job.go
@@ -45,6 +45,7 @@ import (
 	internaljob "d7y.io/dragonfly/v2/internal/job"
 	managertypes "d7y.io/dragonfly/v2/manager/types"
 	"d7y.io/dragonfly/v2/pkg/dfnet"
+	pkgdigest "d7y.io/dragonfly/v2/pkg/digest"
 	"d7y.io/dragonfly/v2/pkg/idgen"
 	cndsystemclient "d7y.io/dragonfly/v2/pkg/rpc/cdnsystem/client"
 	"d7y.io/dragonfly/v2/scheduler/config"
@@ -360,7 +361,13 @@ func (j *job) preheatV2SingleSeedPeer(ctx context.Context, req *internaljob.Preh
 // preheatV2SingleSeedPeerByURL preheats job by v2 grpc protocol for single seed peer by URL.
 func (j *job) preheatV2SingleSeedPeerByURL(ctx context.Context, url string, req *internaljob.PreheatRequest, log *logger.SugaredLoggerOnWith) (*internaljob.PreheatResponse, error) {
 	filteredQueryParams := idgen.ParseFilteredQueryParams(req.FilteredQueryParams)
-	taskID := idgen.TaskIDV2ByURLBased(url, req.PieceLength, req.Tag, req.Application, filteredQueryParams, "")
+	isBlobURL := pkgdigest.IsBlobURL(url)
+	var taskID string
+	if isBlobURL {
+		taskID = idgen.TaskIDByBlobDigest(url)
+	} else {
+		taskID = idgen.TaskIDV2ByURLBased(url, req.PieceLength, req.Tag, req.Application, filteredQueryParams, "")
+	}
 	advertiseIP := j.config.Server.AdvertiseIP.String()
 
 	selected, err := j.resource.SeedPeer().Select(ctx, taskID)
@@ -378,20 +385,21 @@ func (j *job) preheatV2SingleSeedPeerByURL(ctx context.Context, url string, req 
 
 	stream, err := client.DownloadTask(ctx, taskID, &dfdaemonv2.DownloadTaskRequest{
 		Download: &commonv2.Download{
-			Url:                 url,
-			PieceLength:         req.PieceLength,
-			Type:                commonv2.TaskType_STANDARD,
-			Tag:                 &req.Tag,
-			Application:         &req.Application,
-			Priority:            commonv2.Priority(req.Priority),
-			FilteredQueryParams: filteredQueryParams,
-			RequestHeader:       req.Headers,
-			CertificateChain:    req.CertificateChain,
-			RemoteIp:            &advertiseIP,
-			Timeout:             durationpb.New(req.Timeout),
-			ObjectStorage:       req.ObjectStorage,
-			Hdfs:                req.Hdfs,
-			OutputPath:          req.OutputPath,
+			Url:                          url,
+			PieceLength:                  req.PieceLength,
+			Type:                         commonv2.TaskType_STANDARD,
+			Tag:                          &req.Tag,
+			Application:                  &req.Application,
+			Priority:                     commonv2.Priority(req.Priority),
+			FilteredQueryParams:          filteredQueryParams,
+			RequestHeader:                req.Headers,
+			CertificateChain:             req.CertificateChain,
+			RemoteIp:                     &advertiseIP,
+			Timeout:                      durationpb.New(req.Timeout),
+			ObjectStorage:                req.ObjectStorage,
+			Hdfs:                         req.Hdfs,
+			OutputPath:                   req.OutputPath,
+			EnableTaskIdBasedBlobDigest:  isBlobURL,
 		}})
 	if err != nil {
 		log.Errorf("[preheat]: preheat failed: %s", err.Error())
@@ -455,7 +463,13 @@ func (j *job) PreheatAllSeedPeers(ctx context.Context, req *internaljob.PreheatR
 				peg.SetLimit(int(req.ConcurrentPeerCount))
 				peg.Go(func() error {
 					filteredQueryParams := idgen.ParseFilteredQueryParams(req.FilteredQueryParams)
-					taskID := idgen.TaskIDV2ByURLBased(url, req.PieceLength, req.Tag, req.Application, filteredQueryParams, "")
+					isBlobURL := pkgdigest.IsBlobURL(url)
+					var taskID string
+					if isBlobURL {
+						taskID = idgen.TaskIDByBlobDigest(url)
+					} else {
+						taskID = idgen.TaskIDV2ByURLBased(url, req.PieceLength, req.Tag, req.Application, filteredQueryParams, "")
+					}
 					hostID := idgen.HostIDV2(ip, hostname, true)
 					compositeID := fmt.Sprintf("%s-%s", taskID, hostID)
 					log := logger.WithPreheatJobAndHost(req.GroupUUID, req.TaskUUID, taskID, url, idgen.HostIDV2(ip, hostname, true), hostname, ip)
@@ -479,20 +493,21 @@ func (j *job) PreheatAllSeedPeers(ctx context.Context, req *internaljob.PreheatR
 						ctx,
 						taskID,
 						&dfdaemonv2.DownloadTaskRequest{Download: &commonv2.Download{
-							Url:                 url,
-							PieceLength:         req.PieceLength,
-							Type:                commonv2.TaskType_STANDARD,
-							Tag:                 &req.Tag,
-							Application:         &req.Application,
-							Priority:            commonv2.Priority(req.Priority),
-							FilteredQueryParams: filteredQueryParams,
-							RequestHeader:       req.Headers,
-							Timeout:             durationpb.New(req.Timeout),
-							CertificateChain:    req.CertificateChain,
-							RemoteIp:            &advertiseIP,
-							ObjectStorage:       req.ObjectStorage,
-							Hdfs:                req.Hdfs,
-							OutputPath:          req.OutputPath,
+							Url:                          url,
+							PieceLength:                  req.PieceLength,
+							Type:                         commonv2.TaskType_STANDARD,
+							Tag:                          &req.Tag,
+							Application:                  &req.Application,
+							Priority:                     commonv2.Priority(req.Priority),
+							FilteredQueryParams:          filteredQueryParams,
+							RequestHeader:                req.Headers,
+							Timeout:                      durationpb.New(req.Timeout),
+							CertificateChain:             req.CertificateChain,
+							RemoteIp:                     &advertiseIP,
+							ObjectStorage:                req.ObjectStorage,
+							Hdfs:                         req.Hdfs,
+							OutputPath:                   req.OutputPath,
+							EnableTaskIdBasedBlobDigest:  isBlobURL,
 						}})
 					if err != nil {
 						log.Errorf("[preheat]: preheat failed: %s", err.Error())
@@ -676,7 +691,13 @@ func (j *job) PreheatAllPeers(ctx context.Context, req *internaljob.PreheatReque
 				peg.SetLimit(int(req.ConcurrentPeerCount))
 				peg.Go(func() error {
 					filteredQueryParams := idgen.ParseFilteredQueryParams(req.FilteredQueryParams)
-					taskID := idgen.TaskIDV2ByURLBased(url, req.PieceLength, req.Tag, req.Application, filteredQueryParams, "")
+					isBlobURL := pkgdigest.IsBlobURL(url)
+					var taskID string
+					if isBlobURL {
+						taskID = idgen.TaskIDByBlobDigest(url)
+					} else {
+						taskID = idgen.TaskIDV2ByURLBased(url, req.PieceLength, req.Tag, req.Application, filteredQueryParams, "")
+					}
 					hostID := idgen.HostIDV2(ip, hostname, false)
 					compositeID := fmt.Sprintf("%s-%s", taskID, hostID)
 					log := logger.WithPreheatJobAndHost(req.GroupUUID, req.TaskUUID, taskID, url, idgen.HostIDV2(ip, hostname, true), hostname, ip)
@@ -700,20 +721,21 @@ func (j *job) PreheatAllPeers(ctx context.Context, req *internaljob.PreheatReque
 						ctx,
 						taskID,
 						&dfdaemonv2.DownloadTaskRequest{Download: &commonv2.Download{
-							Url:                 url,
-							PieceLength:         req.PieceLength,
-							Type:                commonv2.TaskType_STANDARD,
-							Tag:                 &req.Tag,
-							Application:         &req.Application,
-							Priority:            commonv2.Priority(req.Priority),
-							FilteredQueryParams: filteredQueryParams,
-							RequestHeader:       req.Headers,
-							Timeout:             durationpb.New(req.Timeout),
-							CertificateChain:    req.CertificateChain,
-							RemoteIp:            &advertiseIP,
-							ObjectStorage:       req.ObjectStorage,
-							Hdfs:                req.Hdfs,
-							OutputPath:          req.OutputPath,
+							Url:                          url,
+							PieceLength:                  req.PieceLength,
+							Type:                         commonv2.TaskType_STANDARD,
+							Tag:                          &req.Tag,
+							Application:                  &req.Application,
+							Priority:                     commonv2.Priority(req.Priority),
+							FilteredQueryParams:          filteredQueryParams,
+							RequestHeader:                req.Headers,
+							Timeout:                      durationpb.New(req.Timeout),
+							CertificateChain:             req.CertificateChain,
+							RemoteIp:                     &advertiseIP,
+							ObjectStorage:                req.ObjectStorage,
+							Hdfs:                         req.Hdfs,
+							OutputPath:                   req.OutputPath,
+							EnableTaskIdBasedBlobDigest:  isBlobURL,
 						}})
 					if err != nil {
 						log.Errorf("[preheat]: preheat failed: %s", err.Error())

--- a/scheduler/job/job.go
+++ b/scheduler/job/job.go
@@ -45,7 +45,6 @@ import (
 	internaljob "d7y.io/dragonfly/v2/internal/job"
 	managertypes "d7y.io/dragonfly/v2/manager/types"
 	"d7y.io/dragonfly/v2/pkg/dfnet"
-	pkgdigest "d7y.io/dragonfly/v2/pkg/digest"
 	"d7y.io/dragonfly/v2/pkg/idgen"
 	cndsystemclient "d7y.io/dragonfly/v2/pkg/rpc/cdnsystem/client"
 	"d7y.io/dragonfly/v2/scheduler/config"
@@ -361,13 +360,7 @@ func (j *job) preheatV2SingleSeedPeer(ctx context.Context, req *internaljob.Preh
 // preheatV2SingleSeedPeerByURL preheats job by v2 grpc protocol for single seed peer by URL.
 func (j *job) preheatV2SingleSeedPeerByURL(ctx context.Context, url string, req *internaljob.PreheatRequest, log *logger.SugaredLoggerOnWith) (*internaljob.PreheatResponse, error) {
 	filteredQueryParams := idgen.ParseFilteredQueryParams(req.FilteredQueryParams)
-	isBlobURL := pkgdigest.IsBlobURL(url)
-	var taskID string
-	if isBlobURL {
-		taskID = idgen.TaskIDByBlobDigest(url)
-	} else {
-		taskID = idgen.TaskIDV2ByURLBased(url, req.PieceLength, req.Tag, req.Application, filteredQueryParams, "")
-	}
+	taskID, isBlobURL := preheatTaskID(url, req.PieceLength, req.Tag, req.Application, filteredQueryParams)
 	advertiseIP := j.config.Server.AdvertiseIP.String()
 
 	selected, err := j.resource.SeedPeer().Select(ctx, taskID)
@@ -385,21 +378,21 @@ func (j *job) preheatV2SingleSeedPeerByURL(ctx context.Context, url string, req 
 
 	stream, err := client.DownloadTask(ctx, taskID, &dfdaemonv2.DownloadTaskRequest{
 		Download: &commonv2.Download{
-			Url:                          url,
-			PieceLength:                  req.PieceLength,
-			Type:                         commonv2.TaskType_STANDARD,
-			Tag:                          &req.Tag,
-			Application:                  &req.Application,
-			Priority:                     commonv2.Priority(req.Priority),
-			FilteredQueryParams:          filteredQueryParams,
-			RequestHeader:                req.Headers,
-			CertificateChain:             req.CertificateChain,
-			RemoteIp:                     &advertiseIP,
-			Timeout:                      durationpb.New(req.Timeout),
-			ObjectStorage:                req.ObjectStorage,
-			Hdfs:                         req.Hdfs,
-			OutputPath:                   req.OutputPath,
-			EnableTaskIdBasedBlobDigest:  isBlobURL,
+			Url:                         url,
+			PieceLength:                 req.PieceLength,
+			Type:                        commonv2.TaskType_STANDARD,
+			Tag:                         &req.Tag,
+			Application:                 &req.Application,
+			Priority:                    commonv2.Priority(req.Priority),
+			FilteredQueryParams:         filteredQueryParams,
+			RequestHeader:               req.Headers,
+			CertificateChain:            req.CertificateChain,
+			RemoteIp:                    &advertiseIP,
+			Timeout:                     durationpb.New(req.Timeout),
+			ObjectStorage:               req.ObjectStorage,
+			Hdfs:                        req.Hdfs,
+			OutputPath:                  req.OutputPath,
+			EnableTaskIdBasedBlobDigest: isBlobURL,
 		}})
 	if err != nil {
 		log.Errorf("[preheat]: preheat failed: %s", err.Error())
@@ -463,13 +456,7 @@ func (j *job) PreheatAllSeedPeers(ctx context.Context, req *internaljob.PreheatR
 				peg.SetLimit(int(req.ConcurrentPeerCount))
 				peg.Go(func() error {
 					filteredQueryParams := idgen.ParseFilteredQueryParams(req.FilteredQueryParams)
-					isBlobURL := pkgdigest.IsBlobURL(url)
-					var taskID string
-					if isBlobURL {
-						taskID = idgen.TaskIDByBlobDigest(url)
-					} else {
-						taskID = idgen.TaskIDV2ByURLBased(url, req.PieceLength, req.Tag, req.Application, filteredQueryParams, "")
-					}
+					taskID, isBlobURL := preheatTaskID(url, req.PieceLength, req.Tag, req.Application, filteredQueryParams)
 					hostID := idgen.HostIDV2(ip, hostname, true)
 					compositeID := fmt.Sprintf("%s-%s", taskID, hostID)
 					log := logger.WithPreheatJobAndHost(req.GroupUUID, req.TaskUUID, taskID, url, idgen.HostIDV2(ip, hostname, true), hostname, ip)
@@ -493,21 +480,21 @@ func (j *job) PreheatAllSeedPeers(ctx context.Context, req *internaljob.PreheatR
 						ctx,
 						taskID,
 						&dfdaemonv2.DownloadTaskRequest{Download: &commonv2.Download{
-							Url:                          url,
-							PieceLength:                  req.PieceLength,
-							Type:                         commonv2.TaskType_STANDARD,
-							Tag:                          &req.Tag,
-							Application:                  &req.Application,
-							Priority:                     commonv2.Priority(req.Priority),
-							FilteredQueryParams:          filteredQueryParams,
-							RequestHeader:                req.Headers,
-							Timeout:                      durationpb.New(req.Timeout),
-							CertificateChain:             req.CertificateChain,
-							RemoteIp:                     &advertiseIP,
-							ObjectStorage:                req.ObjectStorage,
-							Hdfs:                         req.Hdfs,
-							OutputPath:                   req.OutputPath,
-							EnableTaskIdBasedBlobDigest:  isBlobURL,
+							Url:                         url,
+							PieceLength:                 req.PieceLength,
+							Type:                        commonv2.TaskType_STANDARD,
+							Tag:                         &req.Tag,
+							Application:                 &req.Application,
+							Priority:                    commonv2.Priority(req.Priority),
+							FilteredQueryParams:         filteredQueryParams,
+							RequestHeader:               req.Headers,
+							Timeout:                     durationpb.New(req.Timeout),
+							CertificateChain:            req.CertificateChain,
+							RemoteIp:                    &advertiseIP,
+							ObjectStorage:               req.ObjectStorage,
+							Hdfs:                        req.Hdfs,
+							OutputPath:                  req.OutputPath,
+							EnableTaskIdBasedBlobDigest: isBlobURL,
 						}})
 					if err != nil {
 						log.Errorf("[preheat]: preheat failed: %s", err.Error())
@@ -691,13 +678,7 @@ func (j *job) PreheatAllPeers(ctx context.Context, req *internaljob.PreheatReque
 				peg.SetLimit(int(req.ConcurrentPeerCount))
 				peg.Go(func() error {
 					filteredQueryParams := idgen.ParseFilteredQueryParams(req.FilteredQueryParams)
-					isBlobURL := pkgdigest.IsBlobURL(url)
-					var taskID string
-					if isBlobURL {
-						taskID = idgen.TaskIDByBlobDigest(url)
-					} else {
-						taskID = idgen.TaskIDV2ByURLBased(url, req.PieceLength, req.Tag, req.Application, filteredQueryParams, "")
-					}
+					taskID, isBlobURL := preheatTaskID(url, req.PieceLength, req.Tag, req.Application, filteredQueryParams)
 					hostID := idgen.HostIDV2(ip, hostname, false)
 					compositeID := fmt.Sprintf("%s-%s", taskID, hostID)
 					log := logger.WithPreheatJobAndHost(req.GroupUUID, req.TaskUUID, taskID, url, idgen.HostIDV2(ip, hostname, true), hostname, ip)
@@ -721,21 +702,21 @@ func (j *job) PreheatAllPeers(ctx context.Context, req *internaljob.PreheatReque
 						ctx,
 						taskID,
 						&dfdaemonv2.DownloadTaskRequest{Download: &commonv2.Download{
-							Url:                          url,
-							PieceLength:                  req.PieceLength,
-							Type:                         commonv2.TaskType_STANDARD,
-							Tag:                          &req.Tag,
-							Application:                  &req.Application,
-							Priority:                     commonv2.Priority(req.Priority),
-							FilteredQueryParams:          filteredQueryParams,
-							RequestHeader:                req.Headers,
-							Timeout:                      durationpb.New(req.Timeout),
-							CertificateChain:             req.CertificateChain,
-							RemoteIp:                     &advertiseIP,
-							ObjectStorage:                req.ObjectStorage,
-							Hdfs:                         req.Hdfs,
-							OutputPath:                   req.OutputPath,
-							EnableTaskIdBasedBlobDigest:  isBlobURL,
+							Url:                         url,
+							PieceLength:                 req.PieceLength,
+							Type:                        commonv2.TaskType_STANDARD,
+							Tag:                         &req.Tag,
+							Application:                 &req.Application,
+							Priority:                    commonv2.Priority(req.Priority),
+							FilteredQueryParams:         filteredQueryParams,
+							RequestHeader:               req.Headers,
+							Timeout:                     durationpb.New(req.Timeout),
+							CertificateChain:            req.CertificateChain,
+							RemoteIp:                    &advertiseIP,
+							ObjectStorage:               req.ObjectStorage,
+							Hdfs:                        req.Hdfs,
+							OutputPath:                  req.OutputPath,
+							EnableTaskIdBasedBlobDigest: isBlobURL,
 						}})
 					if err != nil {
 						log.Errorf("[preheat]: preheat failed: %s", err.Error())

--- a/scheduler/job/task.go
+++ b/scheduler/job/task.go
@@ -1,0 +1,35 @@
+/*
+ *     Copyright 2025 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package job
+
+import (
+	pkgdigest "d7y.io/dragonfly/v2/pkg/digest"
+	"d7y.io/dragonfly/v2/pkg/idgen"
+)
+
+// preheatTaskID computes the task ID for a preheat URL.
+// If the URL is an OCI blob URL, it uses the blob digest-based task ID
+// and returns true for isBlobURL; otherwise it falls back to URL-based task ID.
+func preheatTaskID(url string, pieceLength *uint64, tag, application string, filteredQueryParams []string) (taskID string, isBlobURL bool) {
+	isBlobURL = pkgdigest.IsBlobURL(url)
+	if isBlobURL {
+		taskID = idgen.TaskIDByBlobDigest(url)
+	} else {
+		taskID = idgen.TaskIDV2ByURLBased(url, pieceLength, tag, application, filteredQueryParams, "")
+	}
+	return
+}

--- a/scheduler/job/task_test.go
+++ b/scheduler/job/task_test.go
@@ -1,0 +1,149 @@
+/*
+ *     Copyright 2025 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package job
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"d7y.io/dragonfly/v2/pkg/idgen"
+)
+
+func TestPreheatTaskID(t *testing.T) {
+	pieceLength := uint64(1024)
+
+	tests := []struct {
+		name                string
+		url                 string
+		pieceLength         *uint64
+		tag                 string
+		application         string
+		filteredQueryParams []string
+		expectIsBlobURL     bool
+		expectTaskID        func(t *testing.T, taskID string)
+	}{
+		{
+			name:                "blob URL uses blob digest-based task ID",
+			url:                 "https://registry.example.com/v2/library/nginx/blobs/sha256:c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4",
+			pieceLength:         &pieceLength,
+			tag:                 "foo",
+			application:         "bar",
+			filteredQueryParams: nil,
+			expectIsBlobURL:     true,
+			expectTaskID: func(t *testing.T, taskID string) {
+				assert.Equal(t, "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4", taskID)
+			},
+		},
+		{
+			name:                "blob URL with query params uses blob digest-based task ID",
+			url:                 "https://registry.example.com/v2/library/nginx/blobs/sha256:c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4?foo=bar",
+			pieceLength:         &pieceLength,
+			tag:                 "foo",
+			application:         "bar",
+			filteredQueryParams: nil,
+			expectIsBlobURL:     true,
+			expectTaskID: func(t *testing.T, taskID string) {
+				assert.Equal(t, "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4", taskID)
+			},
+		},
+		{
+			name:                "blob URL with nested repository uses blob digest-based task ID",
+			url:                 "https://registry.example.com/v2/org/team/nginx/blobs/sha256:c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4",
+			pieceLength:         &pieceLength,
+			tag:                 "foo",
+			application:         "bar",
+			filteredQueryParams: nil,
+			expectIsBlobURL:     true,
+			expectTaskID: func(t *testing.T, taskID string) {
+				assert.Equal(t, "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4", taskID)
+			},
+		},
+		{
+			name:                "same blob digest from different registries produces same task ID",
+			url:                 "https://another-registry.example.com/v2/library/nginx/blobs/sha256:c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4",
+			pieceLength:         &pieceLength,
+			tag:                 "foo",
+			application:         "bar",
+			filteredQueryParams: nil,
+			expectIsBlobURL:     true,
+			expectTaskID: func(t *testing.T, taskID string) {
+				assert.Equal(t, "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4", taskID)
+			},
+		},
+		{
+			name:                "non-blob URL uses URL-based task ID",
+			url:                 "https://example.com/file.tar.gz",
+			pieceLength:         &pieceLength,
+			tag:                 "foo",
+			application:         "bar",
+			filteredQueryParams: nil,
+			expectIsBlobURL:     false,
+			expectTaskID: func(t *testing.T, taskID string) {
+				expected := idgen.TaskIDV2ByURLBased("https://example.com/file.tar.gz", &pieceLength, "foo", "bar", nil, "")
+				assert.Equal(t, expected, taskID)
+			},
+		},
+		{
+			name:                "non-blob URL with filtered query params uses URL-based task ID",
+			url:                 "https://example.com/file.tar.gz?foo=foo&bar=bar",
+			pieceLength:         &pieceLength,
+			tag:                 "foo",
+			application:         "bar",
+			filteredQueryParams: []string{"foo", "bar"},
+			expectIsBlobURL:     false,
+			expectTaskID: func(t *testing.T, taskID string) {
+				expected := idgen.TaskIDV2ByURLBased("https://example.com/file.tar.gz?foo=foo&bar=bar", &pieceLength, "foo", "bar", []string{"foo", "bar"}, "")
+				assert.Equal(t, expected, taskID)
+			},
+		},
+		{
+			name:                "manifest URL is not a blob URL",
+			url:                 "https://registry.example.com/v2/library/nginx/manifests/latest",
+			pieceLength:         &pieceLength,
+			tag:                 "foo",
+			application:         "bar",
+			filteredQueryParams: nil,
+			expectIsBlobURL:     false,
+			expectTaskID: func(t *testing.T, taskID string) {
+				expected := idgen.TaskIDV2ByURLBased("https://registry.example.com/v2/library/nginx/manifests/latest", &pieceLength, "foo", "bar", nil, "")
+				assert.Equal(t, expected, taskID)
+			},
+		},
+		{
+			name:                "empty URL is not a blob URL",
+			url:                 "",
+			pieceLength:         &pieceLength,
+			tag:                 "",
+			application:         "",
+			filteredQueryParams: nil,
+			expectIsBlobURL:     false,
+			expectTaskID: func(t *testing.T, taskID string) {
+				expected := idgen.TaskIDV2ByURLBased("", &pieceLength, "", "", nil, "")
+				assert.Equal(t, expected, taskID)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			taskID, isBlobURL := preheatTaskID(tc.url, tc.pieceLength, tc.tag, tc.application, tc.filteredQueryParams)
+			assert.Equal(t, tc.expectIsBlobURL, isBlobURL)
+			tc.expectTaskID(t, taskID)
+		})
+	}
+}

--- a/test/e2e/manager/preheat.go
+++ b/test/e2e/manager/preheat.go
@@ -234,11 +234,11 @@ var _ = Describe("Preheat with Manager", func() {
 
 			taskMetadatas := []util.TaskMetadata{
 				{
-					ID:     "a5040eb77de7f771cb3ce3ecb2ebb61af124d3341e0b5c6854b7e220eb0dc680",
+					ID:     "a711f05d33845e2e9deffcfcc5adf082d7c6e97e3e3a881d193d9aae38f092a8",
 					Sha256: "a711f05d33845e2e9deffcfcc5adf082d7c6e97e3e3a881d193d9aae38f092a8",
 				},
 				{
-					ID:     "f9f24ea0c08c3637d2d5770fbf80a201f69482226de7cf4490bb1c540ac51b37",
+					ID:     "f643e116a03d9604c344edb345d7592c48cc00f2a4848aaf773411f4fb30d2f5",
 					Sha256: "f643e116a03d9604c344edb345d7592c48cc00f2a4848aaf773411f4fb30d2f5",
 				},
 			}


### PR DESCRIPTION
## Description

This PR fixes a preheat cache miss issue caused by task ID mismatch between the scheduler's preheat requests and the dfdaemon client's default task ID calculation behavior.

**Root Cause:** When the dfdaemon client downloads OCI blob URLs (e.g., `/v2/<repository>/blobs/sha256:<digest>`), it defaults `enable_task_id_based_blob_digest` to `true` (see `client/dragonfly-client-util/src/request/mod.rs`), which means the task ID is derived from the blob digest rather than the full URL. However, when the scheduler sends preheat requests, it does not set `EnableTaskIdBasedBlobDigest`, so the task ID is calculated using `TaskIDV2ByURLBased` (based on the full URL). This results in different task IDs for the same blob, causing the preheated cache to be missed by subsequent dfdaemon downloads.

**Changes:**

1. **`pkg/digest/digest.go`** — Added `IsBlobURL()` and `ExtractFromBlobURL()` utilities to detect OCI blob URLs and extract the digest from them, mirroring the Rust client's `is_blob_url()` and `BLOB_URL_REGEX` in `client/dragonfly-client-util/src/digest/mod.rs`.

2. **`pkg/idgen/task_id.go`** — Added `TaskIDByBlobDigest()` function that generates a task ID from the blob digest extracted from an OCI blob URL, consistent with the Rust client's `TaskIDParameter::BlobDigestBased` logic.

3. **`scheduler/job/job.go`** — Updated three preheat functions (`preheatV2SingleSeedPeerByURL`, `PreheatAllSeedPeers`, `PreheatAllPeers`) to:
   - Detect whether the URL is an OCI blob URL using `pkgdigest.IsBlobURL()`.
   - If it is a blob URL, use `idgen.TaskIDByBlobDigest()` for task ID calculation.
   - Set `EnableTaskIdBasedBlobDigest: isBlobURL` in the `DownloadTaskRequest` to align with the dfdaemon client's default behavior.

4. **`pkg/digest/digest_test.go`** — Added unit tests for `IsBlobURL()` (9 cases) and `ExtractFromBlobURL()` (7 cases), covering valid blob URLs with various schemes, query params, nested repositories, and invalid URLs.

5. **`pkg/idgen/task_id_test.go`** — Added unit tests for `TaskIDByBlobDigest()` (7 cases), including a key test that verifies the same blob digest from different registries produces the same task ID.

## Motivation and Context

When preheating OCI container images, the scheduler and dfdaemon client calculate different task IDs for the same blob URL, causing preheated data to never be served to subsequent download requests. This is because:

- **dfdaemon client** (Rust): defaults `enable_task_id_based_blob_digest` to `true` for proxy requests, using the blob's SHA256 digest as the task ID for OCI blob URLs.
- **scheduler preheat**: always uses `TaskIDV2ByURLBased` which incorporates the full URL, producing a different task ID.

This mismatch means preheat operations complete successfully (data is cached on seed peers), but when dfdaemon later downloads the same blob, it looks for a task ID based on the blob digest and cannot find the preheated data, resulting in a cache miss and redundant download.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
