### PR TITLE
feat: add trace info about source seed client in the client SDK

### DIFF
--- a/internal/dflog/logger.go
+++ b/internal/dflog/logger.go
@@ -170,6 +170,12 @@ func WithHostnameAndIP(hostname, ip string) *SugaredLoggerOnWith {
 	}
 }
 
+func WithSeedPeer(hostID, hostname, ip string, port int) *SugaredLoggerOnWith {
+	return &SugaredLoggerOnWith{
+		withArgs: []any{"seedPeerHostID", hostID, "seedPeerHostname", hostname, "seedPeerIP", ip, "seedPeerPort", port},
+	}
+}
+
 func WithGroupUUID(groupUUID string) *SugaredLoggerOnWith {
 	return &SugaredLoggerOnWith{
 		withArgs: []any{"groupUUID", groupUUID},

--- a/pkg/rpc/dfdaemon/client/client_v2.go
+++ b/pkg/rpc/dfdaemon/client/client_v2.go
@@ -28,6 +28,8 @@ import (
 	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
@@ -212,10 +214,24 @@ type v2 struct {
 	*pkgbalancer.ConsistentHashingPickerBuilder
 }
 
+// setPeerTargetAttributes sets OpenTelemetry span attributes for the target peer address.
+func (v *v2) setPeerTargetAttributes(ctx context.Context) {
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+
+	span.SetAttributes(
+		attribute.String("d7y.dfdaemon.target", v.Target()),
+	)
+}
+
 // SyncPieces syncs pieces from the other peers.
 func (v *v2) SyncPieces(ctx context.Context, req *dfdaemonv2.SyncPiecesRequest, opts ...grpc.CallOption) (dfdaemonv2.DfdaemonUpload_SyncPiecesClient, error) {
 	ctx, cancel := context.WithTimeout(ctx, contextTimeout)
 	defer cancel()
+
+	v.setPeerTargetAttributes(ctx)
 
 	return v.DfdaemonUploadClient.SyncPieces(
 		context.WithValue(ctx, pkgbalancer.ContextKey, req.TaskId),
@@ -226,6 +242,8 @@ func (v *v2) SyncPieces(ctx context.Context, req *dfdaemonv2.SyncPiecesRequest, 
 
 // DownloadTask downloads task from p2p network.
 func (v *v2) DownloadTask(ctx context.Context, taskID string, req *dfdaemonv2.DownloadTaskRequest, opts ...grpc.CallOption) (dfdaemonv2.DfdaemonUpload_DownloadTaskClient, error) {
+	v.setPeerTargetAttributes(ctx)
+
 	return v.DfdaemonUploadClient.DownloadTask(
 		context.WithValue(ctx, pkgbalancer.ContextKey, taskID),
 		req,
@@ -260,6 +278,8 @@ func (v *v2) DeleteTask(ctx context.Context, req *dfdaemonv2.DeleteTaskRequest, 
 
 // DownloadPersistentTask downloads persistent task from p2p network.
 func (v *v2) DownloadPersistentTask(ctx context.Context, req *dfdaemonv2.DownloadPersistentTaskRequest, opts ...grpc.CallOption) (dfdaemonv2.DfdaemonUpload_DownloadPersistentTaskClient, error) {
+	v.setPeerTargetAttributes(ctx)
+
 	return v.DfdaemonUploadClient.DownloadPersistentTask(ctx, req, opts...)
 }
 
@@ -291,6 +311,8 @@ func (v *v2) DeletePersistentTask(ctx context.Context, req *dfdaemonv2.DeletePer
 
 // DownloadPersistentCacheTask downloads persistent cache task from p2p network.
 func (v *v2) DownloadPersistentCacheTask(ctx context.Context, req *dfdaemonv2.DownloadPersistentCacheTaskRequest, opts ...grpc.CallOption) (dfdaemonv2.DfdaemonUpload_DownloadPersistentCacheTaskClient, error) {
+	v.setPeerTargetAttributes(ctx)
+
 	return v.DfdaemonUploadClient.DownloadPersistentCacheTask(ctx, req, opts...)
 }
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -22,10 +22,18 @@ import (
 	"os"
 	"strings"
 
+	"go.opentelemetry.io/otel/attribute"
 	"gopkg.in/yaml.v3"
 
 	commonv1 "d7y.io/api/v2/pkg/apis/common/v1"
 	commonv2 "d7y.io/api/v2/pkg/apis/common/v2"
+)
+
+const (
+	AttributeSeedPeerHostID   = attribute.Key("d7y.scheduler.seed_peer.host_id")
+	AttributeSeedPeerHostname = attribute.Key("d7y.scheduler.seed_peer.hostname")
+	AttributeSeedPeerIP       = attribute.Key("d7y.scheduler.seed_peer.ip")
+	AttributeSeedPeerPort     = attribute.Key("d7y.scheduler.seed_peer.port")
 )
 
 // PEMContent supports load PEM format from file or just inline PEM format content

--- a/scheduler/resource/standard/seed_peer.go
+++ b/scheduler/resource/standard/seed_peer.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"stathat.com/c/consistent"
@@ -129,7 +130,16 @@ func (s *seedPeer) TriggerDownloadTask(ctx context.Context, taskID string, req *
 	}
 
 	addr := net.JoinHostPort(selected.IP, strconv.Itoa(int(selected.Port)))
-	logger.Infof("selected seed peer %s for task %s", addr, taskID)
+	if span := trace.SpanFromContext(ctx); span.IsRecording() {
+		span.SetAttributes(
+			attribute.String("d7y.scheduler.seed_peer.host_id", selected.ID),
+			attribute.String("d7y.scheduler.seed_peer.hostname", selected.Hostname),
+			attribute.String("d7y.scheduler.seed_peer.ip", selected.IP),
+			attribute.Int("d7y.scheduler.seed_peer.port", int(selected.Port)),
+		)
+	}
+	logger.WithSeedPeer(selected.ID, selected.Hostname, selected.IP, int(selected.Port)).
+		Infof("selected seed peer %s for task %s", addr, taskID)
 
 	client, err := s.clientPool.Get(addr, s.dialOptions...)
 	if err != nil {
@@ -179,7 +189,16 @@ func (s *seedPeer) TriggerTask(ctx context.Context, rg *http.Range, task *Task) 
 	}
 
 	addr := net.JoinHostPort(selected.IP, strconv.Itoa(int(selected.Port)))
-	logger.Infof("selected seed peer %s for task %s", addr, task.ID)
+	if span := trace.SpanFromContext(ctx); span.IsRecording() {
+		span.SetAttributes(
+			attribute.String("d7y.scheduler.seed_peer.host_id", selected.ID),
+			attribute.String("d7y.scheduler.seed_peer.hostname", selected.Hostname),
+			attribute.String("d7y.scheduler.seed_peer.ip", selected.IP),
+			attribute.Int("d7y.scheduler.seed_peer.port", int(selected.Port)),
+		)
+	}
+	logger.WithSeedPeer(selected.ID, selected.Hostname, selected.IP, int(selected.Port)).
+		Infof("selected seed peer %s for task %s", addr, task.ID)
 
 	// TODO(chlins): reuse the client if we encounter the performance issue in future.
 	client, err := cndsystemclient.GetClientByAddr(ctx, dfnet.NetAddr{Type: dfnet.TCP, Addr: addr}, s.dialOptions...)
@@ -300,7 +319,17 @@ func (s *seedPeer) Select(ctx context.Context, taskID string) (*Host, error) {
 		return nil, fmt.Errorf("failed to load host: %s", addr)
 	}
 
-	return host.(*Host), nil
+	selected := host.(*Host)
+	if span := trace.SpanFromContext(ctx); span.IsRecording() {
+		span.SetAttributes(
+			attribute.String("d7y.scheduler.seed_peer.selected.host_id", selected.ID),
+			attribute.String("d7y.scheduler.seed_peer.selected.hostname", selected.Hostname),
+			attribute.String("d7y.scheduler.seed_peer.selected.ip", selected.IP),
+			attribute.Int("d7y.scheduler.seed_peer.selected.port", int(selected.Port)),
+		)
+	}
+
+	return selected, nil
 }
 
 // HasAvailable returns whether there is any available seed peer.

--- a/scheduler/service/service_v1.go
+++ b/scheduler/service/service_v1.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/go-http-utils/headers"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/status"
 
@@ -731,6 +732,11 @@ func (v *V1) triggerTask(ctx context.Context, req *schedulerv1.PeerTaskRequest, 
 	}
 	peer.Log.Infof("peer priority is %d", priority)
 
+	// Set priority as a span attribute for traceability.
+	if span := trace.SpanFromContext(ctx); span.IsRecording() {
+		span.SetAttributes(attribute.String("d7y.scheduler.seed_peer.priority", priority.String()))
+	}
+
 	switch priority {
 	case commonv1.Priority_LEVEL6, commonv1.Priority_LEVEL0:
 		if v.resource.SeedPeer().HasAvailable() && !task.IsSeedPeerFailed() {
@@ -768,7 +774,9 @@ func (v *V1) triggerTask(ctx context.Context, req *schedulerv1.PeerTaskRequest, 
 
 // triggerSeedPeerTask starts to trigger seed peer task.
 func (v *V1) triggerSeedPeerTask(ctx context.Context, rg *http.Range, task *resource.Task) {
-	ctx, cancel := context.WithTimeout(trace.ContextWithSpan(context.Background(), trace.SpanFromContext(ctx)), v.config.SeedPeer.TaskDownloadTimeout)
+	// Use a detached context to preserve trace propagation while allowing
+	// the seed peer download to complete independently.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), v.config.SeedPeer.TaskDownloadTimeout)
 	defer cancel()
 
 	task.Log.Info("trigger seed peer")

--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -27,6 +27,8 @@ import (
 	"time"
 
 	"github.com/bits-and-blooms/bitset"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -1901,19 +1903,30 @@ func (v *V2) downloadTaskBySeedPeer(ctx context.Context, taskID string, download
 	// refer to https://github.com/dragonflyoss/api/blob/main/pkg/apis/common/v2/common.proto#L74.
 	priority := peer.CalculatePriority(v.dynconfig)
 	peer.Log.Infof("peer priority is %s", priority.String())
+
+	// Set priority as a span attribute for traceability.
+	if span := trace.SpanFromContext(ctx); span.IsRecording() {
+		span.SetAttributes(attribute.String("d7y.scheduler.seed_peer.priority", priority.String()))
+	}
+
+	// Use a detached context that preserves trace propagation but is not cancelled
+	// when the parent context is cancelled, so the seed peer download can complete
+	// independently as a fire-and-forget operation.
+	traceCtx := context.WithoutCancel(ctx)
+
 	switch priority {
 	case commonv2.Priority_LEVEL6, commonv2.Priority_LEVEL0:
 		// Super peer is first triggered to download back-to-source.
 		if !peer.Task.IsSeedPeerFailed() {
-			go func(ctx context.Context, taskID string, download *commonv2.Download, hostType types.HostType) {
+			go func(traceCtx context.Context, taskID string, download *commonv2.Download, hostType types.HostType) {
 				peer.Log.Infof("%s seed peer triggers download task", hostType.Name())
-				if err := v.resource.SeedPeer().TriggerDownloadTask(context.Background(), taskID, &dfdaemonv2.DownloadTaskRequest{Download: download}); err != nil {
+				if err := v.resource.SeedPeer().TriggerDownloadTask(traceCtx, taskID, &dfdaemonv2.DownloadTaskRequest{Download: download}); err != nil {
 					peer.Log.Errorf("%s seed peer triggers download task failed %s", hostType.Name(), err.Error())
 					return
 				}
 
 				peer.Log.Infof("%s seed peer triggers download task success", hostType.Name())
-			}(ctx, taskID, download, types.HostTypeSuperSeed)
+			}(traceCtx, taskID, download, types.HostTypeSuperSeed)
 
 			break
 		}
@@ -1922,15 +1935,15 @@ func (v *V2) downloadTaskBySeedPeer(ctx context.Context, taskID string, download
 	case commonv2.Priority_LEVEL5:
 		// Super peer is first triggered to download back-to-source.
 		if !peer.Task.IsSeedPeerFailed() {
-			go func(ctx context.Context, taskID string, download *commonv2.Download, hostType types.HostType) {
+			go func(traceCtx context.Context, taskID string, download *commonv2.Download, hostType types.HostType) {
 				peer.Log.Infof("%s seed peer triggers download task", hostType.Name())
-				if err := v.resource.SeedPeer().TriggerDownloadTask(context.Background(), taskID, &dfdaemonv2.DownloadTaskRequest{Download: download}); err != nil {
+				if err := v.resource.SeedPeer().TriggerDownloadTask(traceCtx, taskID, &dfdaemonv2.DownloadTaskRequest{Download: download}); err != nil {
 					peer.Log.Errorf("%s seed peer triggers download task failed %s", hostType.Name(), err.Error())
 					return
 				}
 
 				peer.Log.Infof("%s seed peer triggers download task success", hostType.Name())
-			}(ctx, taskID, download, types.HostTypeSuperSeed)
+			}(traceCtx, taskID, download, types.HostTypeSuperSeed)
 
 			break
 		}
@@ -1939,15 +1952,15 @@ func (v *V2) downloadTaskBySeedPeer(ctx context.Context, taskID string, download
 	case commonv2.Priority_LEVEL4:
 		// Super peer is first triggered to download back-to-source.
 		if !peer.Task.IsSeedPeerFailed() {
-			go func(ctx context.Context, taskID string, download *commonv2.Download, hostType types.HostType) {
+			go func(traceCtx context.Context, taskID string, download *commonv2.Download, hostType types.HostType) {
 				peer.Log.Infof("%s seed peer triggers download task", hostType.Name())
-				if err := v.resource.SeedPeer().TriggerDownloadTask(context.Background(), taskID, &dfdaemonv2.DownloadTaskRequest{Download: download}); err != nil {
+				if err := v.resource.SeedPeer().TriggerDownloadTask(traceCtx, taskID, &dfdaemonv2.DownloadTaskRequest{Download: download}); err != nil {
 					peer.Log.Errorf("%s seed peer triggers download task failed %s", hostType.Name(), err.Error())
 					return
 				}
 
 				peer.Log.Infof("%s seed peer triggers download task success", hostType.Name())
-			}(ctx, taskID, download, types.HostTypeSuperSeed)
+			}(traceCtx, taskID, download, types.HostTypeSuperSeed)
 
 			break
 		}


### PR DESCRIPTION
## Description

Add OpenTelemetry span attributes and structured log fields to trace which seed peer is selected and used during peer downloads. This gives operators end-to-end visibility into seed client selection, enabling diagnosis of load balancing issues.

### Changes

- **`internal/dflog/logger.go`**: Added `WithSeedPeer(hostID, hostname, ip, port)` structured logging helper
- **`pkg/types/types.go`**: Added OTel attribute key constants for seed peer identity (`d7y.scheduler.seed_peer.*`)
- **`pkg/rpc/dfdaemon/client/client_v2.go`**: Added `setPeerTargetAttributes()` which sets `d7y.dfdaemon.target` span attribute on all download RPCs (`DownloadTask`, `SyncPieces`, `DownloadPersistentTask`, `DownloadPersistentCacheTask`)
- **`scheduler/resource/standard/seed_peer.go`**: Added OTel span attributes and `WithSeedPeer` logging in `TriggerDownloadTask`, `TriggerTask`, and `Select`
- **`scheduler/service/service_v2.go`**: Added priority span attribute in `downloadTaskBySeedPeer`; replaced `context.Background()` with `context.WithoutCancel(ctx)` to preserve trace context in fire-and-forget goroutines
- **`scheduler/service/service_v1.go`**: Same pattern — priority span attribute and `context.WithoutCancel(ctx)` in `triggerTask` and `triggerSeedPeerTask`

## Related Issue

Closes #4841

## Motivation and Context

Without this change, there is no way to identify which seed peer a peer is downloading from. This makes it impossible to detect load imbalances across seed peers (e.g., all peers hitting the same seed peer while others are idle). The new trace info flows through OpenTelemetry spans and structured logs, giving operators full visibility into seed peer selection and utilization.

## Screenshots (if appropriate)

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.