### PR TITLE
hide token secret in personal access token read endpoints

### DIFF
--- a/manager/service/personal_access_token.go
+++ b/manager/service/personal_access_token.go
@@ -84,6 +84,9 @@ func (s *service) GetPersonalAccessToken(ctx context.Context, id uint) (*models.
 		return nil, err
 	}
 
+	// The token is a secret credential and is only returned once on creation,
+	// do not expose it on read paths.
+	personalAccessToken.Token = ""
 	return &personalAccessToken, nil
 }
 
@@ -95,6 +98,12 @@ func (s *service) GetPersonalAccessTokens(ctx context.Context, q types.GetPerson
 		UserID: q.UserID,
 	}).Preload("User").Find(&personalAccessToken).Limit(-1).Offset(-1).Count(&count).Error; err != nil {
 		return nil, 0, err
+	}
+
+	// The token is a secret credential and is only returned once on creation,
+	// do not expose it on read paths.
+	for i := range personalAccessToken {
+		personalAccessToken[i].Token = ""
 	}
 
 	return personalAccessToken, count, nil

--- a/manager/service/personal_access_token.go
+++ b/manager/service/personal_access_token.go
@@ -92,19 +92,19 @@ func (s *service) GetPersonalAccessToken(ctx context.Context, id uint) (*models.
 
 func (s *service) GetPersonalAccessTokens(ctx context.Context, q types.GetPersonalAccessTokensQuery) ([]models.PersonalAccessToken, int64, error) {
 	var count int64
-	personalAccessToken := []models.PersonalAccessToken{}
+	personalAccessTokens := []models.PersonalAccessToken{}
 	if err := s.db.WithContext(ctx).Scopes(models.Paginate(q.Page, q.PerPage)).Where(&models.PersonalAccessToken{
 		State:  q.State,
 		UserID: q.UserID,
-	}).Preload("User").Find(&personalAccessToken).Limit(-1).Offset(-1).Count(&count).Error; err != nil {
+	}).Preload("User").Find(&personalAccessTokens).Limit(-1).Offset(-1).Count(&count).Error; err != nil {
 		return nil, 0, err
 	}
 
 	// The token is a secret credential and is only returned once on creation,
 	// do not expose it on read paths.
-	for i := range personalAccessToken {
-		personalAccessToken[i].Token = ""
+	for i := range personalAccessTokens {
+		personalAccessTokens[i].Token = ""
 	}
 
-	return personalAccessToken, count, nil
+	return personalAccessTokens, count, nil
 }


### PR DESCRIPTION
## Description

The personal access token read endpoints return the full `models.PersonalAccessToken`, and its `Token` field is tagged `json:"token"`, so the secret bearer value is serialized in the response.

1. `GetPersonalAccessToken` (`GET /api/v1/personal-access-tokens/{id}`) and `GetPersonalAccessTokens` (`GET /api/v1/personal-access-tokens`) both marshal the stored token value.
2. RBAC seeds every authenticated user with the guest role, which holds `read` on all API objects, so any low-privilege user can list these endpoints and read the secret token of every user, then reuse those tokens (job/cluster scopes) to act as the owner.

Cleared the `Token` field in both read service methods. The token stays write-once, returned only by the create response.

## Related Issue

None filed; reporting the fix directly.

## Motivation and Context

A token is a credential. Read paths reachable by guest-level users should expose token metadata (name, scopes, state, owner) but never the secret value itself.

## Screenshots (if appropriate)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.