### PR TITLE
avoid task id collisions for urls FilterQueryParams cannot parse

### DIFF
--- a/pkg/idgen/task_id.go
+++ b/pkg/idgen/task_id.go
@@ -122,13 +122,11 @@ func taskIDV1(url string, meta *commonv1.UrlMeta, ignoreRange bool) string {
 
 	filteredQueryParams := ParseFilteredQueryParams(meta.Filter)
 
-	var (
-		u   string
-		err error
-	)
-	u, err = neturl.FilterQueryParams(url, filteredQueryParams)
-	if err != nil {
-		u = ""
+	// Keep the raw url when it can not be filtered, otherwise every url that
+	// fails to parse collapses onto the same task id.
+	u := url
+	if filteredURL, err := neturl.FilterQueryParams(url, filteredQueryParams); err == nil {
+		u = filteredURL
 	}
 
 	data := []string{u}
@@ -163,9 +161,10 @@ func FormatFilteredQueryParams(params []string) string {
 
 // TaskIDV2ByURLBased generates v2 version of task id by url based.
 func TaskIDV2ByURLBased(url string, pieceLength *uint64, tag, application string, filteredQueryParams []string, revision string) string {
-	url, err := neturl.FilterQueryParams(url, filteredQueryParams)
-	if err != nil {
-		url = ""
+	// Keep the raw url when it can not be filtered, otherwise every url that
+	// fails to parse collapses onto the same task id.
+	if filteredURL, err := neturl.FilterQueryParams(url, filteredQueryParams); err == nil {
+		url = filteredURL
 	}
 
 	params := []string{url, tag, application, revision}

--- a/pkg/idgen/task_id_test.go
+++ b/pkg/idgen/task_id_test.go
@@ -91,6 +91,28 @@ func TestTaskIDV1(t *testing.T) {
 				assert.Equal(d, "2773851c628744fb7933003195db436ce397c1722920696c4274ff804d86920b")
 			},
 		},
+		{
+			name: "generate taskID with undecodable query param",
+			url:  "https://example.com?foo=%zz",
+			meta: &commonv1.UrlMeta{
+				Filter: "bar",
+			},
+			expect: func(t *testing.T, d any) {
+				assert := assert.New(t)
+				assert.NotEqual(d, TaskIDV1("https://example.com?foo=%yy", &commonv1.UrlMeta{Filter: "bar"}))
+			},
+		},
+		{
+			name: "generate taskID with unparsable url",
+			url:  "https://example.com:port/foo",
+			meta: &commonv1.UrlMeta{
+				Filter: "bar",
+			},
+			expect: func(t *testing.T, d any) {
+				assert := assert.New(t)
+				assert.NotEqual(d, TaskIDV1("https://example.com:port/bar", &commonv1.UrlMeta{Filter: "bar"}))
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -185,6 +207,24 @@ func TestTaskIDV2ByURLBased(t *testing.T) {
 			expect: func(t *testing.T, d any) {
 				assert := assert.New(t)
 				assert.Equal(d, "b171331534b80e0bf91da38ebbfcdbf4d177898f4b9beac44f14733e3f004d4e")
+			},
+		},
+		{
+			name:    "generate taskID with undecodable query param",
+			url:     "https://example.com?foo=%zz",
+			filters: []string{"bar"},
+			expect: func(t *testing.T, d any) {
+				assert := assert.New(t)
+				assert.NotEqual(d, TaskIDV2ByURLBased("https://example.com?foo=%yy", nil, "", "", []string{"bar"}, ""))
+			},
+		},
+		{
+			name:    "generate taskID with unparsable url",
+			url:     "https://example.com:port/foo",
+			filters: []string{"bar"},
+			expect: func(t *testing.T, d any) {
+				assert := assert.New(t)
+				assert.NotEqual(d, TaskIDV2ByURLBased("https://example.com:port/bar", nil, "", "", []string{"bar"}, ""))
 			},
 		},
 	}

--- a/pkg/net/url/url.go
+++ b/pkg/net/url/url.go
@@ -31,13 +31,21 @@ func FilterQueryParams(rawURL string, filteredQueryParams []string) (string, err
 		return "", err
 	}
 
+	// u.Query() swallows the parse error and returns only the params it could
+	// decode, which would silently drop the undecodable ones from the returned
+	// url. Parse the raw query directly so the error reaches the caller.
+	query, err := url.ParseQuery(u.RawQuery)
+	if err != nil {
+		return "", err
+	}
+
 	hidden := make(map[string]struct{})
 	for _, filter := range filteredQueryParams {
 		hidden[filter] = struct{}{}
 	}
 
 	var values = make(url.Values)
-	for k, v := range u.Query() {
+	for k, v := range query {
 		if _, ok := hidden[k]; !ok {
 			values[k] = v
 		}

--- a/pkg/net/url/url_test.go
+++ b/pkg/net/url/url_test.go
@@ -34,4 +34,12 @@ func TestFilterQuery(t *testing.T) {
 	url, err = FilterQueryParams(":error_url", []string{"x", "m"})
 	assert.NotNil(t, err)
 	assert.Equal(t, "", url)
+
+	url, err = FilterQueryParams("http://www.xx.yy/path?u=f&n=%zz", []string{"x", "m"})
+	assert.NotNil(t, err)
+	assert.Equal(t, "", url)
+
+	url, err = FilterQueryParams("http://www.xx.yy/path?u=f;n=z", []string{"x", "m"})
+	assert.NotNil(t, err)
+	assert.Equal(t, "", url)
 }


### PR DESCRIPTION
## Description

`FilterQueryParams` rebuilds the query from `u.Query()`, which keeps only the pairs
`url.ParseQuery` could decode and throws the error away, so `?foo=%zz` and `?foo=%yy`
both canonicalize to `https://example.com`. On the error path both `idgen` helpers
substituted `""`, so every url that fails `url.Parse` hashes to `SHA256("")`:

    --- FAIL: TestTaskIDV1/generate_taskID_with_undecodable_query_param
        Error: Should not be: "100680ad546ce6a577f42f52df33b4cfdca756859e664b8d7de329b150d09ce9"
    --- FAIL: TestTaskIDV1/generate_taskID_with_unparsable_url
        Error: Should not be: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

Parse the raw query directly so the error reaches the caller, and keep the raw url in
`taskIDV1` / `TaskIDV2ByURLBased` when filtering fails.

## Related Issue

N/A

## Motivation and Context

The scheduler recomputes the task id server side from the peer-supplied url
(`scheduler/rpcserver/scheduler_server_v1.go:56`, and the `TaskIDV2ByURLBased` calls in
`scheduler/service/service_v2.go`), so two peers requesting different urls that collide
on one id get put on the same task and can be served each other's pieces.

Both triggers are ordinary fetchable urls, not just malformed ones: an invalid percent
escape such as `?discount=100%`, and `;` separated params, which `ParseQuery` has
rejected since Go 1.17. Neither reaches the sink through a caller that could pre-validate,
since the id is derived inside these helpers.

Task ids for well-formed urls are unchanged. `u.Query()` is `ParseQuery(u.RawQuery)` with
the error dropped, so the filtering path is identical when the query decodes, and the
fixed-hash cases already in `task_id_test.go` still pass. A url that now fails to filter
keeps its signature query params in the id, which costs deduplication for that url rather
than merging it with an unrelated one.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
