### PR TITLE
fix: apply redis TLS config in manager cache and job queue

### DIFF
--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -18,6 +18,7 @@ package job
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -50,6 +51,7 @@ type Config struct {
 	SentinelPassword string
 	BrokerDB         int
 	BackendDB        int
+	TLSConfig        *tls.Config
 }
 
 type Job struct {
@@ -70,6 +72,7 @@ func New(cfg *Config, queue Queue) (*Job, error) {
 		SentinelUsername: cfg.SentinelUsername,
 		SentinelPassword: cfg.SentinelPassword,
 		DB:               cfg.BackendDB,
+		TLSConfig:        cfg.TLSConfig,
 	}); err != nil {
 		return nil, err
 	}
@@ -93,6 +96,7 @@ func New(cfg *Config, queue Queue) (*Job, error) {
 		DefaultQueue:    queue.String(),
 		ResultBackend:   backend,
 		ResultsExpireIn: DefaultResultsExpireIn,
+		TLSConfig:       cfg.TLSConfig,
 		Redis: &machineryv1config.RedisConfig{
 			MasterName:             cfg.MasterName,
 			MaxIdle:                DefaultRedisMaxIdle,

--- a/manager/cache/cache.go
+++ b/manager/cache/cache.go
@@ -37,7 +37,7 @@ func New(cfg *config.Config) (*Cache, error) {
 	var localCache *cache.TinyLFU
 	localCache = cache.NewTinyLFU(cfg.Cache.Local.Size, cfg.Cache.Local.TTL)
 
-	rdb, err := pkgredis.NewRedis(&redis.UniversalOptions{
+	redisOpts := &redis.UniversalOptions{
 		Addrs:            cfg.Database.Redis.Addrs,
 		MasterName:       cfg.Database.Redis.MasterName,
 		DB:               cfg.Database.Redis.DB,
@@ -47,7 +47,18 @@ func New(cfg *config.Config) (*Cache, error) {
 		SentinelPassword: cfg.Database.Redis.SentinelPassword,
 		PoolSize:         cfg.Database.Redis.PoolSize,
 		PoolTimeout:      cfg.Database.Redis.PoolTimeout,
-	})
+	}
+
+	if redisTLS := cfg.Database.Redis.TLS; redisTLS != nil {
+		tlsCfg, err := pkgredis.NewTLSClientConfig(redisTLS.CACert, redisTLS.Cert, redisTLS.Key, redisTLS.InsecureSkipVerify)
+		if err != nil {
+			return nil, err
+		}
+
+		redisOpts.TLSConfig = tlsCfg
+	}
+
+	rdb, err := pkgredis.NewRedis(redisOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/manager/database/database.go
+++ b/manager/database/database.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/docker/go-connections/tlsconfig"
 	caches "github.com/go-gorm/caches/v4"
 	"github.com/redis/go-redis/v9"
 	"gorm.io/gorm"
@@ -107,12 +106,7 @@ func New(cfg *config.Config) (*Database, error) {
 	}
 
 	if redisTLS := cfg.Database.Redis.TLS; redisTLS != nil {
-		tlsCfg, err := tlsconfig.Client(tlsconfig.Options{
-			CAFile:             redisTLS.CACert,
-			CertFile:           redisTLS.Cert,
-			KeyFile:            redisTLS.Key,
-			InsecureSkipVerify: redisTLS.InsecureSkipVerify,
-		})
+		tlsCfg, err := pkgredis.NewTLSClientConfig(redisTLS.CACert, redisTLS.Cert, redisTLS.Key, redisTLS.InsecureSkipVerify)
 		if err != nil {
 			return nil, err
 		}

--- a/manager/job/job.go
+++ b/manager/job/job.go
@@ -26,6 +26,7 @@ import (
 	"d7y.io/dragonfly/v2/manager/config"
 	"d7y.io/dragonfly/v2/manager/models"
 	nettls "d7y.io/dragonfly/v2/pkg/net/tls"
+	pkgredis "d7y.io/dragonfly/v2/pkg/redis"
 )
 
 // DefaultTaskPollingInterval is the default interval for polling task.
@@ -44,7 +45,7 @@ type Job struct {
 
 // New returns a new Job.
 func New(cfg *config.Config, gdb *gorm.DB) (*Job, error) {
-	j, err := internaljob.New(&internaljob.Config{
+	redisConfig := &internaljob.Config{
 		Addrs:            cfg.Database.Redis.Addrs,
 		MasterName:       cfg.Database.Redis.MasterName,
 		Username:         cfg.Database.Redis.Username,
@@ -53,7 +54,18 @@ func New(cfg *config.Config, gdb *gorm.DB) (*Job, error) {
 		SentinelPassword: cfg.Database.Redis.SentinelPassword,
 		BrokerDB:         cfg.Database.Redis.BrokerDB,
 		BackendDB:        cfg.Database.Redis.BackendDB,
-	}, internaljob.GlobalQueue)
+	}
+
+	if redisTLS := cfg.Database.Redis.TLS; redisTLS != nil {
+		tlsCfg, err := pkgredis.NewTLSClientConfig(redisTLS.CACert, redisTLS.Cert, redisTLS.Key, redisTLS.InsecureSkipVerify)
+		if err != nil {
+			return nil, err
+		}
+
+		redisConfig.TLSConfig = tlsCfg
+	}
+
+	j, err := internaljob.New(redisConfig, internaljob.GlobalQueue)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/redis/tls.go
+++ b/pkg/redis/tls.go
@@ -1,0 +1,33 @@
+/*
+ *     Copyright 2024 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package redis
+
+import (
+	"crypto/tls"
+
+	"github.com/docker/go-connections/tlsconfig"
+)
+
+// NewTLSClientConfig returns a *tls.Config for connecting to a TLS-enabled redis.
+func NewTLSClientConfig(caCert, cert, key string, insecureSkipVerify bool) (*tls.Config, error) {
+	return tlsconfig.Client(tlsconfig.Options{
+		CAFile:             caCert,
+		CertFile:           cert,
+		KeyFile:            key,
+		InsecureSkipVerify: insecureSkipVerify,
+	})
+}

--- a/pkg/redis/tls_test.go
+++ b/pkg/redis/tls_test.go
@@ -1,0 +1,124 @@
+/*
+ *     Copyright 2024 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package redis
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewTLSClientConfig(t *testing.T) {
+	caCertPath := writeTestCACert(t)
+
+	tests := []struct {
+		name               string
+		caCert             string
+		cert               string
+		key                string
+		insecureSkipVerify bool
+		expect             func(t *testing.T, cfg *tls.Config, err error)
+	}{
+		{
+			name: "no ca and no client cert falls back to system roots",
+			expect: func(t *testing.T, cfg *tls.Config, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.NotNil(cfg)
+				assert.Nil(cfg.RootCAs)
+				assert.False(cfg.InsecureSkipVerify)
+			},
+		},
+		{
+			name:               "insecureSkipVerify is honored",
+			insecureSkipVerify: true,
+			expect: func(t *testing.T, cfg *tls.Config, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.NotNil(cfg)
+				assert.True(cfg.InsecureSkipVerify)
+			},
+		},
+		{
+			name:   "ca certificate is loaded into the root pool",
+			caCert: caCertPath,
+			expect: func(t *testing.T, cfg *tls.Config, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.NotNil(cfg)
+				assert.NotNil(cfg.RootCAs)
+			},
+		},
+		{
+			name:   "missing ca certificate returns an error",
+			caCert: filepath.Join(t.TempDir(), "does-not-exist.pem"),
+			expect: func(t *testing.T, cfg *tls.Config, err error) {
+				assert := assert.New(t)
+				assert.Error(err)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := NewTLSClientConfig(tc.caCert, tc.cert, tc.key, tc.insecureSkipVerify)
+			tc.expect(t, cfg, err)
+		})
+	}
+}
+
+// writeTestCACert generates a self-signed CA certificate and writes it as PEM to
+// a temporary file, returning the file path.
+func writeTestCACert(t *testing.T) string {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	assert.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "dragonfly-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &priv.PublicKey, priv)
+	assert.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "ca.pem")
+	f, err := os.Create(path)
+	assert.NoError(t, err)
+	defer f.Close()
+
+	assert.NoError(t, pem.Encode(f, &pem.Block{Type: "CERTIFICATE", Bytes: der}))
+
+	return path
+}

--- a/scheduler/job/job.go
+++ b/scheduler/job/job.go
@@ -46,6 +46,7 @@ import (
 	managertypes "d7y.io/dragonfly/v2/manager/types"
 	"d7y.io/dragonfly/v2/pkg/dfnet"
 	"d7y.io/dragonfly/v2/pkg/idgen"
+	pkgredis "d7y.io/dragonfly/v2/pkg/redis"
 	cndsystemclient "d7y.io/dragonfly/v2/pkg/rpc/cdnsystem/client"
 	"d7y.io/dragonfly/v2/scheduler/config"
 	resource "d7y.io/dragonfly/v2/scheduler/resource/standard"
@@ -97,6 +98,15 @@ func New(cfg *config.Config, resource resource.Resource, dialOptions ...grpc.Dia
 		SentinelPassword: cfg.Database.Redis.SentinelPassword,
 		BrokerDB:         cfg.Database.Redis.BrokerDB,
 		BackendDB:        cfg.Database.Redis.BackendDB,
+	}
+
+	if redisTLS := cfg.Database.Redis.TLS; redisTLS != nil {
+		tlsCfg, err := pkgredis.NewTLSClientConfig(redisTLS.CACert, redisTLS.Cert, redisTLS.Key, redisTLS.InsecureSkipVerify)
+		if err != nil {
+			return nil, err
+		}
+
+		redisConfig.TLSConfig = tlsCfg
 	}
 
 	globalJob, err := internaljob.New(redisConfig, internaljob.GlobalQueue)

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -23,7 +23,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/docker/go-connections/tlsconfig"
 	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
@@ -336,12 +335,7 @@ func newRedisClient(cfg *config.Config) (redis.UniversalClient, error) {
 	}
 
 	if redisTLS := cfg.Database.Redis.TLS; redisTLS != nil {
-		tlsCfg, err := tlsconfig.Client(tlsconfig.Options{
-			CAFile:             redisTLS.CACert,
-			CertFile:           redisTLS.Cert,
-			KeyFile:            redisTLS.Key,
-			InsecureSkipVerify: redisTLS.InsecureSkipVerify,
-		})
+		tlsCfg, err := pkgredis.NewTLSClientConfig(redisTLS.CACert, redisTLS.Cert, redisTLS.Key, redisTLS.InsecureSkipVerify)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Description

Fixes [#4907](https://github.com/dragonflyoss/dragonfly/issues/4907). The manager cache client and job queue built their redis clients without applying `database.redis.tls`, so it was silently ignored (see the issue for details/repro).

This PR:
- Adds `pkgredis.NewTLSClientConfig` and uses it at every redis client site, replacing the duplicated inline `tlsconfig.Client` blocks.
- Threads `*tls.Config` through `internaljob.Config` into the ping options and the machinery config (`Config.TLSConfig`, honored by the redis broker/backend).
- Adds unit tests (`pkg/redis/tls_test.go`).

No behavior change when `database.redis.tls` is unset (`TLSConfig` stays `nil`).

## Related Issue

Fixes [#4907](https://github.com/dragonflyoss/dragonfly/issues/4907)

## Motivation and Context

Connecting the manager to AWS ElastiCache for Valkey with TLS (encryption in transit) enabled. See [#4907](https://github.com/dragonflyoss/dragonfly/issues/4907).

## Testing

Verified against AWS ElastiCache for Valkey 9.0.0 with **encryption in transit enabled** (TLS required), using images built from this change ([release `v2.5.1-redis-tls`](https://github.com/Smuger/dragonfly/releases/tag/v2.5.1-redis-tls)):

```
  dragonfly-manager  --TLS :6379-->  ElastiCache Valkey 9.0.0 (in-transit encryption: ON)

  Before: plaintext -> handshake never completes -> "i/o timeout" -> CrashLoopBackOff
  After:  TLS handshake OK -> PING OK -> manager Running, schedulers register
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
