### PR TITLE
feat: secure internal gRPC with JWT

### DIFF
--- a/docs/design/grpc-jwt-authentication.md
+++ b/docs/design/grpc-jwt-authentication.md
@@ -1,0 +1,500 @@
+# JWT Authentication for Inter-Component gRPC Requests
+
+Status: Proposed
+
+Tracking issue: <https://github.com/dragonflyoss/dragonfly/issues/4417>
+
+## 1. Summary
+
+Dragonfly components currently trust any caller that can reach their gRPC
+business endpoints unless mTLS is enabled. This proposal adds token-based
+authentication to remote inter-component gRPC requests by using short-lived
+JWTs in gRPC metadata.
+
+The first version deliberately uses a cluster-wide shared HMAC key. Every
+component that initiates a remote gRPC request signs a JWT locally, and every
+component that accepts a remote business request verifies the JWT locally.
+Manager is not a token issuer and no token distribution or refresh RPC is
+introduced.
+
+The authentication layer is independent of the existing transport security
+implementation. This proposal does not change the current TLS or mTLS code.
+
+## 2. Goals
+
+- Authenticate remote inter-component gRPC business requests.
+- Use the same protocol and validation rules in Go and Rust.
+- Support rolling upgrades from unauthenticated deployments.
+- Support key rotation without a cluster-wide authentication outage.
+- Keep the existing protobuf APIs unchanged.
+- Keep Manager REST user authentication separate from internal gRPC
+  authentication.
+- Fail closed when authentication is enabled but its configuration is invalid.
+
+## 3. Non-goals
+
+- Identifying or authorizing individual components.
+- Restricting particular components to particular RPC methods.
+- Adding a Manager token issuance, refresh, or revocation service.
+- Integrating an external OAuth, OIDC, SPIFFE, or identity provider.
+- Replacing or modifying TLS or mTLS.
+- Authenticating local dfdaemon Download RPCs over Unix domain sockets.
+- Detecting replay of a valid JWT within its lifetime.
+- Reloading keys without restarting a component in the first version.
+- Re-authenticating individual messages within an existing gRPC stream.
+
+## 4. Security model
+
+Possession of any active cluster key proves only that the caller is a member of
+the Dragonfly deployment. All holders of the shared key can mint a valid token
+for any Dragonfly audience. Claims such as a component name or role therefore
+must not be used for authorization in the first version.
+
+Compromise of one dfdaemon or Seed Peer that can read the shared key compromises
+the JWT authentication boundary for the whole cluster. This blast radius is an
+accepted first-version tradeoff. Per-component asymmetric credentials can be
+introduced later without changing the gRPC metadata transport.
+
+JWTs are bearer credentials and do not encrypt traffic. When the underlying
+channel is plaintext, this feature protects against callers that can reach a
+gRPC port but cannot read traffic in transit. It does not protect against an
+on-path attacker. Transport security remains a separate deployment decision.
+
+## 5. Protocol contract
+
+### 5.1 Metadata
+
+The client sends exactly one lowercase gRPC metadata entry:
+
+```text
+authorization: Bearer <compact-jwt>
+```
+
+The server rejects multiple authorization values, an empty value, an unknown
+scheme, a malformed JWT, and credentials larger than 4 KiB.
+
+### 5.2 JOSE header
+
+```json
+{
+  "alg": "HS256",
+  "typ": "dragonfly-grpc+jwt",
+  "kid": "key-2026-08"
+}
+```
+
+- `alg` is fixed to `HS256`. The validator must not select an algorithm from
+  untrusted token input.
+- `typ` is fixed to `dragonfly-grpc+jwt` and separates this token from Manager
+  REST user JWTs and other JWT types.
+- `kid` selects a key from the local trusted keyring.
+
+### 5.3 Claims
+
+```json
+{
+  "iss": "dragonfly-internal",
+  "aud": "urn:dragonfly:grpc:scheduler",
+  "iat": 1786435200,
+  "exp": 1786435800
+}
+```
+
+Required claims:
+
+- `iss`: exact configured issuer.
+- `aud`: exact audience expected by the target server.
+- `iat`: token creation time.
+- `exp`: token expiration time.
+
+The first version does not emit or trust `sub`, role, scope, component identity,
+or permission claims. `jti` is omitted because no replay cache is maintained.
+
+Audience values are constants in both implementations:
+
+| Target service | Audience |
+| --- | --- |
+| Manager | `urn:dragonfly:grpc:manager` |
+| Scheduler | `urn:dragonfly:grpc:scheduler` |
+| dfdaemon | `urn:dragonfly:grpc:dfdaemon` |
+
+Audience selection is not configurable at individual call sites.
+
+### 5.4 Validation
+
+The server requires all of the following:
+
+1. Exactly one Bearer credential is present for protected methods.
+2. `alg`, `typ`, `kid`, signature, issuer, and audience are valid.
+3. `iat` is not later than the server time plus the configured clock skew.
+4. `exp` is later than the server time minus the configured clock skew.
+5. `exp - iat` is positive and no greater than `maxTokenTTL`.
+
+Authentication failures return `codes.Unauthenticated` with a generic message.
+Detailed failure reasons are recorded only in bounded metrics. Raw tokens,
+authorization metadata, secrets, and full decoded claims must never be logged.
+
+## 6. Configuration contract
+
+Manager, Scheduler, and dfdaemon use the same top-level configuration shape:
+
+```yaml
+grpcAuth:
+  # disabled, permissive, or required
+  mode: disabled
+
+  # If true, Go PerRPCCredentials and Rust client construction reject a
+  # plaintext transport. It is false by default for compatibility with
+  # existing Dragonfly deployments.
+  requireTransportSecurity: false
+
+  jwt:
+    issuer: dragonfly-internal
+    tokenTTL: 10m
+    maxTokenTTL: 15m
+    clockSkew: 30s
+    refreshBefore: 1m
+
+    activeKeyID: key-2026-08
+    keys:
+      - id: key-2026-08
+        secretFile: /etc/dragonfly/secrets/grpc-jwt/key-2026-08
+      - id: key-2026-07
+        secretFile: /etc/dragonfly/secrets/grpc-jwt/key-2026-07
+```
+
+Modes have symmetric client and server behavior:
+
+| Mode | Client behavior | Server behavior |
+| --- | --- | --- |
+| `disabled` | Does not add a token | Does not authenticate |
+| `permissive` | Adds a token | Accepts a missing token, rejects an invalid supplied token |
+| `required` | Adds a token | Rejects a missing or invalid token |
+
+`permissive` is a migration state, not a secure steady state. Because a missing
+token is accepted, it is vulnerable to metadata stripping.
+
+### 6.1 Key file format
+
+- `secretFile` contains one RFC 4648 standard Base64 string.
+- After trimming leading and trailing whitespace, the content is decoded
+  as Base64.
+- The decoded key must contain at least 32 bytes. Production keys must be
+  generated by a cryptographically secure random generator.
+- The path must refer to a regular readable file.
+- Duplicate key IDs and a missing `activeKeyID` are configuration errors.
+- When mode is `permissive` or `required`, missing or invalid keys are fatal
+  startup errors.
+- Keys are read once during startup and retained only in memory.
+- Production deployments should mount files with mode `0400` or `0440`.
+
+A suitable key can be created with:
+
+```bash
+umask 077
+openssl rand -base64 32 > key-2026-08
+```
+
+All components in one cluster receive the same keyring. The configuration
+contains file paths, not inline secret values. Manager does not distribute
+these files at runtime; Docker Compose, Kubernetes, or the host provisioning
+system does so before process startup.
+
+Manager's existing `auth.jwt` configuration continues to authenticate REST
+users. It must use a different secret and a separate validator. A Manager REST
+JWT must never authenticate an internal gRPC request.
+
+### 6.2 Configuration validation
+
+Configuration loading rejects:
+
+- An unknown mode.
+- A missing issuer in an enabled mode.
+- `tokenTTL < 1s`, `maxTokenTTL < 1s`, or `tokenTTL > maxTokenTTL`.
+- A JWT duration that is not an exact number of seconds.
+- `clockSkew < 0`.
+- `refreshBefore <= 0` or `refreshBefore >= tokenTTL`.
+- A missing, duplicate, unreadable, invalid, or short key.
+- An `activeKeyID` that is absent from the keyring.
+
+Partially configured authentication must never silently fall back to disabled.
+
+## 7. Request lifecycle
+
+Each process constructs one concurrency-safe token provider during startup. The
+provider caches one token per `(audience, activeKeyID)` pair.
+
+- A cached token is reused while more than `refreshBefore` remains.
+- A new token is signed locally when the cached token approaches expiration.
+- Signing or metadata construction failure fails the RPC locally. The client
+  must not retry without authentication.
+- Manager is not contacted during token generation or refresh.
+
+For streaming RPCs, authentication happens when the stream is established. A
+stream that was authenticated successfully continues after the token expires.
+A reconnect obtains a new token. Mode or key changes in the first version
+require a process restart, which also terminates old streams.
+
+## 8. Protected call matrix
+
+| Caller | Target | Repository | Required work |
+| --- | --- | --- | --- |
+| Scheduler | Manager | `dragonfly` | Add Manager audience credentials |
+| dfdaemon / Seed Peer | Manager | `client` | Add Manager audience interceptor |
+| dfdaemon / Seed Peer | Scheduler | `client` | Add Scheduler audience interceptor |
+| Scheduler | dfdaemon / Seed Peer | `dragonfly` | Centralize all peer dial options |
+| dfdaemon | dfdaemon gRPC services | `client` | Add dfdaemon audience interceptor |
+| `dfctl task preheat` | Scheduler | `client` | Load gRPC auth config and add a token |
+
+Manager v1/v2, Scheduler v1/v2, and dfdaemon business methods are
+protected. The gRPC health service is always public so that liveness and
+readiness probes do not need the cluster secret. Reflection is protected in
+`required` mode.
+
+Local dfdaemon Download RPCs over Unix domain sockets are outside this proposal.
+
+Old clients and legacy services that cannot attach or validate JWTs work only
+while the relevant server is `disabled` or `permissive`.
+
+## 9. Go implementation
+
+Add a transport-independent package under `pkg/rpc/auth/jwt` with:
+
+- Configuration and keyring loading.
+- Claims and protocol constants.
+- A concurrency-safe token provider implementing
+  `credentials.PerRPCCredentials`.
+- A verifier.
+- Unary and stream server interceptors.
+- Authentication metrics and bounded failure reasons.
+
+`RequireTransportSecurity()` returns the configured
+`requireTransportSecurity` value. No TLS or mTLS implementation is changed.
+
+Manager and Scheduler add the authentication interceptor to both existing
+unary and stream interceptor chains. Authentication runs before request
+validation and business handlers. The health service is explicitly bypassed;
+reflection and business methods are not.
+
+Inject a single authentication dial option into each existing dial-options
+assembly path. The authentication option owns:
+
+- JWT Per-RPC credentials and target audience.
+
+Existing transport credentials and OpenTelemetry setup remain unchanged and
+are composed with the authentication option at process assembly time. All
+standard, Seed Peer, job, persistent-task, and persistent-cache-task paths must
+receive the authentication option. In particular, the persistent-task paths in
+`scheduler/service/service_v2.go` currently construct clients locally, so the
+auth option must be injected into the V2 service and appended there instead of
+being rediscovered from global configuration. This proposal does not change
+their TLS or mTLS behavior.
+
+The JWT library is declared as a direct Go module dependency. Manager's REST
+authentication package is not reused.
+
+## 10. Rust implementation
+
+Add matching configuration types to `dragonfly-client-config` and a dedicated
+`dragonfly-client-auth` workspace crate with:
+
+- Keyring loading and strict validation.
+- Matching claims, JOSE header, audiences, and clock rules.
+- A concurrency-safe token provider.
+- Client and server Tonic interceptors.
+- Matching bounded metrics and error behavior.
+
+JWT injection is composed with the existing tracing interceptor so both tracing
+and authorization metadata are retained.
+
+Update:
+
+- Manager client.
+- Scheduler client.
+- dfdaemon DfdaemonUpload gRPC clients. The maintained Rust client no longer
+  contains the legacy Seeder service.
+- dfdaemon business gRPC servers.
+- Reflection service authentication.
+- `dfctl task preheat` direct Scheduler calls.
+
+The health service remains outside the auth interceptor. Local dfdaemon Download
+clients and servers over Unix domain sockets are unchanged.
+
+The JWT crate is declared as a direct dependency at a version compatible with
+the repository's Rust toolchain. The implementation must not rely on a
+transitive `jsonwebtoken` dependency from `Cargo.lock`.
+
+## 11. Observability
+
+Expose a bounded server counter equivalent to:
+
+```text
+dragonfly_grpc_auth_requests_total{audience,mode,result,reason}
+```
+
+Allowed `reason` values are:
+
+- `none`
+- `missing`
+- `malformed`
+- `unsupported_alg`
+- `invalid_type`
+- `unknown_kid`
+- `invalid_signature`
+- `invalid_issuer`
+- `invalid_audience`
+- `expired`
+- `invalid_iat`
+- `ttl_exceeded`
+
+Also expose token generation, generation failure, cache hit, and cache miss
+counters. RPC methods and remote addresses are not metric labels because both
+can be attacker-controlled. Remote addresses may be included only in sampled
+logs.
+
+Startup logs may report the mode, active key ID, and trusted key count. They
+must not report keys or tokens.
+
+## 12. Rolling upgrade
+
+When mode is omitted or `disabled`, no keyring is required, clients do not add
+credentials, and servers do not authenticate requests. A normal application or
+chart rolling upgrade therefore preserves the legacy behavior.
+
+The first authenticated rollout uses one global mode transition:
+
+1. Create and distribute the shared keyring, deploy JWT-capable binaries, and
+   set the global mode to `permissive`. These changes may be combined in one
+   rolling update: upgraded clients send tokens, upgraded servers accept both
+   authenticated requests and requests from old callers, and old servers
+   ignore the additional authorization metadata.
+2. Wait for every component and maintained external caller, including
+   `dfctl task preheat`, to be upgraded. Monitor `missing` authentication
+   metrics until every expected business call path sends tokens.
+3. Change the global mode to `required`. This transition is safe as a rolling
+   update because clients in both `permissive` and `required` modes send tokens,
+   while servers in both modes accept valid tokens.
+
+Once a deployment is in `required` mode, later application upgrades keep that
+mode and use the normal one-step rolling update as long as the JWT protocol and
+trusted keyring remain compatible.
+
+Each mode change restarts the process in the first version, ensuring that
+streams established before `required` mode do not remain unauthenticated.
+
+Rollback changes the global mode from `required` to `permissive` before
+disabling authentication. Older servers ignore the extra authorization
+metadata sent by upgraded clients.
+
+## 13. Key rotation
+
+1. Distribute a new key to every component as a trusted key while the old key
+   remains active.
+2. Restart all components so every verifier accepts both keys.
+3. Change `activeKeyID` to the new key and restart callers incrementally.
+4. Wait at least `maxTokenTTL + clockSkew` after the last caller switches.
+5. Remove the old key and restart servers. The restart also terminates streams
+   authenticated with the old key.
+
+## 14. Testing
+
+### 14.1 Unit tests in both languages
+
+- Valid token signing and validation.
+- Invalid algorithm, type, key ID, signature, issuer, and audience.
+- Missing and duplicate authorization metadata.
+- Expired, future-issued, and excessive-lifetime tokens.
+- All three modes.
+- Token cache refresh behavior under concurrency.
+- Unary and stream interceptor behavior.
+- Health bypass and reflection protection.
+- Strict configuration and key-file validation.
+
+### 14.2 Cross-language contract tests
+
+Commit the same deterministic test vector to both repositories with a fixed
+test key, header, claims, and clock:
+
+- Go signs and Rust validates.
+- Rust signs and Go validates.
+- Both produce and accept the same audience and time semantics.
+
+The fixture keeps one deterministic token from each implementation. Their
+compact strings may differ because JSON member order in the JOSE header is not
+semantically significant; cross-language signature validation is the contract.
+
+The fixture secret is test-only and clearly marked as unusable in production.
+
+### 14.3 Integration tests
+
+- Scheduler to Manager.
+- Rust dfdaemon to Manager and Scheduler.
+- Scheduler standard, persistent, and persistent-cache callbacks to dfdaemon.
+- Rust peer-to-peer Upload calls.
+- `dfctl task preheat` to Scheduler.
+- A stream starts with a valid token, survives token expiration, and reconnects
+  with a refreshed token.
+- Mixed old/new binaries in `permissive` mode.
+- Missing and invalid credentials in `required` mode.
+- Overlapping old/new keys during rotation.
+- Existing Manager REST authentication remains unchanged.
+- Local Unix domain socket calls and health probes remain unchanged.
+
+## 15. Repository and merge order
+
+Three repositories require changes:
+
+1. `dragonflyoss/dragonfly`
+2. `dragonflyoss/client`
+3. `dragonflyoss/helm-charts`
+
+`dragonflyoss/api` is not changed because authorization is transported in gRPC
+metadata and no protobuf message or token RPC is introduced.
+
+Recommended merge sequence:
+
+1. **dragonfly PR 1: protocol and Go implementation**
+   - Land this design and protocol constants.
+   - Add Go keyring, provider, verifier, interceptors, config, unit tests, and
+     authentication metrics.
+   - Protect Manager and Scheduler business servers.
+   - Add credentials to every Scheduler outbound client path without changing
+     the existing TLS or mTLS behavior.
+   - Keep the default mode `disabled`.
+2. **client PR: Rust implementation**
+   - Implement the frozen protocol and matching test vector.
+   - Update Manager, Scheduler, Upload, and `dfctl` call paths.
+   - Protect the Upload business server.
+   - Keep the default mode `disabled`.
+3. **dragonfly PR 2: integration**
+   - Advance the `client` submodule to the merged client commit.
+   - Add cross-component compatibility and end-to-end tests.
+   - Add Docker Compose examples and migration documentation.
+4. **helm-charts PR: deployment support**
+   - Add one `existingSecret` reference for the cluster JWT keyring.
+   - Mount the same keyring into Manager, Scheduler, dfdaemon, and Seed Peer.
+   - Render matching `grpcAuth` configuration for every workload.
+   - Do not put secret values directly into ordinary chart values.
+5. **dragonfly PR 3: chart pointer**
+   - Advance the `deploy/helm-charts` submodule after the chart PR merges.
+   - Run the final mixed-version and required-mode E2E suites.
+
+The Go and Rust implementation PRs may be developed concurrently after this
+contract is frozen. The first authenticated rollout uses `permissive`, and a
+deployment must not enable `required` until every component and maintained
+external caller runs a compatible version and sends tokens.
+
+## 16. Acceptance criteria
+
+- In `required` mode, every remote business RPC without a valid JWT returns
+  `Unauthenticated` before entering its business handler.
+- Every maintained Go and Rust remote client path sends the correct audience.
+- Manager REST JWTs are rejected by internal gRPC validators.
+- Health checks and local Unix domain socket RPCs continue to work without JWT.
+- An omitted or `disabled` configuration preserves legacy behavior and requires
+  no key files.
+- Mixed-version rolling upgrades work in `permissive` mode.
+- The global `permissive` to `required` transition works as a rolling upgrade.
+- Key rotation works with an overlap window and without authentication outage.
+- Tokens and secrets never appear in logs, errors, metrics labels, or traces.
+- No protobuf API change or Manager token service is introduced.

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/go-gorm/caches/v4 v4.0.5
 	github.com/go-http-utils/headers v0.0.0-20181008091004-fed159eddc2a
 	github.com/go-playground/validator/v10 v10.30.3
+	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/go-redis/cache/v9 v9.0.0
 	github.com/go-redis/redis_rate/v10 v10.0.1
 	github.com/go-redis/redismock/v9 v9.2.0
@@ -126,7 +127,6 @@ require (
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
-	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/golang/mock v1.6.0 // indirect

--- a/manager/config/config.go
+++ b/manager/config/config.go
@@ -26,6 +26,7 @@ import (
 
 	"d7y.io/dragonfly/v2/cmd/dependency/base"
 	"d7y.io/dragonfly/v2/pkg/net/ip"
+	grpcauth "d7y.io/dragonfly/v2/pkg/rpc/auth/jwt"
 	"d7y.io/dragonfly/v2/pkg/types"
 )
 
@@ -38,6 +39,9 @@ type Config struct {
 
 	// Auth configuration.
 	Auth AuthConfig `yaml:"auth" mapstructure:"auth"`
+
+	// GRPCAuth is the inter-component gRPC authentication configuration.
+	GRPCAuth grpcauth.Config `yaml:"grpcAuth" mapstructure:"grpcAuth"`
 
 	// Database configuration.
 	Database DatabaseConfig `yaml:"database" mapstructure:"database"`
@@ -441,6 +445,7 @@ func New() *Config {
 				MaxRefresh: DefaultJWTMaxRefresh,
 			},
 		},
+		GRPCAuth: grpcauth.DefaultConfig(),
 		Database: DatabaseConfig{
 			Type: DatabaseTypeMysql,
 			Mysql: MysqlConfig{
@@ -531,6 +536,10 @@ func (cfg *Config) Validate() error {
 
 	if cfg.Server.GRPC.RequestRateLimit <= 0 {
 		return errors.New("grpc requires parameter requestRateLimit")
+	}
+
+	if err := grpcauth.ValidateConfig(cfg.GRPCAuth); err != nil {
+		return err
 	}
 
 	if cfg.Server.REST.TLS != nil {

--- a/manager/config/config_test.go
+++ b/manager/config/config_test.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
+
+	grpcauth "d7y.io/dragonfly/v2/pkg/rpc/auth/jwt"
 )
 
 var (
@@ -125,6 +127,22 @@ func TestConfig_Load(t *testing.T) {
 				Key:        "bar",
 				Timeout:    30 * time.Second,
 				MaxRefresh: 1 * time.Minute,
+			},
+		},
+		GRPCAuth: grpcauth.Config{
+			Mode:                     grpcauth.ModeRequired,
+			RequireTransportSecurity: true,
+			JWT: grpcauth.JWTConfig{
+				Issuer:        "dragonfly-test",
+				TokenTTL:      10 * time.Minute,
+				MaxTokenTTL:   15 * time.Minute,
+				ClockSkew:     30 * time.Second,
+				RefreshBefore: time.Minute,
+				ActiveKeyID:   "test-key",
+				Keys: []grpcauth.KeyConfig{{
+					ID:         "test-key",
+					SecretFile: "/etc/dragonfly/secrets/grpc-jwt/test-key",
+				}},
 			},
 		},
 		Database: DatabaseConfig{
@@ -260,6 +278,16 @@ func TestConfig_Validate(t *testing.T) {
 			expect: func(t *testing.T, err error) {
 				assert := assert.New(t)
 				assert.EqualError(err, "server requires parameter name")
+			},
+		},
+		{
+			name:   "grpc auth rejects unsupported mode",
+			config: New(),
+			mock: func(cfg *Config) {
+				cfg.GRPCAuth.Mode = "unknown"
+			},
+			expect: func(t *testing.T, err error) {
+				assert.EqualError(t, err, `grpc auth has unsupported mode "unknown"`)
 			},
 		},
 		{

--- a/manager/config/testdata/manager.yaml
+++ b/manager/config/testdata/manager.yaml
@@ -30,6 +30,20 @@ auth:
     timeout: 30s
     maxRefresh: 1m
 
+grpcAuth:
+  mode: required
+  requireTransportSecurity: true
+  jwt:
+    issuer: dragonfly-test
+    tokenTTL: 10m
+    maxTokenTTL: 15m
+    clockSkew: 30s
+    refreshBefore: 1m
+    activeKeyID: test-key
+    keys:
+      - id: test-key
+        secretFile: /etc/dragonfly/secrets/grpc-jwt/test-key
+
 database:
   type: mysql
   mysql:

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -46,6 +46,7 @@ import (
 	pkggc "d7y.io/dragonfly/v2/pkg/gc"
 	"d7y.io/dragonfly/v2/pkg/redis"
 	"d7y.io/dragonfly/v2/pkg/rpc"
+	grpcauth "d7y.io/dragonfly/v2/pkg/rpc/auth/jwt"
 )
 
 const (
@@ -113,6 +114,11 @@ type Server struct {
 // New creates a new manager server.
 func New(cfg *config.Config, d dfpath.Dfpath) (*Server, error) {
 	s := &Server{config: cfg}
+	authenticator, err := grpcauth.New(cfg.GRPCAuth)
+	if err != nil {
+		return nil, err
+	}
+	logger.Infof("initialized gRPC authentication with mode %s", authenticator.Mode())
 
 	// Initialize database.
 	db, err := database.New(cfg)
@@ -189,7 +195,7 @@ func New(cfg *config.Config, d dfpath.Dfpath) (*Server, error) {
 	}
 
 	// Initialize GRPC server.
-	_, grpcServer, err := rpcserver.New(cfg, db, cache, searcher, options...)
+	_, grpcServer, err := rpcserver.NewWithAuthentication(cfg, authenticator, db, cache, searcher, options...)
 	if err != nil {
 		return nil, err
 	}

--- a/manager/rpcserver/rpcserver.go
+++ b/manager/rpcserver/rpcserver.go
@@ -26,6 +26,7 @@ import (
 	"d7y.io/dragonfly/v2/manager/database"
 	"d7y.io/dragonfly/v2/manager/models"
 	"d7y.io/dragonfly/v2/manager/searcher"
+	grpcauth "d7y.io/dragonfly/v2/pkg/rpc/auth/jwt"
 	managerserver "d7y.io/dragonfly/v2/pkg/rpc/manager/server"
 )
 
@@ -51,6 +52,14 @@ type Server struct {
 func New(
 	cfg *config.Config, database *database.Database, cache *cache.Cache, searcher searcher.Searcher,
 	opts ...grpc.ServerOption) (*Server, *grpc.Server, error) {
+	return NewWithAuthentication(cfg, nil, database, cache, searcher, opts...)
+}
+
+// NewWithAuthentication returns a new manager server with inter-component JWT
+// authentication.
+func NewWithAuthentication(
+	cfg *config.Config, authenticator *grpcauth.Authenticator, database *database.Database, cache *cache.Cache, searcher searcher.Searcher,
+	opts ...grpc.ServerOption) (*Server, *grpc.Server, error) {
 	s := &Server{
 		config:   cfg,
 		db:       database.DB,
@@ -59,10 +68,11 @@ func New(
 		searcher: searcher,
 	}
 
-	return s, managerserver.New(
+	return s, managerserver.NewWithAuthentication(
 		newManagerServerV1(s.config, database, s.cache, s.searcher),
 		newManagerServerV2(s.config, database, s.cache, s.searcher),
 		cfg.Server.GRPC.RequestRateLimit,
+		authenticator,
 		opts...), nil
 }
 

--- a/pkg/rpc/auth/jwt/auth.go
+++ b/pkg/rpc/auth/jwt/auth.go
@@ -1,0 +1,221 @@
+/*
+ *     Copyright 2026 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jwt
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	jwtlib "github.com/golang-jwt/jwt/v4"
+	"google.golang.org/grpc/credentials"
+)
+
+const (
+	// TokenType is the explicit JWT type for Dragonfly inter-component gRPC
+	// authentication.
+	TokenType = "dragonfly-grpc+jwt"
+
+	// AudienceManager is the expected audience of Manager gRPC servers.
+	AudienceManager = "urn:dragonfly:grpc:manager"
+
+	// AudienceScheduler is the expected audience of Scheduler gRPC servers.
+	AudienceScheduler = "urn:dragonfly:grpc:scheduler"
+
+	// AudienceDfdaemon is the expected audience of dfdaemon gRPC servers.
+	AudienceDfdaemon = "urn:dragonfly:grpc:dfdaemon"
+
+	authorizationMetadataKey = "authorization"
+	bearerScheme             = "Bearer"
+	maxCredentialLength      = 4 * 1024
+)
+
+var knownAudiences = map[string]struct{}{
+	AudienceManager:   {},
+	AudienceScheduler: {},
+	AudienceDfdaemon:  {},
+}
+
+// Claims contains only the claims used by the first version of Dragonfly gRPC
+// authentication.
+type Claims struct {
+	Issuer    string `json:"iss"`
+	Audience  string `json:"aud"`
+	IssuedAt  int64  `json:"iat"`
+	ExpiresAt int64  `json:"exp"`
+}
+
+// Valid is intentionally empty because Authenticator applies Dragonfly's
+// validation rules with an injected clock and configured clock skew.
+func (Claims) Valid() error {
+	return nil
+}
+
+type cachedToken struct {
+	value     string
+	expiresAt time.Time
+}
+
+// Option configures an Authenticator.
+type Option func(*Authenticator)
+
+// WithClock overrides the clock used to generate and validate tokens.
+func WithClock(now func() time.Time) Option {
+	return func(authenticator *Authenticator) {
+		authenticator.now = now
+	}
+}
+
+// Authenticator signs and verifies inter-component gRPC JWTs.
+type Authenticator struct {
+	config Config
+	keys   map[string][]byte
+	now    func() time.Time
+
+	cacheMu sync.Mutex
+	cache   map[string]cachedToken
+}
+
+// New returns an Authenticator using the configured shared keyring.
+func New(config Config, options ...Option) (*Authenticator, error) {
+	keys, err := validateAndLoadKeys(config)
+	if err != nil {
+		return nil, err
+	}
+
+	config.Mode = config.EffectiveMode()
+	authenticator := &Authenticator{
+		config: config,
+		keys:   keys,
+		now:    time.Now,
+		cache:  make(map[string]cachedToken),
+	}
+
+	for _, option := range options {
+		option(authenticator)
+	}
+
+	if authenticator.now == nil {
+		return nil, errors.New("grpc auth clock must not be nil")
+	}
+
+	return authenticator, nil
+}
+
+// Mode returns the configured effective authentication mode.
+func (a *Authenticator) Mode() Mode {
+	if a == nil {
+		return ModeDisabled
+	}
+
+	return a.config.Mode
+}
+
+// Enabled returns whether authentication is enabled.
+func (a *Authenticator) Enabled() bool {
+	if a == nil {
+		return false
+	}
+
+	return a.config.Enabled()
+}
+
+// PerRPCCredentials returns credentials that generate JWTs for audience.
+func (a *Authenticator) PerRPCCredentials(audience string) credentials.PerRPCCredentials {
+	return &perRPCCredentials{authenticator: a, audience: audience}
+}
+
+type perRPCCredentials struct {
+	authenticator *Authenticator
+	audience      string
+}
+
+// GetRequestMetadata returns authorization metadata for a new RPC.
+func (c *perRPCCredentials) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
+	if !c.authenticator.Enabled() {
+		return nil, nil
+	}
+
+	token, err := c.authenticator.token(c.audience)
+	if err != nil {
+		clientTokenEvents.WithLabelValues(c.audience, tokenEventGenerationFailed).Inc()
+		return nil, err
+	}
+
+	return map[string]string{authorizationMetadataKey: bearerScheme + " " + token}, nil
+}
+
+// RequireTransportSecurity reports whether gRPC must refuse plaintext
+// transports before attaching the JWT.
+func (c *perRPCCredentials) RequireTransportSecurity() bool {
+	return c.authenticator.Enabled() && c.authenticator.config.RequireTransportSecurity
+}
+
+func (a *Authenticator) token(audience string) (string, error) {
+	if err := validateAudience(audience); err != nil {
+		return "", err
+	}
+
+	now := a.now()
+	cacheKey := audience + "\x00" + a.config.JWT.ActiveKeyID
+
+	a.cacheMu.Lock()
+	defer a.cacheMu.Unlock()
+
+	if cached, ok := a.cache[cacheKey]; ok && cached.expiresAt.Sub(now) > a.config.JWT.RefreshBefore {
+		clientTokenEvents.WithLabelValues(audience, tokenEventCacheHit).Inc()
+		return cached.value, nil
+	}
+
+	clientTokenEvents.WithLabelValues(audience, tokenEventCacheMiss).Inc()
+	key, ok := a.keys[a.config.JWT.ActiveKeyID]
+	if !ok {
+		return "", fmt.Errorf("grpc auth active key id %q is unavailable", a.config.JWT.ActiveKeyID)
+	}
+
+	issuedAt := now.Unix()
+	expiresAt := now.Add(a.config.JWT.TokenTTL)
+	claims := Claims{
+		Issuer:    a.config.JWT.Issuer,
+		Audience:  audience,
+		IssuedAt:  issuedAt,
+		ExpiresAt: expiresAt.Unix(),
+	}
+
+	token := jwtlib.NewWithClaims(jwtlib.SigningMethodHS256, claims)
+	token.Header["typ"] = TokenType
+	token.Header["kid"] = a.config.JWT.ActiveKeyID
+
+	signed, err := token.SignedString(key)
+	if err != nil {
+		return "", fmt.Errorf("sign grpc auth jwt: %w", err)
+	}
+
+	a.cache[cacheKey] = cachedToken{value: signed, expiresAt: expiresAt}
+	clientTokenEvents.WithLabelValues(audience, tokenEventGenerated).Inc()
+	return signed, nil
+}
+
+func validateAudience(audience string) error {
+	if _, ok := knownAudiences[audience]; !ok {
+		return fmt.Errorf("grpc auth has unsupported audience %q", audience)
+	}
+
+	return nil
+}

--- a/pkg/rpc/auth/jwt/auth_test.go
+++ b/pkg/rpc/auth/jwt/auth_test.go
@@ -1,0 +1,425 @@
+/*
+ *     Copyright 2026 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jwt
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	jwtlib "github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+type interoperabilityFixture struct {
+	SecretBase64 string `json:"secretBase64"`
+	KeyID        string `json:"keyID"`
+	Issuer       string `json:"issuer"`
+	Audience     string `json:"audience"`
+	IssuedAt     int64  `json:"issuedAt"`
+	ExpiresAt    int64  `json:"expiresAt"`
+	GoToken      string `json:"goToken"`
+	RustToken    string `json:"rustToken"`
+}
+
+func TestPerRPCCredentials(t *testing.T) {
+	now := time.Unix(1_786_435_200, 0)
+	authenticator := newTestAuthenticator(t, ModeRequired, func() time.Time { return now })
+	credentials := authenticator.PerRPCCredentials(AudienceScheduler)
+
+	md, err := credentials.GetRequestMetadata(context.Background())
+	require.NoError(t, err)
+	credential := md[authorizationMetadataKey]
+	require.True(t, strings.HasPrefix(credential, bearerScheme+" "))
+	assert.NoError(t, authenticator.verify(strings.TrimPrefix(credential, bearerScheme+" "), AudienceScheduler))
+	assert.False(t, credentials.RequireTransportSecurity())
+}
+
+func TestInteroperabilityFixture(t *testing.T) {
+	content, err := os.ReadFile(filepath.Join("testdata", "interop.json"))
+	require.NoError(t, err)
+
+	var fixture interoperabilityFixture
+	require.NoError(t, json.Unmarshal(content, &fixture))
+	secret, err := base64.StdEncoding.DecodeString(fixture.SecretBase64)
+	require.NoError(t, err)
+
+	config := DefaultConfig()
+	config.Mode = ModeRequired
+	config.JWT.Issuer = fixture.Issuer
+	config.JWT.TokenTTL = time.Duration(fixture.ExpiresAt-fixture.IssuedAt) * time.Second
+	config.JWT.ActiveKeyID = fixture.KeyID
+	config.JWT.Keys = []KeyConfig{{ID: fixture.KeyID, SecretFile: writeTestKey(t, string(secret))}}
+	authenticator, err := New(config, WithClock(func() time.Time { return time.Unix(fixture.IssuedAt, 0) }))
+	require.NoError(t, err)
+
+	md, err := authenticator.PerRPCCredentials(fixture.Audience).GetRequestMetadata(context.Background())
+	require.NoError(t, err)
+	rawToken := strings.TrimPrefix(md[authorizationMetadataKey], bearerScheme+" ")
+	assert.Equal(t, fixture.GoToken, rawToken)
+	assert.NoError(t, authenticator.verify(fixture.GoToken, fixture.Audience))
+	assert.NoError(t, authenticator.verify(fixture.RustToken, fixture.Audience))
+}
+
+func TestOverlappingKeysSupportRotation(t *testing.T) {
+	now := time.Unix(1_786_435_200, 0)
+	oldKey := []byte(strings.Repeat("o", MinimumKeySize))
+	newKey := []byte(strings.Repeat("n", MinimumKeySize))
+	config := DefaultConfig()
+	config.Mode = ModeRequired
+	config.JWT.ActiveKeyID = "new"
+	config.JWT.Keys = []KeyConfig{
+		{ID: "old", SecretFile: writeTestKey(t, string(oldKey))},
+		{ID: "new", SecretFile: writeTestKey(t, string(newKey))},
+	}
+	authenticator, err := New(config, WithClock(func() time.Time { return now }))
+	require.NoError(t, err)
+
+	claims := Claims{
+		Issuer:    DefaultIssuer,
+		Audience:  AudienceScheduler,
+		IssuedAt:  now.Unix(),
+		ExpiresAt: now.Add(DefaultTokenTTL).Unix(),
+	}
+	oldToken := signTestToken(t, claims, jwtlib.SigningMethodHS256, TokenType, "old", oldKey)
+	assert.NoError(t, authenticator.verify(oldToken, AudienceScheduler))
+
+	metadata, err := authenticator.PerRPCCredentials(AudienceScheduler).GetRequestMetadata(context.Background())
+	require.NoError(t, err)
+	newToken := strings.TrimPrefix(metadata[authorizationMetadataKey], bearerScheme+" ")
+	parser := jwtlib.NewParser()
+	header, _, err := parser.ParseUnverified(newToken, new(Claims))
+	require.NoError(t, err)
+	assert.Equal(t, "new", header.Header["kid"])
+}
+
+func TestDisabledPerRPCCredentials(t *testing.T) {
+	authenticator, err := New(DefaultConfig())
+	require.NoError(t, err)
+
+	md, err := authenticator.PerRPCCredentials(AudienceManager).GetRequestMetadata(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, md)
+}
+
+func TestNilAuthenticatorIsDisabled(t *testing.T) {
+	var authenticator *Authenticator
+	assert.Equal(t, ModeDisabled, authenticator.Mode())
+	assert.False(t, authenticator.Enabled())
+
+	md, err := authenticator.PerRPCCredentials(AudienceManager).GetRequestMetadata(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, md)
+}
+
+func TestPerRPCCredentialsRequireTransportSecurity(t *testing.T) {
+	config := validTestConfig(writeTestKey(t, strings.Repeat("k", MinimumKeySize)))
+	config.RequireTransportSecurity = true
+	authenticator, err := New(config)
+	require.NoError(t, err)
+
+	assert.True(t, authenticator.PerRPCCredentials(AudienceManager).RequireTransportSecurity())
+}
+
+func TestTokenCacheRefresh(t *testing.T) {
+	now := time.Unix(1_786_435_200, 0)
+	clock := func() time.Time { return now }
+	authenticator := newTestAuthenticator(t, ModeRequired, clock)
+	credentials := authenticator.PerRPCCredentials(AudienceManager)
+
+	first, err := credentials.GetRequestMetadata(context.Background())
+	require.NoError(t, err)
+	second, err := credentials.GetRequestMetadata(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+
+	now = now.Add(DefaultTokenTTL - DefaultRefreshBefore)
+	refreshed, err := credentials.GetRequestMetadata(context.Background())
+	require.NoError(t, err)
+	assert.NotEqual(t, first, refreshed)
+}
+
+func TestTokenProviderConcurrentAccess(t *testing.T) {
+	now := time.Unix(1_786_435_200, 0)
+	authenticator := newTestAuthenticator(t, ModeRequired, func() time.Time { return now })
+	credentials := authenticator.PerRPCCredentials(AudienceDfdaemon)
+
+	const goroutines = 32
+	results := make(chan string, goroutines)
+	errors := make(chan error, goroutines)
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			md, err := credentials.GetRequestMetadata(context.Background())
+			if err != nil {
+				errors <- err
+				return
+			}
+			results <- md[authorizationMetadataKey]
+		}()
+	}
+
+	wg.Wait()
+	close(results)
+	close(errors)
+	require.Empty(t, errors)
+
+	var expected string
+	for result := range results {
+		if expected == "" {
+			expected = result
+		}
+		assert.Equal(t, expected, result)
+	}
+}
+
+func TestVerifyRejectsInvalidClaimsAndHeaders(t *testing.T) {
+	now := time.Unix(1_786_435_200, 0)
+	authenticator := newTestAuthenticator(t, ModeRequired, func() time.Time { return now })
+	validClaims := Claims{
+		Issuer:    DefaultIssuer,
+		Audience:  AudienceScheduler,
+		IssuedAt:  now.Unix(),
+		ExpiresAt: now.Add(DefaultTokenTTL).Unix(),
+	}
+
+	tests := []struct {
+		name      string
+		claims    Claims
+		algorithm jwtlib.SigningMethod
+		tokenType string
+		keyID     string
+		key       []byte
+		reason    string
+	}{
+		{
+			name:      "unsupported algorithm",
+			claims:    validClaims,
+			algorithm: jwtlib.SigningMethodHS384,
+			tokenType: TokenType,
+			keyID:     "test-key",
+			key:       authenticator.keys["test-key"],
+			reason:    reasonUnsupportedAlg,
+		},
+		{
+			name:      "invalid type",
+			claims:    validClaims,
+			algorithm: jwtlib.SigningMethodHS256,
+			tokenType: "JWT",
+			keyID:     "test-key",
+			key:       authenticator.keys["test-key"],
+			reason:    reasonInvalidType,
+		},
+		{
+			name:      "unknown key id",
+			claims:    validClaims,
+			algorithm: jwtlib.SigningMethodHS256,
+			tokenType: TokenType,
+			keyID:     "unknown",
+			key:       authenticator.keys["test-key"],
+			reason:    reasonUnknownKeyID,
+		},
+		{
+			name:      "invalid signature",
+			claims:    validClaims,
+			algorithm: jwtlib.SigningMethodHS256,
+			tokenType: TokenType,
+			keyID:     "test-key",
+			key:       []byte(strings.Repeat("x", MinimumKeySize)),
+			reason:    reasonInvalidSignature,
+		},
+		{
+			name:      "invalid issuer",
+			claims:    withClaims(validClaims, func(claims *Claims) { claims.Issuer = "other" }),
+			algorithm: jwtlib.SigningMethodHS256,
+			tokenType: TokenType,
+			keyID:     "test-key",
+			key:       authenticator.keys["test-key"],
+			reason:    reasonInvalidIssuer,
+		},
+		{
+			name:      "invalid audience",
+			claims:    withClaims(validClaims, func(claims *Claims) { claims.Audience = AudienceManager }),
+			algorithm: jwtlib.SigningMethodHS256,
+			tokenType: TokenType,
+			keyID:     "test-key",
+			key:       authenticator.keys["test-key"],
+			reason:    reasonInvalidAudience,
+		},
+		{
+			name:      "future issued at",
+			claims:    withClaims(validClaims, func(claims *Claims) { claims.IssuedAt = now.Add(DefaultClockSkew + time.Second).Unix() }),
+			algorithm: jwtlib.SigningMethodHS256,
+			tokenType: TokenType,
+			keyID:     "test-key",
+			key:       authenticator.keys["test-key"],
+			reason:    reasonInvalidIssuedAt,
+		},
+		{
+			name:      "expired",
+			claims:    withClaims(validClaims, func(claims *Claims) { claims.ExpiresAt = now.Add(-DefaultClockSkew).Unix() }),
+			algorithm: jwtlib.SigningMethodHS256,
+			tokenType: TokenType,
+			keyID:     "test-key",
+			key:       authenticator.keys["test-key"],
+			reason:    reasonExpired,
+		},
+		{
+			name:      "ttl exceeded",
+			claims:    withClaims(validClaims, func(claims *Claims) { claims.ExpiresAt = claims.IssuedAt + int64(DefaultMaxTokenTTL/time.Second) + 1 }),
+			algorithm: jwtlib.SigningMethodHS256,
+			tokenType: TokenType,
+			keyID:     "test-key",
+			key:       authenticator.keys["test-key"],
+			reason:    reasonTTLExceeded,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rawToken := signTestToken(t, tc.claims, tc.algorithm, tc.tokenType, tc.keyID, tc.key)
+			err := authenticator.verify(rawToken, AudienceScheduler)
+			var authenticationError *authError
+			require.ErrorAs(t, err, &authenticationError)
+			assert.Equal(t, tc.reason, authenticationError.reason)
+		})
+	}
+}
+
+func TestUnaryServerInterceptorModes(t *testing.T) {
+	now := time.Unix(1_786_435_200, 0)
+	fullMethod := "/dragonfly.scheduler.v2.Scheduler/AnnounceHost"
+
+	tests := []struct {
+		name        string
+		mode        Mode
+		metadata    metadata.MD
+		wantCode    codes.Code
+		wantHandled bool
+	}{
+		{name: "disabled", mode: ModeDisabled, wantCode: codes.OK, wantHandled: true},
+		{name: "permissive missing", mode: ModePermissive, wantCode: codes.OK, wantHandled: true},
+		{name: "permissive invalid", mode: ModePermissive, metadata: metadata.Pairs(authorizationMetadataKey, "invalid"), wantCode: codes.Unauthenticated},
+		{name: "required missing", mode: ModeRequired, wantCode: codes.Unauthenticated},
+		{name: "required malformed", mode: ModeRequired, metadata: metadata.Pairs(authorizationMetadataKey, "invalid"), wantCode: codes.Unauthenticated},
+		{name: "required duplicate", mode: ModeRequired, metadata: metadata.MD{authorizationMetadataKey: []string{"Bearer first", "Bearer second"}}, wantCode: codes.Unauthenticated},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			authenticator := newTestAuthenticator(t, tc.mode, func() time.Time { return now })
+			ctx := metadata.NewIncomingContext(context.Background(), tc.metadata)
+			handled := false
+			_, err := authenticator.UnaryServerInterceptor(AudienceScheduler)(ctx, nil, &grpc.UnaryServerInfo{FullMethod: fullMethod}, func(context.Context, any) (any, error) {
+				handled = true
+				return nil, nil
+			})
+			assert.Equal(t, tc.wantCode, status.Code(err))
+			assert.Equal(t, tc.wantHandled, handled)
+		})
+	}
+}
+
+func TestUnaryServerInterceptorAcceptsValidToken(t *testing.T) {
+	now := time.Unix(1_786_435_200, 0)
+	authenticator := newTestAuthenticator(t, ModeRequired, func() time.Time { return now })
+	clientMetadata, err := authenticator.PerRPCCredentials(AudienceScheduler).GetRequestMetadata(context.Background())
+	require.NoError(t, err)
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.New(clientMetadata))
+	handled := false
+	_, err = authenticator.UnaryServerInterceptor(AudienceScheduler)(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/dragonfly.scheduler.v2.Scheduler/AnnounceHost"}, func(context.Context, any) (any, error) {
+		handled = true
+		return nil, nil
+	})
+	require.NoError(t, err)
+	assert.True(t, handled)
+}
+
+func TestHealthBypassesAuthentication(t *testing.T) {
+	authenticator := newTestAuthenticator(t, ModeRequired, time.Now)
+	handled := false
+	_, err := authenticator.UnaryServerInterceptor(AudienceScheduler)(context.Background(), nil, &grpc.UnaryServerInfo{FullMethod: "/grpc.health.v1.Health/Check"}, func(context.Context, any) (any, error) {
+		handled = true
+		return nil, nil
+	})
+	require.NoError(t, err)
+	assert.True(t, handled)
+}
+
+func TestReflectionDoesNotBypassAuthentication(t *testing.T) {
+	authenticator := newTestAuthenticator(t, ModeRequired, time.Now)
+	stream := &testServerStream{ctx: context.Background()}
+	err := authenticator.StreamServerInterceptor(AudienceScheduler)(nil, stream, &grpc.StreamServerInfo{FullMethod: "/grpc.reflection.v1.ServerReflection/ServerReflectionInfo"}, func(any, grpc.ServerStream) error {
+		return nil
+	})
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+type testServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *testServerStream) Context() context.Context {
+	return s.ctx
+}
+
+func newTestAuthenticator(t *testing.T, mode Mode, clock func() time.Time) *Authenticator {
+	t.Helper()
+
+	if mode == ModeDisabled {
+		authenticator, err := New(DefaultConfig(), WithClock(clock))
+		require.NoError(t, err)
+		return authenticator
+	}
+
+	config := validTestConfig(writeTestKey(t, strings.Repeat("k", MinimumKeySize)))
+	config.Mode = mode
+	authenticator, err := New(config, WithClock(clock))
+	require.NoError(t, err)
+	return authenticator
+}
+
+func signTestToken(t *testing.T, claims Claims, method jwtlib.SigningMethod, tokenType, keyID string, key []byte) string {
+	t.Helper()
+
+	token := jwtlib.NewWithClaims(method, claims)
+	token.Header["typ"] = tokenType
+	token.Header["kid"] = keyID
+	signed, err := token.SignedString(key)
+	require.NoError(t, err)
+	return signed
+}
+
+func withClaims(claims Claims, mutate func(*Claims)) Claims {
+	mutate(&claims)
+	return claims
+}

--- a/pkg/rpc/auth/jwt/config.go
+++ b/pkg/rpc/auth/jwt/config.go
@@ -1,0 +1,246 @@
+/*
+ *     Copyright 2026 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jwt
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	// DefaultIssuer is the default issuer of inter-component gRPC JWTs.
+	DefaultIssuer = "dragonfly-internal"
+
+	// DefaultTokenTTL is the default lifetime of a generated JWT.
+	DefaultTokenTTL = 10 * time.Minute
+
+	// DefaultMaxTokenTTL is the maximum accepted lifetime of a JWT.
+	DefaultMaxTokenTTL = 15 * time.Minute
+
+	// DefaultClockSkew is the default clock skew allowed by the verifier.
+	DefaultClockSkew = 30 * time.Second
+
+	// DefaultRefreshBefore is the default duration before expiration at which a
+	// cached JWT is refreshed.
+	DefaultRefreshBefore = time.Minute
+
+	// MinimumKeySize is the minimum decoded HMAC key size in bytes.
+	MinimumKeySize = 32
+)
+
+// Mode controls client and server authentication behavior.
+type Mode string
+
+const (
+	// ModeDisabled does not send or verify JWTs.
+	ModeDisabled Mode = "disabled"
+
+	// ModePermissive sends JWTs and accepts requests without JWTs during a
+	// rolling upgrade. Invalid supplied JWTs are still rejected.
+	ModePermissive Mode = "permissive"
+
+	// ModeRequired sends JWTs and rejects requests without a valid JWT.
+	ModeRequired Mode = "required"
+)
+
+// Config is the configuration for inter-component gRPC authentication.
+type Config struct {
+	// Mode controls client and server authentication behavior.
+	Mode Mode `yaml:"mode" mapstructure:"mode"`
+
+	// RequireTransportSecurity rejects sending JWTs over plaintext transports
+	// when it is true.
+	RequireTransportSecurity bool `yaml:"requireTransportSecurity" mapstructure:"requireTransportSecurity"`
+
+	// JWT is the JWT configuration.
+	JWT JWTConfig `yaml:"jwt" mapstructure:"jwt"`
+}
+
+// JWTConfig is the configuration for signing and verifying JWTs.
+type JWTConfig struct {
+	// Issuer is the exact issuer required by the verifier.
+	Issuer string `yaml:"issuer" mapstructure:"issuer"`
+
+	// TokenTTL is the lifetime of a generated JWT.
+	TokenTTL time.Duration `yaml:"tokenTTL" mapstructure:"tokenTTL"`
+
+	// MaxTokenTTL is the maximum accepted lifetime of a JWT.
+	MaxTokenTTL time.Duration `yaml:"maxTokenTTL" mapstructure:"maxTokenTTL"`
+
+	// ClockSkew is the allowed clock difference between components.
+	ClockSkew time.Duration `yaml:"clockSkew" mapstructure:"clockSkew"`
+
+	// RefreshBefore controls when a cached JWT is refreshed.
+	RefreshBefore time.Duration `yaml:"refreshBefore" mapstructure:"refreshBefore"`
+
+	// ActiveKeyID identifies the key used to sign new JWTs.
+	ActiveKeyID string `yaml:"activeKeyID" mapstructure:"activeKeyID"`
+
+	// Keys contains all keys trusted by the verifier.
+	Keys []KeyConfig `yaml:"keys" mapstructure:"keys"`
+}
+
+// KeyConfig identifies a shared HMAC key file.
+type KeyConfig struct {
+	// ID is serialized as the JWT kid header.
+	ID string `yaml:"id" mapstructure:"id"`
+
+	// SecretFile contains a Base64-encoded HMAC key.
+	SecretFile string `yaml:"secretFile" mapstructure:"secretFile"`
+}
+
+// DefaultConfig returns the default disabled gRPC authentication configuration.
+func DefaultConfig() Config {
+	return Config{
+		Mode: ModeDisabled,
+		JWT: JWTConfig{
+			Issuer:        DefaultIssuer,
+			TokenTTL:      DefaultTokenTTL,
+			MaxTokenTTL:   DefaultMaxTokenTTL,
+			ClockSkew:     DefaultClockSkew,
+			RefreshBefore: DefaultRefreshBefore,
+		},
+	}
+}
+
+// EffectiveMode treats an omitted mode as disabled for backward compatibility.
+func (c Config) EffectiveMode() Mode {
+	if c.Mode == "" {
+		return ModeDisabled
+	}
+
+	return c.Mode
+}
+
+// Enabled returns whether gRPC authentication is enabled.
+func (c Config) Enabled() bool {
+	return c.EffectiveMode() != ModeDisabled
+}
+
+// ValidateConfig validates configuration and referenced key files.
+func ValidateConfig(config Config) error {
+	_, err := validateAndLoadKeys(config)
+	return err
+}
+
+func validateAndLoadKeys(config Config) (map[string][]byte, error) {
+	switch config.EffectiveMode() {
+	case ModeDisabled:
+		return nil, nil
+	case ModePermissive, ModeRequired:
+	default:
+		return nil, fmt.Errorf("grpc auth has unsupported mode %q", config.Mode)
+	}
+
+	if config.JWT.Issuer == "" {
+		return nil, errors.New("grpc auth jwt requires parameter issuer")
+	}
+
+	if config.JWT.TokenTTL < time.Second {
+		return nil, errors.New("grpc auth jwt tokenTTL must be at least one second")
+	}
+
+	if config.JWT.MaxTokenTTL < time.Second {
+		return nil, errors.New("grpc auth jwt maxTokenTTL must be at least one second")
+	}
+
+	if config.JWT.TokenTTL%time.Second != 0 ||
+		config.JWT.MaxTokenTTL%time.Second != 0 ||
+		config.JWT.ClockSkew%time.Second != 0 ||
+		config.JWT.RefreshBefore%time.Second != 0 {
+		return nil, errors.New("grpc auth jwt durations must use whole seconds")
+	}
+
+	if config.JWT.TokenTTL > config.JWT.MaxTokenTTL {
+		return nil, errors.New("grpc auth jwt tokenTTL must not exceed maxTokenTTL")
+	}
+
+	if config.JWT.ClockSkew < 0 {
+		return nil, errors.New("grpc auth jwt clockSkew must not be negative")
+	}
+
+	if config.JWT.RefreshBefore <= 0 || config.JWT.RefreshBefore >= config.JWT.TokenTTL {
+		return nil, errors.New("grpc auth jwt refreshBefore must be positive and less than tokenTTL")
+	}
+
+	if config.JWT.ActiveKeyID == "" {
+		return nil, errors.New("grpc auth jwt requires parameter activeKeyID")
+	}
+
+	if len(config.JWT.Keys) == 0 {
+		return nil, errors.New("grpc auth jwt requires at least one key")
+	}
+
+	keys := make(map[string][]byte, len(config.JWT.Keys))
+	for _, keyConfig := range config.JWT.Keys {
+		if keyConfig.ID == "" {
+			return nil, errors.New("grpc auth jwt key requires parameter id")
+		}
+
+		if _, ok := keys[keyConfig.ID]; ok {
+			return nil, fmt.Errorf("grpc auth jwt key id %q is duplicated", keyConfig.ID)
+		}
+
+		if keyConfig.SecretFile == "" {
+			return nil, fmt.Errorf("grpc auth jwt key %q requires parameter secretFile", keyConfig.ID)
+		}
+
+		secret, err := loadKey(keyConfig.SecretFile)
+		if err != nil {
+			return nil, fmt.Errorf("grpc auth jwt key %q: %w", keyConfig.ID, err)
+		}
+
+		keys[keyConfig.ID] = secret
+	}
+
+	if _, ok := keys[config.JWT.ActiveKeyID]; !ok {
+		return nil, fmt.Errorf("grpc auth jwt active key id %q is not trusted", config.JWT.ActiveKeyID)
+	}
+
+	return keys, nil
+}
+
+func loadKey(path string) ([]byte, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("stat secret file: %w", err)
+	}
+
+	if !info.Mode().IsRegular() {
+		return nil, errors.New("secret file is not a regular file")
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read secret file: %w", err)
+	}
+
+	secret, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(content)))
+	if err != nil {
+		return nil, errors.New("secret file is not valid standard Base64")
+	}
+
+	if len(secret) < MinimumKeySize {
+		return nil, fmt.Errorf("decoded secret must contain at least %d bytes", MinimumKeySize)
+	}
+
+	return secret, nil
+}

--- a/pkg/rpc/auth/jwt/config_test.go
+++ b/pkg/rpc/auth/jwt/config_test.go
@@ -1,0 +1,190 @@
+/*
+ *     Copyright 2026 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jwt
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	config := DefaultConfig()
+	assert.Equal(t, ModeDisabled, config.Mode)
+	assert.Equal(t, DefaultIssuer, config.JWT.Issuer)
+	assert.Equal(t, DefaultTokenTTL, config.JWT.TokenTTL)
+	assert.Equal(t, DefaultMaxTokenTTL, config.JWT.MaxTokenTTL)
+	assert.Equal(t, DefaultClockSkew, config.JWT.ClockSkew)
+	assert.Equal(t, DefaultRefreshBefore, config.JWT.RefreshBefore)
+}
+
+func TestConfigEffectiveMode(t *testing.T) {
+	assert.Equal(t, ModeDisabled, Config{}.EffectiveMode())
+	assert.False(t, Config{}.Enabled())
+	assert.True(t, Config{Mode: ModeRequired}.Enabled())
+}
+
+func TestValidateConfig(t *testing.T) {
+	keyFile := writeTestKey(t, strings.Repeat("k", MinimumKeySize))
+	valid := validTestConfig(keyFile)
+
+	tests := []struct {
+		name    string
+		mutate  func(*Config)
+		wantErr string
+	}{
+		{
+			name:    "unsupported mode",
+			mutate:  func(config *Config) { config.Mode = "unknown" },
+			wantErr: `grpc auth has unsupported mode "unknown"`,
+		},
+		{
+			name:    "missing issuer",
+			mutate:  func(config *Config) { config.JWT.Issuer = "" },
+			wantErr: "grpc auth jwt requires parameter issuer",
+		},
+		{
+			name:    "token ttl below one second",
+			mutate:  func(config *Config) { config.JWT.TokenTTL = 0 },
+			wantErr: "grpc auth jwt tokenTTL must be at least one second",
+		},
+		{
+			name:    "max token ttl below one second",
+			mutate:  func(config *Config) { config.JWT.MaxTokenTTL = 0 },
+			wantErr: "grpc auth jwt maxTokenTTL must be at least one second",
+		},
+		{
+			name:    "duration with fractional second",
+			mutate:  func(config *Config) { config.JWT.TokenTTL += time.Millisecond },
+			wantErr: "grpc auth jwt durations must use whole seconds",
+		},
+		{
+			name:    "token ttl exceeds maximum",
+			mutate:  func(config *Config) { config.JWT.TokenTTL = config.JWT.MaxTokenTTL + time.Second },
+			wantErr: "grpc auth jwt tokenTTL must not exceed maxTokenTTL",
+		},
+		{
+			name:    "negative clock skew",
+			mutate:  func(config *Config) { config.JWT.ClockSkew = -time.Second },
+			wantErr: "grpc auth jwt clockSkew must not be negative",
+		},
+		{
+			name:    "invalid refresh before",
+			mutate:  func(config *Config) { config.JWT.RefreshBefore = config.JWT.TokenTTL },
+			wantErr: "grpc auth jwt refreshBefore must be positive and less than tokenTTL",
+		},
+		{
+			name:    "missing active key id",
+			mutate:  func(config *Config) { config.JWT.ActiveKeyID = "" },
+			wantErr: "grpc auth jwt requires parameter activeKeyID",
+		},
+		{
+			name:    "missing keys",
+			mutate:  func(config *Config) { config.JWT.Keys = nil },
+			wantErr: "grpc auth jwt requires at least one key",
+		},
+		{
+			name: "duplicate key id",
+			mutate: func(config *Config) {
+				config.JWT.Keys = append(config.JWT.Keys, config.JWT.Keys[0])
+			},
+			wantErr: `grpc auth jwt key id "test-key" is duplicated`,
+		},
+		{
+			name:    "untrusted active key",
+			mutate:  func(config *Config) { config.JWT.ActiveKeyID = "unknown" },
+			wantErr: `grpc auth jwt active key id "unknown" is not trusted`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			config := valid
+			config.JWT.Keys = append([]KeyConfig(nil), valid.JWT.Keys...)
+			tc.mutate(&config)
+			assert.EqualError(t, ValidateConfig(config), tc.wantErr)
+		})
+	}
+
+	assert.NoError(t, ValidateConfig(valid))
+	assert.NoError(t, ValidateConfig(Config{}))
+}
+
+func TestValidateConfigRejectsInvalidKeyFiles(t *testing.T) {
+	shortKeyFile := writeTestKey(t, "short")
+	invalidBase64File := filepath.Join(t.TempDir(), "invalid")
+	require.NoError(t, os.WriteFile(invalidBase64File, []byte("not-base64!"), 0o600))
+
+	directory := t.TempDir()
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr string
+	}{
+		{
+			name:    "missing file",
+			path:    filepath.Join(t.TempDir(), "missing"),
+			wantErr: "stat secret file",
+		},
+		{
+			name:    "directory",
+			path:    directory,
+			wantErr: "secret file is not a regular file",
+		},
+		{
+			name:    "invalid base64",
+			path:    invalidBase64File,
+			wantErr: "secret file is not valid standard Base64",
+		},
+		{
+			name:    "short key",
+			path:    shortKeyFile,
+			wantErr: "decoded secret must contain at least 32 bytes",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			config := validTestConfig(tc.path)
+			assert.ErrorContains(t, ValidateConfig(config), tc.wantErr)
+		})
+	}
+}
+
+func validTestConfig(keyFile string) Config {
+	config := DefaultConfig()
+	config.Mode = ModeRequired
+	config.JWT.ActiveKeyID = "test-key"
+	config.JWT.Keys = []KeyConfig{{ID: "test-key", SecretFile: keyFile}}
+	return config
+}
+
+func writeTestKey(t *testing.T, secret string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "key")
+	encoded := base64.StdEncoding.EncodeToString([]byte(secret)) + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(encoded), 0o600))
+	return path
+}

--- a/pkg/rpc/auth/jwt/interceptor.go
+++ b/pkg/rpc/auth/jwt/interceptor.go
@@ -1,0 +1,250 @@
+/*
+ *     Copyright 2026 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jwt
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	jwtlib "github.com/golang-jwt/jwt/v4"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	authenticationErrorMessage = "invalid authentication credentials"
+	healthMethodPrefix         = "/grpc.health.v1.Health/"
+)
+
+const (
+	reasonNone             = "none"
+	reasonMissing          = "missing"
+	reasonMalformed        = "malformed"
+	reasonUnsupportedAlg   = "unsupported_alg"
+	reasonInvalidType      = "invalid_type"
+	reasonUnknownKeyID     = "unknown_kid"
+	reasonInvalidSignature = "invalid_signature"
+	reasonInvalidIssuer    = "invalid_issuer"
+	reasonInvalidAudience  = "invalid_audience"
+	reasonExpired          = "expired"
+	reasonInvalidIssuedAt  = "invalid_iat"
+	reasonTTLExceeded      = "ttl_exceeded"
+)
+
+type authError struct {
+	reason string
+	cause  error
+}
+
+var errPermissiveMissing = &authError{
+	reason: reasonMissing,
+	cause:  errors.New("authorization metadata is missing in permissive mode"),
+}
+
+func (e *authError) Error() string {
+	return e.cause.Error()
+}
+
+func (e *authError) Unwrap() error {
+	return e.cause
+}
+
+// UnaryServerInterceptor authenticates unary gRPC requests for audience.
+func (a *Authenticator) UnaryServerInterceptor(audience string) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if a.skipServerAuthentication(info.FullMethod) {
+			return handler(ctx, req)
+		}
+
+		if err := a.authenticate(ctx, audience); errors.Is(err, errPermissiveMissing) {
+			a.recordPermissiveMissing(audience)
+			return handler(ctx, req)
+		} else if err != nil {
+			a.recordServerResult(audience, err)
+			return nil, status.Error(codes.Unauthenticated, authenticationErrorMessage)
+		}
+
+		a.recordServerResult(audience, nil)
+		return handler(ctx, req)
+	}
+}
+
+// StreamServerInterceptor authenticates streaming gRPC requests for audience
+// when a stream is established.
+func (a *Authenticator) StreamServerInterceptor(audience string) grpc.StreamServerInterceptor {
+	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if a.skipServerAuthentication(info.FullMethod) {
+			return handler(srv, stream)
+		}
+
+		if err := a.authenticate(stream.Context(), audience); errors.Is(err, errPermissiveMissing) {
+			a.recordPermissiveMissing(audience)
+			return handler(srv, stream)
+		} else if err != nil {
+			a.recordServerResult(audience, err)
+			return status.Error(codes.Unauthenticated, authenticationErrorMessage)
+		}
+
+		a.recordServerResult(audience, nil)
+		return handler(srv, stream)
+	}
+}
+
+func (a *Authenticator) skipServerAuthentication(fullMethod string) bool {
+	return !a.Enabled() || strings.HasPrefix(fullMethod, healthMethodPrefix)
+}
+
+func (a *Authenticator) authenticate(ctx context.Context, audience string) error {
+	if err := validateAudience(audience); err != nil {
+		return &authError{reason: reasonInvalidAudience, cause: err}
+	}
+
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return a.handleMissingCredentials()
+	}
+
+	values := md.Get(authorizationMetadataKey)
+	if len(values) == 0 {
+		return a.handleMissingCredentials()
+	}
+
+	if len(values) != 1 {
+		return &authError{reason: reasonMalformed, cause: errors.New("multiple authorization metadata values")}
+	}
+
+	credential := values[0]
+	if len(credential) > maxCredentialLength {
+		return &authError{reason: reasonMalformed, cause: errors.New("authorization metadata is too large")}
+	}
+
+	parts := strings.Fields(credential)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], bearerScheme) || parts[1] == "" {
+		return &authError{reason: reasonMalformed, cause: errors.New("malformed bearer credential")}
+	}
+
+	return a.verify(parts[1], audience)
+}
+
+func (a *Authenticator) handleMissingCredentials() error {
+	if a.Mode() == ModePermissive {
+		return errPermissiveMissing
+	}
+
+	return &authError{reason: reasonMissing, cause: errors.New("authorization metadata is missing")}
+}
+
+func (a *Authenticator) recordPermissiveMissing(audience string) {
+	serverRequests.WithLabelValues(audience, string(a.Mode()), "allowed", reasonMissing).Inc()
+}
+
+func (a *Authenticator) verify(rawToken, audience string) error {
+	parser := jwtlib.NewParser(jwtlib.WithValidMethods([]string{jwtlib.SigningMethodHS256.Alg()}), jwtlib.WithoutClaimsValidation())
+	unverifiedClaims := new(Claims)
+	unverifiedToken, _, err := parser.ParseUnverified(rawToken, unverifiedClaims)
+	if err != nil {
+		return &authError{reason: reasonMalformed, cause: fmt.Errorf("parse jwt header: %w", err)}
+	}
+
+	if unverifiedToken.Method != jwtlib.SigningMethodHS256 {
+		return &authError{reason: reasonUnsupportedAlg, cause: errors.New("jwt algorithm is not HS256")}
+	}
+
+	tokenType, ok := unverifiedToken.Header["typ"].(string)
+	if !ok || tokenType != TokenType {
+		return &authError{reason: reasonInvalidType, cause: errors.New("jwt type is invalid")}
+	}
+
+	keyID, ok := unverifiedToken.Header["kid"].(string)
+	if !ok || keyID == "" {
+		return &authError{reason: reasonUnknownKeyID, cause: errors.New("jwt key id is missing")}
+	}
+
+	key, ok := a.keys[keyID]
+	if !ok {
+		return &authError{reason: reasonUnknownKeyID, cause: errors.New("jwt key id is not trusted")}
+	}
+
+	claims := new(Claims)
+	token, err := parser.ParseWithClaims(rawToken, claims, func(token *jwtlib.Token) (any, error) {
+		if token.Method != jwtlib.SigningMethodHS256 {
+			return nil, errors.New("jwt algorithm is not HS256")
+		}
+
+		return key, nil
+	})
+	if err != nil || !token.Valid {
+		return &authError{reason: reasonInvalidSignature, cause: errors.New("jwt signature is invalid")}
+	}
+
+	if claims.Issuer != a.config.JWT.Issuer {
+		return &authError{reason: reasonInvalidIssuer, cause: errors.New("jwt issuer is invalid")}
+	}
+
+	if claims.Audience != audience {
+		return &authError{reason: reasonInvalidAudience, cause: errors.New("jwt audience is invalid")}
+	}
+
+	if claims.IssuedAt <= 0 {
+		return &authError{reason: reasonInvalidIssuedAt, cause: errors.New("jwt issued-at time is missing")}
+	}
+
+	if claims.ExpiresAt <= 0 {
+		return &authError{reason: reasonExpired, cause: errors.New("jwt expiration time is missing")}
+	}
+
+	now := a.now().Unix()
+	skew := int64(a.config.JWT.ClockSkew / time.Second)
+	if claims.IssuedAt > now+skew {
+		return &authError{reason: reasonInvalidIssuedAt, cause: errors.New("jwt issued-at time is in the future")}
+	}
+
+	if claims.ExpiresAt <= now-skew {
+		return &authError{reason: reasonExpired, cause: errors.New("jwt is expired")}
+	}
+
+	if claims.ExpiresAt <= claims.IssuedAt {
+		return &authError{reason: reasonTTLExceeded, cause: errors.New("jwt lifetime is not positive")}
+	}
+
+	maxLifetimeSeconds := int64(a.config.JWT.MaxTokenTTL / time.Second)
+	if claims.ExpiresAt-claims.IssuedAt > maxLifetimeSeconds {
+		return &authError{reason: reasonTTLExceeded, cause: errors.New("jwt lifetime exceeds the configured maximum")}
+	}
+
+	return nil
+}
+
+func (a *Authenticator) recordServerResult(audience string, err error) {
+	if err == nil {
+		serverRequests.WithLabelValues(audience, string(a.Mode()), "success", reasonNone).Inc()
+		return
+	}
+
+	reason := reasonMalformed
+	var authenticationError *authError
+	if errors.As(err, &authenticationError) {
+		reason = authenticationError.reason
+	}
+
+	serverRequests.WithLabelValues(audience, string(a.Mode()), "failure", reason).Inc()
+}

--- a/pkg/rpc/auth/jwt/metrics.go
+++ b/pkg/rpc/auth/jwt/metrics.go
@@ -1,0 +1,45 @@
+/*
+ *     Copyright 2026 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jwt
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	tokenEventCacheHit         = "cache_hit"
+	tokenEventCacheMiss        = "cache_miss"
+	tokenEventGenerated        = "generated"
+	tokenEventGenerationFailed = "generation_failed"
+)
+
+var (
+	serverRequests = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "dragonfly",
+		Subsystem: "grpc_auth",
+		Name:      "requests_total",
+		Help:      "Total number of inter-component gRPC authentication attempts.",
+	}, []string{"audience", "mode", "result", "reason"})
+
+	clientTokenEvents = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "dragonfly",
+		Subsystem: "grpc_auth",
+		Name:      "client_token_events_total",
+		Help:      "Total number of inter-component gRPC client JWT cache and generation events.",
+	}, []string{"audience", "event"})
+)

--- a/pkg/rpc/auth/jwt/testdata/interop.json
+++ b/pkg/rpc/auth/jwt/testdata/interop.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "TEST ONLY. This deterministic key must never be used in a deployment.",
+  "secretBase64": "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
+  "keyID": "test-key",
+  "issuer": "dragonfly-internal",
+  "audience": "urn:dragonfly:grpc:scheduler",
+  "issuedAt": 1786435200,
+  "expiresAt": 1786435800,
+  "goToken": "eyJhbGciOiJIUzI1NiIsImtpZCI6InRlc3Qta2V5IiwidHlwIjoiZHJhZ29uZmx5LWdycGMrand0In0.eyJpc3MiOiJkcmFnb25mbHktaW50ZXJuYWwiLCJhdWQiOiJ1cm46ZHJhZ29uZmx5OmdycGM6c2NoZWR1bGVyIiwiaWF0IjoxNzg2NDM1MjAwLCJleHAiOjE3ODY0MzU4MDB9.-BwX7Ur59WOu00J90_FUGr7wFQ7FqKmmYbd8OVNf8s4",
+  "rustToken": "eyJ0eXAiOiJkcmFnb25mbHktZ3JwYytqd3QiLCJhbGciOiJIUzI1NiIsImtpZCI6InRlc3Qta2V5In0.eyJpc3MiOiJkcmFnb25mbHktaW50ZXJuYWwiLCJhdWQiOiJ1cm46ZHJhZ29uZmx5OmdycGM6c2NoZWR1bGVyIiwiaWF0IjoxNzg2NDM1MjAwLCJleHAiOjE3ODY0MzU4MDB9.GPft73L1Y8aPMedYlf_drg_vHGzwirKIzfn3lxH8ZeY"
+}

--- a/pkg/rpc/manager/server/server.go
+++ b/pkg/rpc/manager/server/server.go
@@ -39,6 +39,7 @@ import (
 
 	logger "d7y.io/dragonfly/v2/internal/dflog"
 	"d7y.io/dragonfly/v2/pkg/rpc"
+	grpcauth "d7y.io/dragonfly/v2/pkg/rpc/auth/jwt"
 )
 
 const (
@@ -54,6 +55,12 @@ const (
 
 // New returns grpc server instance and register service on grpc server.
 func New(managerServerV1 managerv1.ManagerServer, managerServerV2 managerv2.ManagerServer, requestRateLimit float64, opts ...grpc.ServerOption) *grpc.Server {
+	return NewWithAuthentication(managerServerV1, managerServerV2, requestRateLimit, nil, opts...)
+}
+
+// NewWithAuthentication returns a gRPC server with inter-component JWT
+// authentication.
+func NewWithAuthentication(managerServerV1 managerv1.ManagerServer, managerServerV2 managerv2.ManagerServer, requestRateLimit float64, authenticator *grpcauth.Authenticator, opts ...grpc.ServerOption) *grpc.Server {
 	limiter := rpc.NewRateLimiterInterceptor(requestRateLimit, int64(requestRateLimit))
 
 	grpcServer := grpc.NewServer(append([]grpc.ServerOption{
@@ -70,6 +77,7 @@ func New(managerServerV1 managerv1.ManagerServer, managerServerV2 managerv2.Mana
 		}),
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
 			grpc_ratelimit.UnaryServerInterceptor(limiter),
+			authenticator.UnaryServerInterceptor(grpcauth.AudienceManager),
 			grpc_prometheus.UnaryServerInterceptor,
 			grpc_zap.UnaryServerInterceptor(logger.GrpcLogger.Desugar()),
 			grpc_validator.UnaryServerInterceptor(),
@@ -77,6 +85,7 @@ func New(managerServerV1 managerv1.ManagerServer, managerServerV2 managerv2.Mana
 		)),
 		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
 			grpc_ratelimit.StreamServerInterceptor(limiter),
+			authenticator.StreamServerInterceptor(grpcauth.AudienceManager),
 			grpc_prometheus.StreamServerInterceptor,
 			grpc_zap.StreamServerInterceptor(logger.GrpcLogger.Desugar()),
 			grpc_validator.StreamServerInterceptor(),

--- a/pkg/rpc/manager/server/server_test.go
+++ b/pkg/rpc/manager/server/server_test.go
@@ -1,0 +1,116 @@
+/*
+ *     Copyright 2026 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import (
+	"context"
+	"encoding/base64"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	managerv1 "d7y.io/api/v2/pkg/apis/manager/v1"
+	managerv2 "d7y.io/api/v2/pkg/apis/manager/v2"
+
+	grpcauth "d7y.io/dragonfly/v2/pkg/rpc/auth/jwt"
+)
+
+func TestServerAuthentication(t *testing.T) {
+	authenticator := newTestAuthenticator(t)
+	listener := bufconn.Listen(1024 * 1024)
+	grpcServer := NewWithAuthentication(
+		&managerv1.UnimplementedManagerServer{},
+		&managerv2.UnimplementedManagerServer{},
+		100,
+		authenticator,
+	)
+
+	go func() { _ = grpcServer.Serve(listener) }()
+	t.Cleanup(func() {
+		grpcServer.Stop()
+		require.NoError(t, listener.Close())
+	})
+
+	connection := dialTestServer(t, listener)
+	_, err := managerv2.NewManagerClient(connection).ListSchedulers(
+		context.Background(),
+		&managerv2.ListSchedulersRequest{},
+	)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+
+	response, err := healthpb.NewHealthClient(connection).Check(
+		context.Background(),
+		&healthpb.HealthCheckRequest{},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, healthpb.HealthCheckResponse_SERVING, response.GetStatus())
+
+	authenticatedConnection := dialTestServer(
+		t,
+		listener,
+		grpc.WithPerRPCCredentials(authenticator.PerRPCCredentials(grpcauth.AudienceManager)),
+	)
+	_, err = managerv2.NewManagerClient(authenticatedConnection).ListSchedulers(
+		context.Background(),
+		&managerv2.ListSchedulersRequest{Hostname: "test", Ip: "127.0.0.1"},
+	)
+	assert.Equal(t, codes.Unimplemented, status.Code(err))
+}
+
+func dialTestServer(t *testing.T, listener *bufconn.Listener, options ...grpc.DialOption) *grpc.ClientConn {
+	t.Helper()
+
+	connection, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		append([]grpc.DialOption{
+			grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+				return listener.Dial()
+			}),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		}, options...)...,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, connection.Close()) })
+	return connection
+}
+
+func newTestAuthenticator(t *testing.T) *grpcauth.Authenticator {
+	t.Helper()
+
+	secretFile := filepath.Join(t.TempDir(), "grpc-auth-key")
+	secret := base64.StdEncoding.EncodeToString([]byte(strings.Repeat("k", grpcauth.MinimumKeySize)))
+	require.NoError(t, os.WriteFile(secretFile, []byte(secret), 0o600))
+
+	config := grpcauth.DefaultConfig()
+	config.Mode = grpcauth.ModeRequired
+	config.JWT.ActiveKeyID = "test-key"
+	config.JWT.Keys = []grpcauth.KeyConfig{{ID: "test-key", SecretFile: secretFile}}
+	authenticator, err := grpcauth.New(config)
+	require.NoError(t, err)
+	return authenticator
+}

--- a/pkg/rpc/scheduler/server/server.go
+++ b/pkg/rpc/scheduler/server/server.go
@@ -39,6 +39,7 @@ import (
 
 	logger "d7y.io/dragonfly/v2/internal/dflog"
 	"d7y.io/dragonfly/v2/pkg/rpc"
+	grpcauth "d7y.io/dragonfly/v2/pkg/rpc/auth/jwt"
 )
 
 const (
@@ -54,6 +55,12 @@ const (
 
 // New returns a grpc server instance and register service on grpc server.
 func New(schedulerServerV1 schedulerv1.SchedulerServer, schedulerServerV2 schedulerv2.SchedulerServer, requestRateLimit float64, opts ...grpc.ServerOption) *grpc.Server {
+	return NewWithAuthentication(schedulerServerV1, schedulerServerV2, requestRateLimit, nil, opts...)
+}
+
+// NewWithAuthentication returns a gRPC server with inter-component JWT
+// authentication.
+func NewWithAuthentication(schedulerServerV1 schedulerv1.SchedulerServer, schedulerServerV2 schedulerv2.SchedulerServer, requestRateLimit float64, authenticator *grpcauth.Authenticator, opts ...grpc.ServerOption) *grpc.Server {
 	limiter := rpc.NewRateLimiterInterceptor(requestRateLimit, int64(requestRateLimit))
 
 	grpcServer := grpc.NewServer(append([]grpc.ServerOption{
@@ -70,6 +77,7 @@ func New(schedulerServerV1 schedulerv1.SchedulerServer, schedulerServerV2 schedu
 		}),
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
 			grpc_ratelimit.UnaryServerInterceptor(limiter),
+			authenticator.UnaryServerInterceptor(grpcauth.AudienceScheduler),
 			rpc.ConvertErrorUnaryServerInterceptor,
 			grpc_prometheus.UnaryServerInterceptor,
 			grpc_zap.UnaryServerInterceptor(logger.GrpcLogger.Desugar()),
@@ -78,6 +86,7 @@ func New(schedulerServerV1 schedulerv1.SchedulerServer, schedulerServerV2 schedu
 		)),
 		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
 			grpc_ratelimit.StreamServerInterceptor(limiter),
+			authenticator.StreamServerInterceptor(grpcauth.AudienceScheduler),
 			rpc.ConvertErrorStreamServerInterceptor,
 			grpc_prometheus.StreamServerInterceptor,
 			grpc_zap.StreamServerInterceptor(logger.GrpcLogger.Desugar()),

--- a/pkg/rpc/scheduler/server/server_test.go
+++ b/pkg/rpc/scheduler/server/server_test.go
@@ -1,0 +1,116 @@
+/*
+ *     Copyright 2026 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import (
+	"context"
+	"encoding/base64"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	schedulerv1 "d7y.io/api/v2/pkg/apis/scheduler/v1"
+	schedulerv2 "d7y.io/api/v2/pkg/apis/scheduler/v2"
+
+	grpcauth "d7y.io/dragonfly/v2/pkg/rpc/auth/jwt"
+)
+
+func TestServerAuthentication(t *testing.T) {
+	authenticator := newTestAuthenticator(t)
+	listener := bufconn.Listen(1024 * 1024)
+	grpcServer := NewWithAuthentication(
+		&schedulerv1.UnimplementedSchedulerServer{},
+		&schedulerv2.UnimplementedSchedulerServer{},
+		100,
+		authenticator,
+	)
+
+	go func() { _ = grpcServer.Serve(listener) }()
+	t.Cleanup(func() {
+		grpcServer.Stop()
+		require.NoError(t, listener.Close())
+	})
+
+	connection := dialTestServer(t, listener)
+	_, err := schedulerv2.NewSchedulerClient(connection).ListHosts(
+		context.Background(),
+		&schedulerv2.ListHostsRequest{},
+	)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+
+	response, err := healthpb.NewHealthClient(connection).Check(
+		context.Background(),
+		&healthpb.HealthCheckRequest{},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, healthpb.HealthCheckResponse_SERVING, response.GetStatus())
+
+	authenticatedConnection := dialTestServer(
+		t,
+		listener,
+		grpc.WithPerRPCCredentials(authenticator.PerRPCCredentials(grpcauth.AudienceScheduler)),
+	)
+	_, err = schedulerv2.NewSchedulerClient(authenticatedConnection).ListHosts(
+		context.Background(),
+		&schedulerv2.ListHostsRequest{},
+	)
+	assert.Equal(t, codes.Unimplemented, status.Code(err))
+}
+
+func dialTestServer(t *testing.T, listener *bufconn.Listener, options ...grpc.DialOption) *grpc.ClientConn {
+	t.Helper()
+
+	connection, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		append([]grpc.DialOption{
+			grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+				return listener.Dial()
+			}),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		}, options...)...,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, connection.Close()) })
+	return connection
+}
+
+func newTestAuthenticator(t *testing.T) *grpcauth.Authenticator {
+	t.Helper()
+
+	secretFile := filepath.Join(t.TempDir(), "grpc-auth-key")
+	secret := base64.StdEncoding.EncodeToString([]byte(strings.Repeat("k", grpcauth.MinimumKeySize)))
+	require.NoError(t, os.WriteFile(secretFile, []byte(secret), 0o600))
+
+	config := grpcauth.DefaultConfig()
+	config.Mode = grpcauth.ModeRequired
+	config.JWT.ActiveKeyID = "test-key"
+	config.JWT.Keys = []grpcauth.KeyConfig{{ID: "test-key", SecretFile: secretFile}}
+	authenticator, err := grpcauth.New(config)
+	require.NoError(t, err)
+	return authenticator
+}

--- a/scheduler/config/config.go
+++ b/scheduler/config/config.go
@@ -25,6 +25,7 @@ import (
 	"d7y.io/dragonfly/v2/cmd/dependency/base"
 	"d7y.io/dragonfly/v2/pkg/net/fqdn"
 	"d7y.io/dragonfly/v2/pkg/net/ip"
+	grpcauth "d7y.io/dragonfly/v2/pkg/rpc/auth/jwt"
 	"d7y.io/dragonfly/v2/pkg/types"
 )
 
@@ -34,6 +35,9 @@ type Config struct {
 
 	// Server configuration.
 	Server ServerConfig `yaml:"server" mapstructure:"server"`
+
+	// GRPCAuth is the inter-component gRPC authentication configuration.
+	GRPCAuth grpcauth.Config `yaml:"grpcAuth" mapstructure:"grpcAuth"`
 
 	// Scheduler configuration.
 	Scheduler SchedulerConfig `yaml:"scheduler" mapstructure:"scheduler"`
@@ -353,6 +357,7 @@ func New() *Config {
 			LogMaxAge:        DefaultLogRotateMaxAge,
 			LogMaxBackups:    DefaultLogRotateMaxBackups,
 		},
+		GRPCAuth: grpcauth.DefaultConfig(),
 		Scheduler: SchedulerConfig{
 			Algorithm:              DefaultSchedulerAlgorithm,
 			BackToSourceCount:      DefaultSchedulerBackToSourceCount,
@@ -444,6 +449,10 @@ func (cfg *Config) Validate() error {
 
 	if cfg.Server.RequestRateLimit <= 0 {
 		return errors.New("server requires parameter requestRateLimit")
+	}
+
+	if err := grpcauth.ValidateConfig(cfg.GRPCAuth); err != nil {
+		return err
 	}
 
 	if cfg.Scheduler.Algorithm == "" {

--- a/scheduler/config/config_test.go
+++ b/scheduler/config/config_test.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
+
+	grpcauth "d7y.io/dragonfly/v2/pkg/rpc/auth/jwt"
 )
 
 var (
@@ -62,6 +64,22 @@ var (
 func TestConfig_Load(t *testing.T) {
 	mockManagerLoadAddr := "127.0.0.1:65003"
 	config := &Config{
+		GRPCAuth: grpcauth.Config{
+			Mode:                     grpcauth.ModeRequired,
+			RequireTransportSecurity: true,
+			JWT: grpcauth.JWTConfig{
+				Issuer:        "dragonfly-test",
+				TokenTTL:      10 * time.Minute,
+				MaxTokenTTL:   15 * time.Minute,
+				ClockSkew:     30 * time.Second,
+				RefreshBefore: time.Minute,
+				ActiveKeyID:   "test-key",
+				Keys: []grpcauth.KeyConfig{{
+					ID:         "test-key",
+					SecretFile: "/etc/dragonfly/secrets/grpc-jwt/test-key",
+				}},
+			},
+		},
 		Scheduler: SchedulerConfig{
 			Algorithm:              "default",
 			BackToSourceCount:      3,
@@ -193,6 +211,16 @@ func TestConfig_Validate(t *testing.T) {
 			expect: func(t *testing.T, err error) {
 				assert := assert.New(t)
 				assert.NoError(err)
+			},
+		},
+		{
+			name:   "grpc auth rejects unsupported mode",
+			config: New(),
+			mock: func(cfg *Config) {
+				cfg.GRPCAuth.Mode = "unknown"
+			},
+			expect: func(t *testing.T, err error) {
+				assert.EqualError(t, err, `grpc auth has unsupported mode "unknown"`)
 			},
 		},
 		{

--- a/scheduler/config/testdata/scheduler.yaml
+++ b/scheduler/config/testdata/scheduler.yaml
@@ -16,6 +16,20 @@ server:
   logMaxAge: 5
   logMaxBackups: 3
 
+grpcAuth:
+  mode: required
+  requireTransportSecurity: true
+  jwt:
+    issuer: dragonfly-test
+    tokenTTL: 10m
+    maxTokenTTL: 15m
+    clockSkew: 30s
+    refreshBefore: 1m
+    activeKeyID: test-key
+    keys:
+      - id: test-key
+        secretFile: /etc/dragonfly/secrets/grpc-jwt/test-key
+
 scheduler:
   algorithm: default
   backToSourceCount: 3

--- a/scheduler/resource/standard/resource.go
+++ b/scheduler/resource/standard/resource.go
@@ -74,7 +74,7 @@ type resource struct {
 }
 
 // New returns Resource interface.
-func New(cfg *config.Config, gc gc.GC, transportCredentials credentials.TransportCredentials) (Resource, error) {
+func New(cfg *config.Config, gc gc.GC, transportCredentials credentials.TransportCredentials, options ...grpc.DialOption) (Resource, error) {
 	resource := &resource{config: cfg}
 
 	// Initialize host manager interface.
@@ -102,7 +102,7 @@ func New(cfg *config.Config, gc gc.GC, transportCredentials credentials.Transpor
 	resource.peerClientPool = dfdaemonclient.GetPool()
 
 	// Initialize seed peer interface.
-	dialOptions := []grpc.DialOption{grpc.WithStatsHandler(otelgrpc.NewClientHandler()), grpc.WithTransportCredentials(transportCredentials)}
+	dialOptions := append([]grpc.DialOption{grpc.WithStatsHandler(otelgrpc.NewClientHandler()), grpc.WithTransportCredentials(transportCredentials)}, options...)
 	resource.seedPeer = newSeedPeer(peerManager, hostManager, resource.peerClientPool, dialOptions...)
 
 	return resource, nil

--- a/scheduler/rpcserver/rpcserver.go
+++ b/scheduler/rpcserver/rpcserver.go
@@ -19,6 +19,7 @@ package rpcserver
 import (
 	"google.golang.org/grpc"
 
+	grpcauth "d7y.io/dragonfly/v2/pkg/rpc/auth/jwt"
 	"d7y.io/dragonfly/v2/pkg/rpc/scheduler/server"
 	"d7y.io/dragonfly/v2/scheduler/config"
 	"d7y.io/dragonfly/v2/scheduler/job"
@@ -39,9 +40,27 @@ func New(
 	dynconfig config.DynconfigInterface,
 	opts ...grpc.ServerOption,
 ) *grpc.Server {
-	return server.New(
+	return NewWithAuthentication(cfg, nil, resource, persistentResource, persistentCacheResource, scheduling, job, dynconfig, opts...)
+}
+
+// NewWithAuthentication returns a new scheduler server with inter-component
+// JWT authentication.
+func NewWithAuthentication(
+	cfg *config.Config,
+	authenticator *grpcauth.Authenticator,
+	resource standard.Resource,
+	persistentResource persistent.Resource,
+	persistentCacheResource persistentcache.Resource,
+	scheduling scheduling.Scheduling,
+	job job.Job,
+	dynconfig config.DynconfigInterface,
+	opts ...grpc.ServerOption,
+) *grpc.Server {
+	return server.NewWithAuthentication(
 		newSchedulerServerV1(cfg, resource, scheduling, dynconfig),
-		newSchedulerServerV2(cfg, resource, persistentResource, persistentCacheResource, scheduling, job, dynconfig),
+		newSchedulerServerV2(cfg, resource, persistentResource, persistentCacheResource, scheduling, job, dynconfig,
+			grpc.WithPerRPCCredentials(authenticator.PerRPCCredentials(grpcauth.AudienceDfdaemon))),
 		cfg.Server.RequestRateLimit,
+		authenticator,
 		opts...)
 }

--- a/scheduler/rpcserver/scheduler_server_v2.go
+++ b/scheduler/rpcserver/scheduler_server_v2.go
@@ -19,6 +19,7 @@ package rpcserver
 import (
 	"context"
 
+	"google.golang.org/grpc"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
 
 	commonv2 "d7y.io/api/v2/pkg/apis/common/v2"
@@ -50,8 +51,9 @@ func newSchedulerServerV2(
 	scheduling scheduling.Scheduling,
 	job job.Job,
 	dynconfig config.DynconfigInterface,
+	dfdaemonDialOptions ...grpc.DialOption,
 ) schedulerv2.SchedulerServer {
-	return &schedulerServerV2{service.NewV2(cfg, resource, persistentResource, persistentCacheResource, scheduling, job, internaljob.NewImage(), dynconfig)}
+	return &schedulerServerV2{service.NewV2(cfg, resource, persistentResource, persistentCacheResource, scheduling, job, internaljob.NewImage(), dynconfig, dfdaemonDialOptions...)}
 }
 
 // AnnouncePeer announces peer to scheduler.

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -35,6 +35,7 @@ import (
 	"d7y.io/dragonfly/v2/pkg/gc"
 	pkgredis "d7y.io/dragonfly/v2/pkg/redis"
 	"d7y.io/dragonfly/v2/pkg/rpc"
+	grpcauth "d7y.io/dragonfly/v2/pkg/rpc/auth/jwt"
 	managerclient "d7y.io/dragonfly/v2/pkg/rpc/manager/client"
 	"d7y.io/dragonfly/v2/scheduler/announcer"
 	"d7y.io/dragonfly/v2/scheduler/config"
@@ -92,6 +93,11 @@ type Server struct {
 // New creates a new scheduler server.
 func New(ctx context.Context, cfg *config.Config, d dfpath.Dfpath, dynconfigPath string) (*Server, error) {
 	s := &Server{config: cfg}
+	authenticator, err := grpcauth.New(cfg.GRPCAuth)
+	if err != nil {
+		return nil, err
+	}
+	logger.Infof("initialized gRPC authentication with mode %s", authenticator.Mode())
 
 	// Initialize redis client if redis is enabled.
 	rdb, err := newRedisClient(cfg)
@@ -103,7 +109,7 @@ func New(ctx context.Context, cfg *config.Config, d dfpath.Dfpath, dynconfigPath
 	// configured. If it is nil, the scheduler runs without a manager and
 	// the announcer is disabled.
 	if cfg.Manager.Addr != nil {
-		managerClient, err := newManagerClient(ctx, cfg)
+		managerClient, err := newManagerClient(ctx, cfg, authenticator)
 		if err != nil {
 			return nil, err
 		}
@@ -139,7 +145,8 @@ func New(ctx context.Context, cfg *config.Config, d dfpath.Dfpath, dynconfigPath
 	}
 
 	// Initialize resource.
-	resource, err := standard.New(cfg, s.gc, seedPeerClientTransportCredentials)
+	resource, err := standard.New(cfg, s.gc, seedPeerClientTransportCredentials,
+		grpc.WithPerRPCCredentials(authenticator.PerRPCCredentials(grpcauth.AudienceDfdaemon)))
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +175,8 @@ func New(ctx context.Context, cfg *config.Config, d dfpath.Dfpath, dynconfigPath
 	if cfg.Job.Enable && rdb != nil {
 		s.job, err = job.New(cfg, resource,
 			grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
-			grpc.WithTransportCredentials(seedPeerClientTransportCredentials))
+			grpc.WithTransportCredentials(seedPeerClientTransportCredentials),
+			grpc.WithPerRPCCredentials(authenticator.PerRPCCredentials(grpcauth.AudienceDfdaemon)))
 		if err != nil {
 			return nil, err
 		}
@@ -185,7 +193,7 @@ func New(ctx context.Context, cfg *config.Config, d dfpath.Dfpath, dynconfigPath
 			return nil, err
 		}
 	}
-	s.grpcServer = rpcserver.New(cfg, resource, s.persistentResource, s.persistentCacheResource, scheduling, s.job, dynconfig, grpc.Creds(serverTransportCredentials))
+	s.grpcServer = rpcserver.NewWithAuthentication(cfg, authenticator, resource, s.persistentResource, s.persistentCacheResource, scheduling, s.job, dynconfig, grpc.Creds(serverTransportCredentials))
 
 	// Initialize metrics server if metrics is enabled.
 	if cfg.Metrics.Enable {
@@ -306,7 +314,7 @@ func (s *Server) Stop() {
 }
 
 // newManagerClient returns a new manager client.
-func newManagerClient(ctx context.Context, cfg *config.Config) (managerclient.V2, error) {
+func newManagerClient(ctx context.Context, cfg *config.Config, authenticator *grpcauth.Authenticator) (managerclient.V2, error) {
 	clientTransportCredentials, err := newClientTransportCredentials(cfg.Manager.TLS)
 	if err != nil {
 		return nil, err
@@ -314,7 +322,8 @@ func newManagerClient(ctx context.Context, cfg *config.Config) (managerclient.V2
 
 	return managerclient.GetV2ByAddr(ctx, *cfg.Manager.Addr,
 		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
-		grpc.WithTransportCredentials(clientTransportCredentials))
+		grpc.WithTransportCredentials(clientTransportCredentials),
+		grpc.WithPerRPCCredentials(authenticator.PerRPCCredentials(grpcauth.AudienceManager)))
 }
 
 // newRedisClient returns a new redis client. If redis is not enabled, it

--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -92,6 +92,11 @@ type V2 struct {
 
 	// Dynamic config.
 	dynconfig config.DynconfigInterface
+
+	// dfdaemonDialOptions contains authentication options added to outbound
+	// dfdaemon clients. Transport credentials remain selected by each existing
+	// call path.
+	dfdaemonDialOptions []grpc.DialOption
 }
 
 // New v2 version of service instance.
@@ -104,6 +109,7 @@ func NewV2(
 	job job.Job,
 	internalJobImage internaljob.Image,
 	dynconfig config.DynconfigInterface,
+	dfdaemonDialOptions ...grpc.DialOption,
 ) *V2 {
 	return &V2{
 		resource:                resource,
@@ -114,7 +120,12 @@ func NewV2(
 		internalJobImage:        internalJobImage,
 		config:                  cfg,
 		dynconfig:               dynconfig,
+		dfdaemonDialOptions:     append([]grpc.DialOption(nil), dfdaemonDialOptions...),
 	}
+}
+
+func (v *V2) newDfdaemonDialOptions() []grpc.DialOption {
+	return append([]grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}, v.dfdaemonDialOptions...)
 }
 
 // AnnouncePeer announces peer to scheduler.
@@ -2854,7 +2865,7 @@ func (v *V2) DeletePersistentPeer(_ctx context.Context, req *schedulerv2.DeleteP
 
 	// Delete the persistent task from the peer, if delete failed, skip it.
 	addr := net.JoinHostPort(peer.Host.IP, strconv.Itoa(int(peer.Host.DownloadPort)))
-	dialOptions := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	dialOptions := v.newDfdaemonDialOptions()
 	dfdaemonClient, err := v.resource.PeerClientPool().Get(addr, dialOptions...)
 	if err != nil {
 		peer.Log.Errorf("get dfdaemon client failed %s", err)
@@ -3057,7 +3068,7 @@ func (v *V2) replicatePersistentTask(ctx context.Context, peer *persistent.Peer,
 // downloadPersistentTaskByPeer downloads the persistent task by peer.
 func (v *V2) downloadPersistentTaskByPeer(ctx context.Context, task *persistent.Task, host *persistent.Host) error {
 	addr := net.JoinHostPort(host.IP, strconv.Itoa(int(host.DownloadPort)))
-	dialOptions := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	dialOptions := v.newDfdaemonDialOptions()
 	dfdaemonClient, err := v.resource.PeerClientPool().Get(addr, dialOptions...)
 	if err != nil {
 		task.Log.Errorf("get dfdaemon client failed %s", err)
@@ -3098,7 +3109,7 @@ func (v *V2) downloadPersistentTaskByPeer(ctx context.Context, task *persistent.
 // persistPersistentTaskByPeer persists the persistent task by peer.
 func (v *V2) persistPersistentTaskByPeer(ctx context.Context, peer *persistent.Peer, cachedParent *persistent.Peer) error {
 	addr := net.JoinHostPort(cachedParent.Host.IP, strconv.Itoa(int(cachedParent.Host.DownloadPort)))
-	dialOptions := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	dialOptions := v.newDfdaemonDialOptions()
 	dfdaemonClient, err := v.resource.PeerClientPool().Get(addr, dialOptions...)
 	if err != nil {
 		peer.Log.Errorf("get dfdaemon client failed %s", err)
@@ -3234,7 +3245,7 @@ func (v *V2) DeletePersistentTask(_ctx context.Context, req *schedulerv2.DeleteP
 
 		// Delete the persistent task from the peer, if delete failed, skip it.
 		addr := net.JoinHostPort(peer.Host.IP, strconv.Itoa(int(peer.Host.DownloadPort)))
-		dialOptions := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+		dialOptions := v.newDfdaemonDialOptions()
 		dfdaemonClient, err := v.resource.PeerClientPool().Get(addr, dialOptions...)
 		if err != nil {
 			peer.Log.Errorf("get dfdaemon client failed %s", err)
@@ -4060,7 +4071,7 @@ func (v *V2) DeletePersistentCachePeer(_ctx context.Context, req *schedulerv2.De
 
 	// Delete the persistent cache task from the peer, if delete failed, skip it.
 	addr := net.JoinHostPort(peer.Host.IP, strconv.Itoa(int(peer.Host.DownloadPort)))
-	dialOptions := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	dialOptions := v.newDfdaemonDialOptions()
 	dfdaemonClient, err := v.resource.PeerClientPool().Get(addr, dialOptions...)
 	if err != nil {
 		peer.Log.Errorf("get dfdaemon client failed %s", err)
@@ -4267,7 +4278,7 @@ func (v *V2) replicatePersistentCacheTask(ctx context.Context, peer *persistentc
 // downloadPersistentCacheTaskByPeer downloads the persistent cache task by peer.
 func (v *V2) downloadPersistentCacheTaskByPeer(ctx context.Context, task *persistentcache.Task, host *persistentcache.Host) error {
 	addr := net.JoinHostPort(host.IP, strconv.Itoa(int(host.DownloadPort)))
-	dialOptions := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	dialOptions := v.newDfdaemonDialOptions()
 	dfdaemonClient, err := v.resource.PeerClientPool().Get(addr, dialOptions...)
 	if err != nil {
 		task.Log.Errorf("get dfdaemon client failed %s", err)
@@ -4305,7 +4316,7 @@ func (v *V2) downloadPersistentCacheTaskByPeer(ctx context.Context, task *persis
 // persistPersistentCacheTaskByPeer persists the persistent cache task by peer.
 func (v *V2) persistPersistentCacheTaskByPeer(ctx context.Context, peer *persistentcache.Peer, cachedParent *persistentcache.Peer) error {
 	addr := net.JoinHostPort(cachedParent.Host.IP, strconv.Itoa(int(cachedParent.Host.DownloadPort)))
-	dialOptions := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	dialOptions := v.newDfdaemonDialOptions()
 	dfdaemonClient, err := v.resource.PeerClientPool().Get(addr, dialOptions...)
 	if err != nil {
 		peer.Log.Errorf("get dfdaemon client failed %s", err)
@@ -4444,7 +4455,7 @@ func (v *V2) DeletePersistentCacheTask(_ctx context.Context, req *schedulerv2.De
 
 		// Delete the persistent cache task from the peer, if delete failed, skip it.
 		addr := net.JoinHostPort(peer.Host.IP, strconv.Itoa(int(peer.Host.DownloadPort)))
-		dialOptions := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+		dialOptions := v.newDfdaemonDialOptions()
 		dfdaemonClient, err := v.resource.PeerClientPool().Get(addr, dialOptions...)
 		if err != nil {
 			peer.Log.Errorf("get dfdaemon client failed %s", err)


### PR DESCRIPTION
  ## Description

  Add optional JWT-based authentication for internal gRPC communication between Dragonfly components.

  This change introduces:

  - Shared HMAC keyring loading from Base64-encoded secret files.
  - JWT generation and verification using component-specific audiences.
  - Unary and streaming gRPC client and server interceptors.
  - Three authentication modes:
    - `disabled`: preserves the existing unauthenticated behavior.
    - `permissive`: sends and validates JWTs while accepting requests without credentials during rolling upgrades.
    - `required`: rejects requests without a valid JWT.
  - Authentication for Manager and Scheduler business gRPC servers.
  - JWT credentials for Scheduler outbound gRPC calls.
  - Authentication metrics for requests and token generation.
  - Support for overlapping keys and `kid`-based key rotation.
  - A detailed protocol, deployment, rolling-upgrade, and key-rotation design document.

  Authentication is disabled by default. When the configuration is omitted or set to `disabled`, no key files are required, clients do not attach JWTs, and servers do not authenticate requests.

  Health checks and local Unix domain socket calls remain unauthenticated.

  ## Related Issue

  Related to https://github.com/dragonflyoss/dragonfly/issues/4417

  ## Motivation and Context

  Internal Dragonfly components currently communicate over gRPC without application-level authentication unless mTLS is enabled.

  This change adds token-based authentication using short-lived JWTs signed with a shared secret. It provides an additional authentication option without requiring a PKI or an external token-issuing service.

  The `permissive` mode supports a simple and backward-compatible first rollout:

  1. Upgrade the deployment with JWT-capable binaries and set the global mode to `permissive`.
  2. Old and new components can coexist during the rolling update.
  3. After all components and maintained external callers send JWTs, change the global mode to `required`.

  After a deployment reaches `required` mode, subsequent compatible releases can use the normal one-step rolling upgrade while keeping authentication enabled.

  The default `disabled` mode ensures that users who do not enable JWT authentication are unaffected.

  ## Screenshots (if appropriate)

  N/A

  ## Types of changes

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation Update (if none of the other choices apply)

  ## Checklist

  - [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
  - [x] I have read the **CONTRIBUTING** document.
  - [x] I have added tests to cover my changes.
