### PR TITLE
fix(manager): redact secrets from job responses

### DIFF
--- a/manager/handlers/job.go
+++ b/manager/handlers/job.go
@@ -63,7 +63,7 @@ func (h *Handlers) CreateJob(ctx *gin.Context) {
 			return
 		}
 
-		ctx.JSON(http.StatusOK, job)
+		ctx.JSON(http.StatusOK, sanitizeJobForResponse(job))
 	case job.SyncPeersJob:
 		var json types.CreateSyncPeersJobRequest
 		if err := ctx.ShouldBindBodyWith(&json, binding.JSON); err != nil {
@@ -98,7 +98,7 @@ func (h *Handlers) CreateJob(ctx *gin.Context) {
 			return
 		}
 
-		ctx.JSON(http.StatusOK, job)
+		ctx.JSON(http.StatusOK, sanitizeJobForResponse(job))
 	case job.GetImageDistributionJob:
 		var json types.CreateGetImageDistributionJobRequest
 		if err := ctx.ShouldBindBodyWith(&json, binding.JSON); err != nil {
@@ -131,7 +131,7 @@ func (h *Handlers) CreateJob(ctx *gin.Context) {
 			return
 		}
 
-		ctx.JSON(http.StatusOK, job)
+		ctx.JSON(http.StatusOK, sanitizeJobForResponse(job))
 	case job.GCJob:
 		var json types.CreateGCJobRequest
 		if err := ctx.ShouldBindBodyWith(&json, binding.JSON); err != nil {
@@ -145,7 +145,7 @@ func (h *Handlers) CreateJob(ctx *gin.Context) {
 			return
 		}
 
-		ctx.JSON(http.StatusOK, job)
+		ctx.JSON(http.StatusOK, sanitizeJobForResponse(job))
 	default:
 		ctx.JSON(http.StatusUnprocessableEntity, gin.H{"errors": "Unknow type"})
 	}
@@ -210,7 +210,7 @@ func (h *Handlers) UpdateJob(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, job)
+	ctx.JSON(http.StatusOK, sanitizeJobForResponse(job))
 }
 
 // @Summary Get Job
@@ -238,7 +238,7 @@ func (h *Handlers) GetJob(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, job)
+	ctx.JSON(http.StatusOK, sanitizeJobForResponse(job))
 }
 
 // @Summary Get Jobs
@@ -269,5 +269,5 @@ func (h *Handlers) GetJobs(ctx *gin.Context) {
 	}
 
 	h.setPaginationLinkHeader(ctx, query.Page, query.PerPage, int(count))
-	ctx.JSON(http.StatusOK, jobs)
+	ctx.JSON(http.StatusOK, sanitizeJobsForResponse(jobs))
 }

--- a/manager/handlers/job_response.go
+++ b/manager/handlers/job_response.go
@@ -1,0 +1,98 @@
+/*
+ *     Copyright 2026 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package handlers
+
+import "d7y.io/dragonfly/v2/manager/models"
+
+var (
+	jobArgsSecretKeys = map[string]struct{}{
+		"password": {},
+		"headers":  {},
+	}
+
+	objectStorageSecretKeys = map[string]struct{}{
+		"access_key_id":     {},
+		"access_key_secret": {},
+		"session_token":     {},
+		"security_token":    {},
+	}
+
+	hdfsSecretKeys = map[string]struct{}{
+		"delegation_token": {},
+	}
+)
+
+func sanitizeJobForResponse(job *models.Job) models.Job {
+	if job == nil {
+		return models.Job{}
+	}
+
+	sanitized := *job
+	sanitized.Args = sanitizeJobArgs(job.Args)
+	return sanitized
+}
+
+func sanitizeJobsForResponse(jobs []models.Job) []models.Job {
+	sanitized := make([]models.Job, 0, len(jobs))
+	for i := range jobs {
+		sanitized = append(sanitized, sanitizeJobForResponse(&jobs[i]))
+	}
+
+	return sanitized
+}
+
+func sanitizeJobArgs(args models.JSONMap) models.JSONMap {
+	if args == nil {
+		return nil
+	}
+
+	sanitized := make(models.JSONMap, len(args))
+	for key, value := range args {
+		if _, ok := jobArgsSecretKeys[key]; ok {
+			continue
+		}
+
+		switch key {
+		case "object_storage":
+			sanitized[key] = sanitizeNestedMap(value, objectStorageSecretKeys)
+		case "hdfs":
+			sanitized[key] = sanitizeNestedMap(value, hdfsSecretKeys)
+		default:
+			sanitized[key] = value
+		}
+	}
+
+	return sanitized
+}
+
+func sanitizeNestedMap(value any, secretKeys map[string]struct{}) any {
+	nested, ok := value.(map[string]any)
+	if !ok {
+		return value
+	}
+
+	sanitized := make(map[string]any, len(nested))
+	for key, nestedValue := range nested {
+		if _, ok := secretKeys[key]; ok {
+			continue
+		}
+
+		sanitized[key] = nestedValue
+	}
+
+	return sanitized
+}

--- a/manager/handlers/job_test.go
+++ b/manager/handlers/job_test.go
@@ -92,6 +92,40 @@ var (
 		Type:      "preheat",
 		BIO:       "bio",
 		TaskID:    "dec6fe878785cea844dcecdf2ea25e19156822201016455733e47e9f0bfab563",
+		Args: models.JSONMap{
+			"url":      "https://registry.example.com/v2/library/busybox/manifests/latest",
+			"username": "robot$dragonfly",
+			"password": "super-secret",
+			"headers": map[string]any{
+				"Authorization": "Bearer abc123",
+				"Accept":        "application/json",
+			},
+			"object_storage": map[string]any{
+				"endpoint":          "https://s3.example.com",
+				"access_key_id":     "access-key",
+				"access_key_secret": "secret-key",
+				"session_token":     "session-token",
+				"security_token":    "security-token",
+			},
+			"hdfs": map[string]any{
+				"delegation_token": "delegation-token",
+			},
+		},
+	}
+	mockSanitizedPreheatJobModel = &models.Job{
+		BaseModel: mockBaseModel,
+		UserID:    4,
+		Type:      "preheat",
+		BIO:       "bio",
+		TaskID:    "dec6fe878785cea844dcecdf2ea25e19156822201016455733e47e9f0bfab563",
+		Args: models.JSONMap{
+			"url":      "https://registry.example.com/v2/library/busybox/manifests/latest",
+			"username": "robot$dragonfly",
+			"object_storage": map[string]any{
+				"endpoint": "https://s3.example.com",
+			},
+			"hdfs": map[string]any{},
+		},
 	}
 	mockGetTaskJobModel = &models.Job{
 		BaseModel: mockBaseModel,
@@ -158,7 +192,7 @@ func TestHandlers_CreateJob(t *testing.T) {
 				job := models.Job{}
 				err := json.Unmarshal(w.Body.Bytes(), &job)
 				assert.NoError(err)
-				assert.Equal(mockPreheatJobModel, &job)
+				assert.Equal(mockSanitizedPreheatJobModel, &job)
 			},
 		},
 		{
@@ -289,7 +323,7 @@ func TestHandlers_UpdateJob(t *testing.T) {
 				job := models.Job{}
 				err := json.Unmarshal(w.Body.Bytes(), &job)
 				assert.NoError(err)
-				assert.Equal(mockPreheatJobModel, &job)
+				assert.Equal(mockSanitizedPreheatJobModel, &job)
 			},
 		},
 	}
@@ -337,7 +371,7 @@ func TestHandlers_GetJob(t *testing.T) {
 				job := models.Job{}
 				err := json.Unmarshal(w.Body.Bytes(), &job)
 				assert.NoError(err)
-				assert.Equal(mockPreheatJobModel, &job)
+				assert.Equal(mockSanitizedPreheatJobModel, &job)
 			},
 		},
 	}
@@ -389,7 +423,7 @@ func TestHandlers_GetJobs(t *testing.T) {
 				job := models.Job{}
 				err := json.Unmarshal(w.Body.Bytes()[1:w.Body.Len()-1], &job)
 				assert.NoError(err)
-				assert.Equal(mockPreheatJobModel, &job)
+				assert.Equal(mockSanitizedPreheatJobModel, &job)
 			},
 		},
 	}


### PR DESCRIPTION
## Description

Preheat job responses leak creds back in `args`. Kinda rough.
This strips `password`, `headers`, object storage secrets, and hdfs delegation tokens from create, get, list, and update job responses.

## Related Issue

N/A. Same leak pattern is already visible in public reports like #3226 and #3928.

## Motivation and Context

Repro:
1. `POST /oapi/v1/jobs` with a `preheat` job that includes private registry creds, request headers, object storage creds, or an hdfs delegation token.
2. `GET /oapi/v1/jobs/{id}` or `GET /oapi/v1/jobs`.
3. Before this patch the response echoes those secrets in `args`.

The job still runs with the original data. This only stops sending secrets back to API clients.

## Screenshots (if appropriate)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
