### PR TITLE
feat(idgen): add TaskIDV2ByBlobDigest and IsBlobURL

### DIFF
--- a/pkg/idgen/task_id.go
+++ b/pkg/idgen/task_id.go
@@ -17,6 +17,8 @@
 package idgen
 
 import (
+	"fmt"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -27,6 +29,9 @@ import (
 	pkgdigest "d7y.io/dragonfly/v2/pkg/digest"
 	neturl "d7y.io/dragonfly/v2/pkg/net/url"
 )
+
+// blobURLRegexp matches OCI blob URLs, e.g. http(s)://<registry>/v2/<repository>/blobs/<digest>.
+var blobURLRegexp = regexp.MustCompile(`^(.*)://(.*)/v2/(.*)/blobs/([^?]+)(?:\?.*)?$`)
 
 // DefaultFilteredQueryParams is the default filtered query params to generate the task id.
 var DefaultFilteredQueryParams []string = slices.Concat(
@@ -168,6 +173,32 @@ func TaskIDV2ByURLBased(url string, pieceLength *uint64, tag, application string
 // TaskIDV2ByContent generates v2 version of task id by content.
 func TaskIDV2ByContent(content string) string {
 	return pkgdigest.SHA256FromStrings(content)
+}
+
+// IsBlobURL reports whether the url is an OCI blob URL.
+func IsBlobURL(url string) bool {
+	return blobURLRegexp.MatchString(url)
+}
+
+// TaskIDV2ByBlobDigest generates v2 version of task id by the digest
+// extracted from the OCI blob url.
+func TaskIDV2ByBlobDigest(url string) (string, error) {
+	matches := blobURLRegexp.FindStringSubmatch(url)
+	if matches == nil {
+		return "", fmt.Errorf("invalid blob url: %s", url)
+	}
+
+	d, err := pkgdigest.Parse(matches[4])
+	if err != nil {
+		return "", err
+	}
+
+	switch d.Algorithm {
+	case pkgdigest.AlgorithmCRC32, pkgdigest.AlgorithmSHA256, pkgdigest.AlgorithmSHA512:
+		return d.Encoded, nil
+	default:
+		return "", fmt.Errorf("unsupported digest algorithm: %s", d.Algorithm)
+	}
 }
 
 // PersistentCacheTaskIDByContent generates persistent cache task id by content.

--- a/pkg/idgen/task_id.go
+++ b/pkg/idgen/task_id.go
@@ -30,9 +30,6 @@ import (
 	neturl "d7y.io/dragonfly/v2/pkg/net/url"
 )
 
-// blobURLRegexp matches OCI blob URLs, e.g. http(s)://<registry>/v2/<repository>/blobs/<digest>.
-var blobURLRegexp = regexp.MustCompile(`^(.*)://(.*)/v2/(.*)/blobs/([^?]+)(?:\?.*)?$`)
-
 // DefaultFilteredQueryParams is the default filtered query params to generate the task id.
 var DefaultFilteredQueryParams []string = slices.Concat(
 	S3FilteredQueryParams,
@@ -106,6 +103,14 @@ const (
 	FilteredQueryParamsSeparator = "&"
 )
 
+// blobURLRegexp matches OCI blob URLs, e.g. http(s)://<registry>/v2/<repository>/blobs/<digest>.
+var blobURLRegexp = regexp.MustCompile(`^(.*)://(.*)/v2/(.*)/blobs/([^?]+)(?:\?.*)?$`)
+
+// IsBlobURL reports whether the url is an OCI blob URL.
+func IsBlobURL(url string) bool {
+	return blobURLRegexp.MatchString(url)
+}
+
 // TaskIDV1 generates v1 version of task id.
 // filter is separated by & character.
 func TaskIDV1(url string, meta *commonv1.UrlMeta) string {
@@ -173,11 +178,6 @@ func TaskIDV2ByURLBased(url string, pieceLength *uint64, tag, application string
 // TaskIDV2ByContent generates v2 version of task id by content.
 func TaskIDV2ByContent(content string) string {
 	return pkgdigest.SHA256FromStrings(content)
-}
-
-// IsBlobURL reports whether the url is an OCI blob URL.
-func IsBlobURL(url string) bool {
-	return blobURLRegexp.MatchString(url)
 }
 
 // TaskIDV2ByBlobDigest generates v2 version of task id by the digest

--- a/pkg/idgen/task_id_test.go
+++ b/pkg/idgen/task_id_test.go
@@ -220,3 +220,125 @@ func TestPersistentCacheTaskIDbyContent(t *testing.T) {
 		})
 	}
 }
+
+func TestIsBlobURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		url    string
+		expect func(t *testing.T, ok bool)
+	}{
+		{
+			name: "http blob url",
+			url:  "http://registry.example.com/v2/library/ubuntu/blobs/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e",
+			expect: func(t *testing.T, ok bool) {
+				assert := assert.New(t)
+				assert.True(ok)
+			},
+		},
+		{
+			name: "blob url with nested repository",
+			url:  "https://registry.io/v2/org/team/project/blobs/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e",
+			expect: func(t *testing.T, ok bool) {
+				assert := assert.New(t)
+				assert.True(ok)
+			},
+		},
+		{
+			name: "blob url with port and query params",
+			url:  "http://localhost:5000/v2/myrepo/blobs/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e?ns=docker.io",
+			expect: func(t *testing.T, ok bool) {
+				assert := assert.New(t)
+				assert.True(ok)
+			},
+		},
+		{
+			name: "url without blobs path",
+			url:  "https://registry.example.com/v2/library/ubuntu/manifests/latest",
+			expect: func(t *testing.T, ok bool) {
+				assert := assert.New(t)
+				assert.False(ok)
+			},
+		},
+		{
+			name: "plain url",
+			url:  "https://example.com/file.txt",
+			expect: func(t *testing.T, ok bool) {
+				assert := assert.New(t)
+				assert.False(ok)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.expect(t, IsBlobURL(tc.url))
+		})
+	}
+}
+
+func TestTaskIDV2ByBlobDigest(t *testing.T) {
+	tests := []struct {
+		name   string
+		url    string
+		expect func(t *testing.T, d string, err error)
+	}{
+		{
+			name: "generate taskID by sha256 blob digest",
+			url:  "http://registry.example.com/v2/library/ubuntu/blobs/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e",
+			expect: func(t *testing.T, d string, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Equal(d, "b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e")
+			},
+		},
+		{
+			name: "generate taskID by sha512 blob digest",
+			url:  "https://registry.example.com/v2/myorg/myrepo/blobs/sha512:94381a28e8c039fedfa78de025158a068226c3ccd041b22c2c8e73fc993584e9b167d9ae32bc8b372c66701c808ab134e0768c8f16b9a3e61eec1ccf8faa9db8",
+			expect: func(t *testing.T, d string, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Equal(d, "94381a28e8c039fedfa78de025158a068226c3ccd041b22c2c8e73fc993584e9b167d9ae32bc8b372c66701c808ab134e0768c8f16b9a3e61eec1ccf8faa9db8")
+			},
+		},
+		{
+			name: "generate taskID by blob digest with query params",
+			url:  "http://localhost:5000/v2/myrepo/blobs/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e?ns=docker.io",
+			expect: func(t *testing.T, d string, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Equal(d, "b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e")
+			},
+		},
+		{
+			name: "not a blob url",
+			url:  "https://example.com/file.txt",
+			expect: func(t *testing.T, d string, err error) {
+				assert := assert.New(t)
+				assert.Error(err)
+			},
+		},
+		{
+			name: "invalid digest length",
+			url:  "http://registry.example.com/v2/library/ubuntu/blobs/sha256:abc",
+			expect: func(t *testing.T, d string, err error) {
+				assert := assert.New(t)
+				assert.Error(err)
+			},
+		},
+		{
+			name: "unsupported digest algorithm",
+			url:  "http://registry.example.com/v2/library/ubuntu/blobs/md5:8a04994a666b4e4b20a2fd9e5a44f44c",
+			expect: func(t *testing.T, d string, err error) {
+				assert := assert.New(t)
+				assert.Error(err)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := TaskIDV2ByBlobDigest(tc.url)
+			tc.expect(t, d, err)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Port the blob digest based task id generation from the Rust client to `pkg/idgen`, so Go consumers generate identical task ids for OCI blob URLs:

- `IsBlobURL(url)` — same regex as `dragonfly-client-util`'s `digest::is_blob_url` (`^(.*)://(.*)/v2/(.*)/blobs/([^?]+)(?:\?.*)?$`).
- `TaskIDV2ByBlobDigest(url)` — extracts the digest from the blob URL and returns its encoded part as the task id, mirroring `TaskIDParameter::BlobDigestBased`. Accepted algorithms are restricted to crc32/sha256/sha512 to match the Rust side, on top of `pkg/digest.Parse` validation.

## Motivation

The upcoming Go client-request SDK (dragonflyoss/dragonfly-sdk) uses `pkg/idgen` for all task id paths; this was the only missing one. Cross-language consistency is pinned by test vectors mirrored from the Rust `digest` tests.

## Test plan

`go test ./pkg/idgen/...` — new `TestIsBlobURL` and `TestTaskIDV2ByBlobDigest` table tests, vectors identical to `dragonfly-client-util/src/digest/mod.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)