### PR TITLE
refactor: extract OCI registry client from internal/job into pkg/oci

### DIFF
--- a/internal/job/image.go
+++ b/internal/job/image.go
@@ -22,30 +22,17 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"errors"
 	"fmt"
-	"io"
 	"net/http"
-	"net/url"
-	"regexp"
 	"time"
 
 	"github.com/containerd/platforms"
 	"github.com/docker/distribution"
-	"github.com/docker/distribution/manifest/manifestlist"
-	"github.com/docker/distribution/manifest/ocischema"
-	"github.com/docker/distribution/manifest/schema1"
-	"github.com/docker/distribution/manifest/schema2"
-	registryclient "github.com/docker/distribution/registry/client"
-	"github.com/docker/distribution/registry/client/auth"
-	"github.com/docker/distribution/registry/client/transport"
-	typesregistry "github.com/docker/docker/api/types/registry"
-	"github.com/docker/docker/registry"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"go.opentelemetry.io/otel/trace"
 
 	"d7y.io/dragonfly/v2/manager/config"
 	nethttp "d7y.io/dragonfly/v2/pkg/net/http"
+	pkgoci "d7y.io/dragonfly/v2/pkg/oci"
 )
 
 // defaultRegistryTimeout is the default timeout for registry requests.
@@ -57,42 +44,6 @@ var defaultHTTPTransport = &http.Transport{
 	MaxIdleConnsPerHost: 20,
 	MaxConnsPerHost:     50,
 	IdleConnTimeout:     120 * time.Second,
-}
-
-// accessURLRegexp is the regular expression for parsing access url.
-var accessURLRegexp, _ = regexp.Compile("^(.*)://(.*)/v2/(.*)/manifests/(.*)")
-
-// preheatImage is image information for preheat.
-type preheatImage struct {
-	protocol string
-	domain   string
-	name     string
-	tag      string
-}
-
-func (p *preheatImage) manifestURL() string {
-	return fmt.Sprintf("%s://%s/v2/%s/manifests/%s", p.protocol, p.domain, p.name, p.tag)
-}
-
-func (p *preheatImage) blobURL(digest string) string {
-	return fmt.Sprintf("%s://%s/v2/%s/blobs/%s", p.protocol, p.domain, p.name, digest)
-}
-
-// parseManifestURL parses a container image manifest URL into its components.
-// It extracts the protocol, domain, image name, and tag from the provided URL
-// using a regular expression.
-func parseManifestURL(url string) (*preheatImage, error) {
-	r := accessURLRegexp.FindStringSubmatch(url)
-	if len(r) != 5 {
-		return nil, errors.New("parse access url failed")
-	}
-
-	return &preheatImage{
-		protocol: r[1],
-		domain:   r[2],
-		name:     r[3],
-		tag:      r[4],
-	}, nil
 }
 
 type ManifestRequest struct {
@@ -191,17 +142,16 @@ func (i *image) CreatePreheatRequestsByManifestURL(ctx context.Context, req *Man
 	defer span.End()
 
 	// Parse image manifest url.
-	image, err := parseManifestURL(req.URL)
+	ref, err := pkgoci.ParseManifestURL(req.URL)
 	if err != nil {
 		return nil, err
 	}
 
-	// Background:
 	// Harbor uses the V1 preheat request and will carry the auth info in the headers.
-	options := []imageAuthClientOption{}
+	options := []pkgoci.Option{}
 	header := nethttp.MapToHeader(req.Headers)
 	if token := header.Get("Authorization"); len(token) > 0 {
-		options = append(options, withIssuedToken(token))
+		options = append(options, pkgoci.WithIssuedToken(token))
 		header.Set("Authorization", token)
 	}
 
@@ -218,7 +168,7 @@ func (i *image) CreatePreheatRequestsByManifestURL(ctx context.Context, req *Man
 	}
 
 	// Init docker auth client.
-	client, err := newImageAuthClient(image, httpClient, &typesregistry.AuthConfig{Username: req.Username, Password: req.Password}, options...)
+	client, err := pkgoci.NewAuthClient(ref, httpClient, req.Username, req.Password, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +183,7 @@ func (i *image) CreatePreheatRequestsByManifestURL(ctx context.Context, req *Man
 	}
 
 	// Resolve manifests for the image.
-	manifests, err := resolveManifests(ctx, client, image, header.Clone(), platform)
+	manifests, err := client.ResolveManifests(ctx, ref, header.Clone(), platform)
 	if err != nil {
 		return nil, err
 	}
@@ -244,10 +194,10 @@ func (i *image) CreatePreheatRequestsByManifestURL(ctx context.Context, req *Man
 	}
 
 	// Set authorization header
-	header.Set("Authorization", client.GetAuthToken())
+	header.Set("Authorization", client.AuthToken())
 
 	// Build preheat requests for container image layers from the provided manifests.
-	preheatRequest, err := buildPreheatRequestFromManifests(manifests, req, header.Clone(), image)
+	preheatRequest, err := buildPreheatRequestFromManifests(manifests, req, header.Clone(), ref)
 	if err != nil {
 		return nil, err
 	}
@@ -255,90 +205,10 @@ func (i *image) CreatePreheatRequestsByManifestURL(ctx context.Context, req *Man
 	return preheatRequest, nil
 }
 
-// resolveManifests fetches and resolves container image manifests from a registry for a specified platform.
-// It constructs an HTTP request to retrieve the manifest, handles authentication via headers, and processes the response
-// to return manifests matching the given platform. Supports single manifests and manifest lists.
-func resolveManifests(ctx context.Context, client *imageAuthClient, image *preheatImage, header http.Header, platform specs.Platform) ([]distribution.Manifest, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, image.manifestURL(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	// Set header from the user request.
-	for key, values := range header {
-		for _, value := range values {
-			req.Header.Add(key, value)
-		}
-	}
-
-	// Set accept header with media types.
-	for _, mediaType := range distribution.ManifestMediaTypes() {
-		req.Header.Add("Accept", mediaType)
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	// Handle response.
-	if resp.StatusCode == http.StatusNotModified {
-		return nil, distribution.ErrManifestNotModified
-	} else if !registryclient.SuccessStatus(resp.StatusCode) {
-		return nil, registryclient.HandleErrorResponse(resp)
-	}
-
-	ctHeader := resp.Header.Get("Content-Type")
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	// Unmarshal manifest.
-	manifest, _, err := distribution.UnmarshalManifest(ctHeader, body)
-	if err != nil {
-		return nil, err
-	}
-
-	switch v := manifest.(type) {
-	case *schema1.SignedManifest, *schema2.DeserializedManifest, *ocischema.DeserializedManifest:
-		return []distribution.Manifest{v}, nil
-	case *manifestlist.DeserializedManifestList:
-		var result []distribution.Manifest
-		for _, v := range filterManifests(v.Manifests, platform) {
-			image.tag = v.Digest.String()
-			manifests, err := resolveManifests(ctx, client, image, header.Clone(), platform)
-			if err != nil {
-				return nil, err
-			}
-
-			result = append(result, manifests...)
-		}
-
-		return result, nil
-	}
-
-	return nil, errors.New("unknown manifest type")
-}
-
-// filterManifests filters a list of manifest descriptors to return only those matching the specified platform.
-// It compares the architecture and operating system of each manifest descriptor against the target platform.
-func filterManifests(manifests []manifestlist.ManifestDescriptor, platform specs.Platform) []manifestlist.ManifestDescriptor {
-	var matches []manifestlist.ManifestDescriptor
-	for _, desc := range manifests {
-		if desc.Platform.Architecture == platform.Architecture && desc.Platform.OS == platform.OS {
-			matches = append(matches, desc)
-		}
-	}
-
-	return matches
-}
-
 // buildPreheatRequestFromManifests constructs preheat requests for container image layers from
 // the provided manifests. It extracts layer URLs from the manifests and builds a PreheatRequest
 // using the specified arguments, headers, and TLS settings.
-func buildPreheatRequestFromManifests(manifests []distribution.Manifest, req *ManifestRequest, header http.Header, image *preheatImage) ([]*PreheatRequest, error) {
+func buildPreheatRequestFromManifests(manifests []distribution.Manifest, req *ManifestRequest, header http.Header, ref *pkgoci.Reference) ([]*PreheatRequest, error) {
 	var certificateChain [][]byte
 	if req.RootCAs != nil {
 		certificateChain = req.RootCAs.Subjects() //nolint:staticcheck
@@ -348,7 +218,7 @@ func buildPreheatRequestFromManifests(manifests []distribution.Manifest, req *Ma
 	for _, m := range manifests {
 		for _, v := range m.References() {
 			header.Set("Accept", v.MediaType)
-			layerURLs = append(layerURLs, image.blobURL(v.Digest.String()))
+			layerURLs = append(layerURLs, ref.BlobURL(v.Digest.String()))
 		}
 	}
 
@@ -371,119 +241,4 @@ func buildPreheatRequestFromManifests(manifests []distribution.Manifest, req *Ma
 	}
 
 	return []*PreheatRequest{layers}, nil
-}
-
-// imageAuthClientOption is an option for imageAuthClient.
-type imageAuthClientOption func(*imageAuthClient)
-
-// withIssuedToken sets the issuedToken for imageAuthClient.
-func withIssuedToken(token string) imageAuthClientOption {
-	return func(c *imageAuthClient) {
-		c.issuedToken = token
-	}
-}
-
-// imageAuthClient is a client for image authentication.
-type imageAuthClient struct {
-	// issuedToken is the issued token specified in header from user request,
-	// there is no need to go through v2 authentication to get a new token
-	// if the token is not empty, just use this token to access v2 API directly.
-	issuedToken string
-
-	// httpClient is the http client.
-	httpClient *http.Client
-
-	// authConfig is the auth config.
-	authConfig *typesregistry.AuthConfig
-
-	// interceptorTokenHandler is the token interceptor.
-	interceptorTokenHandler *interceptorTokenHandler
-}
-
-// newImageAuthClient creates a new imageAuthClient.
-func newImageAuthClient(image *preheatImage, httpClient *http.Client, authConfig *typesregistry.AuthConfig, opts ...imageAuthClientOption) (*imageAuthClient, error) {
-	d := &imageAuthClient{
-		httpClient:              httpClient,
-		authConfig:              authConfig,
-		interceptorTokenHandler: newInterceptorTokenHandler(),
-	}
-
-	for _, opt := range opts {
-		opt(d)
-	}
-
-	if len(d.issuedToken) > 0 {
-		return d, nil
-	}
-
-	// New a challenge manager for the supported authentication types.
-	challengeManager, err := registry.PingV2Registry(&url.URL{Scheme: image.protocol, Host: image.domain}, d.httpClient.Transport)
-	if err != nil {
-		return nil, err
-	}
-
-	// New a credential store which always returns the same credential values.
-	creds := registry.NewStaticCredentialStore(d.authConfig)
-
-	// Transport with authentication.
-	d.httpClient.Transport = transport.NewTransport(
-		d.httpClient.Transport,
-		auth.NewAuthorizer(
-			challengeManager,
-			auth.NewTokenHandlerWithOptions(auth.TokenHandlerOptions{
-				Transport:   d.httpClient.Transport,
-				Credentials: creds,
-				Scopes: []auth.Scope{auth.RepositoryScope{
-					Repository: image.name,
-					Actions:    []string{"pull"},
-				}},
-				ClientID: registry.AuthClientID,
-			}),
-			d.interceptorTokenHandler,
-			auth.NewBasicHandler(creds),
-		),
-	)
-
-	return d, nil
-}
-
-// Do sends an HTTP request and returns an HTTP response.
-func (d *imageAuthClient) Do(req *http.Request) (*http.Response, error) {
-	return d.httpClient.Do(req)
-}
-
-// GetAuthToken returns the bearer token.
-func (d *imageAuthClient) GetAuthToken() string {
-	if len(d.issuedToken) > 0 {
-		return d.issuedToken
-	}
-
-	return d.interceptorTokenHandler.GetAuthToken()
-}
-
-// interceptorTokenHandler is a token interceptor intercept bearer token from auth handler.
-type interceptorTokenHandler struct {
-	auth.AuthenticationHandler
-	token string
-}
-
-// NewInterceptorTokenHandler returns a new InterceptorTokenHandler.
-func newInterceptorTokenHandler() *interceptorTokenHandler {
-	return &interceptorTokenHandler{}
-}
-
-// Scheme returns the authentication scheme.
-func (h *interceptorTokenHandler) Scheme() string {
-	return "bearer"
-}
-
-// AuthorizeRequest sets the Authorization header on the request.
-func (h *interceptorTokenHandler) AuthorizeRequest(req *http.Request, params map[string]string) error {
-	h.token = req.Header.Get("Authorization")
-	return nil
-}
-
-// GetAuthToken returns the bearer token.
-func (h *interceptorTokenHandler) GetAuthToken() string {
-	return h.token
 }

--- a/pkg/oci/auth.go
+++ b/pkg/oci/auth.go
@@ -1,0 +1,140 @@
+/*
+ *     Copyright 2026 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package oci
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/docker/distribution/registry/client/auth"
+	"github.com/docker/distribution/registry/client/transport"
+	typesregistry "github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/registry"
+)
+
+// Option is an option for AuthClient.
+type Option func(c *AuthClient)
+
+// WithIssuedToken sets the issued token for AuthClient.
+func WithIssuedToken(token string) Option {
+	return func(c *AuthClient) {
+		c.issuedToken = token
+	}
+}
+
+// AuthClient is an HTTP client that negotiates registry v2 authentication and
+// intercepts the issued bearer token.
+type AuthClient struct {
+	// issuedToken is the issued token specified in header from user request,
+	// there is no need to go through v2 authentication to get a new token
+	// if the token is not empty, just use this token to access v2 API directly.
+	issuedToken string
+
+	// httpClient is the http client.
+	httpClient *http.Client
+
+	// authConfig is the auth config.
+	authConfig *typesregistry.AuthConfig
+
+	// tokenHandler is the token interceptor.
+	tokenHandler *tokenHandler
+}
+
+// NewAuthClient creates a new AuthClient for the registry of the given
+// reference. If no username and password are provided, anonymous access is
+// used.
+func NewAuthClient(ref *Reference, httpClient *http.Client, username, password string, opts ...Option) (*AuthClient, error) {
+	c := &AuthClient{
+		httpClient:   httpClient,
+		authConfig:   &typesregistry.AuthConfig{Username: username, Password: password},
+		tokenHandler: newTokenHandler(),
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	if len(c.issuedToken) > 0 {
+		return c, nil
+	}
+
+	// New a challenge manager for the supported authentication types.
+	challengeManager, err := registry.PingV2Registry(&url.URL{Scheme: ref.Scheme, Host: ref.Registry}, c.httpClient.Transport)
+	if err != nil {
+		return nil, err
+	}
+
+	// New a credential store which always returns the same credential values.
+	creds := registry.NewStaticCredentialStore(c.authConfig)
+
+	// Transport with authentication.
+	c.httpClient.Transport = transport.NewTransport(
+		c.httpClient.Transport,
+		auth.NewAuthorizer(
+			challengeManager,
+			auth.NewTokenHandlerWithOptions(auth.TokenHandlerOptions{
+				Transport:   c.httpClient.Transport,
+				Credentials: creds,
+				Scopes: []auth.Scope{auth.RepositoryScope{
+					Repository: ref.Repository,
+					Actions:    []string{"pull"},
+				}},
+				ClientID: registry.AuthClientID,
+			}),
+			c.tokenHandler,
+			auth.NewBasicHandler(creds),
+		),
+	)
+
+	return c, nil
+}
+
+// Do sends an HTTP request and returns an HTTP response.
+func (c *AuthClient) Do(req *http.Request) (*http.Response, error) {
+	return c.httpClient.Do(req)
+}
+
+// AuthToken returns the bearer token.
+func (c *AuthClient) AuthToken() string {
+	if len(c.issuedToken) > 0 {
+		return c.issuedToken
+	}
+
+	return c.tokenHandler.token
+}
+
+// tokenHandler is a token interceptor intercept bearer token from auth handler.
+type tokenHandler struct {
+	auth.AuthenticationHandler
+	token string
+}
+
+// newTokenHandler returns a new tokenHandler.
+func newTokenHandler() *tokenHandler {
+	return &tokenHandler{}
+}
+
+// Scheme returns the authentication scheme.
+func (h *tokenHandler) Scheme() string {
+	return "bearer"
+}
+
+// AuthorizeRequest saves the Authorization header from the request.
+func (h *tokenHandler) AuthorizeRequest(req *http.Request, params map[string]string) error {
+	h.token = req.Header.Get("Authorization")
+	return nil
+}

--- a/pkg/oci/auth_test.go
+++ b/pkg/oci/auth_test.go
@@ -1,0 +1,114 @@
+/*
+ *     Copyright 2026 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package oci
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewAuthClientWithIssuedToken(t *testing.T) {
+	assert := assert.New(t)
+	ref := &Reference{
+		Scheme:     "http",
+		Registry:   "127.0.0.1:1",
+		Repository: "library/nginx",
+		Reference:  "latest",
+	}
+
+	client, err := NewAuthClient(ref, &http.Client{}, "", "", WithIssuedToken("Bearer issued-token"))
+	assert.NoError(err)
+	assert.Equal("Bearer issued-token", client.AuthToken())
+}
+
+func TestNewAuthClientUnreachableRegistry(t *testing.T) {
+	assert := assert.New(t)
+	ref := &Reference{
+		Scheme:     "http",
+		Registry:   "127.0.0.1:1",
+		Repository: "library/nginx",
+		Reference:  "latest",
+	}
+
+	_, err := NewAuthClient(ref, &http.Client{Transport: http.DefaultTransport}, "", "")
+	assert.Error(err)
+}
+
+func TestAuthClientTokenChallenge(t *testing.T) {
+	assert := assert.New(t)
+	var server *httptest.Server
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			w.Header().Set("WWW-Authenticate", fmt.Sprintf("Bearer realm=%q,service=\"registry\"", server.URL+"/token"))
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(r.URL.Query().Get("scope"), "repository:library/nginx:pull")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"token":"test-token"}`)
+	})
+
+	server = httptest.NewServer(mux)
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	assert.NoError(err)
+
+	ref := &Reference{
+		Scheme:     "http",
+		Registry:   serverURL.Host,
+		Repository: "library/nginx",
+		Reference:  "latest",
+	}
+
+	client, err := NewAuthClient(ref, &http.Client{Transport: http.DefaultTransport}, "", "")
+	assert.NoError(err)
+
+	req, err := http.NewRequest(http.MethodGet, ref.ManifestURL(), nil)
+	assert.NoError(err)
+
+	resp, err := client.Do(req)
+	assert.NoError(err)
+	defer resp.Body.Close()
+
+	assert.Equal(http.StatusOK, resp.StatusCode)
+	assert.Equal("Bearer test-token", client.AuthToken())
+}
+
+func TestTokenHandler(t *testing.T) {
+	assert := assert.New(t)
+
+	h := newTokenHandler()
+	assert.Equal("bearer", h.Scheme())
+
+	req, err := http.NewRequest(http.MethodGet, "http://registry.example.com/v2/", nil)
+	assert.NoError(err)
+	req.Header.Set("Authorization", "Bearer test-token")
+
+	assert.NoError(h.AuthorizeRequest(req, nil))
+	assert.Equal("Bearer test-token", h.token)
+}

--- a/pkg/oci/reference.go
+++ b/pkg/oci/reference.go
@@ -1,0 +1,71 @@
+/*
+ *     Copyright 2026 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package oci resolves container image manifests from a registry with v2
+// authentication, used for preheating images.
+package oci
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+// manifestURLRegexp is the regular expression for parsing manifest urls.
+var manifestURLRegexp = regexp.MustCompile("^(.*)://(.*)/v2/(.*)/manifests/(.*)")
+
+// Reference is the set of registry coordinates of an image, following the
+// naming of the OCI distribution spec.
+type Reference struct {
+	// Scheme is the registry scheme (http or https).
+	Scheme string
+
+	// Registry is the registry host.
+	Registry string
+
+	// Repository is the repository name.
+	Repository string
+
+	// Reference is the image tag or digest.
+	Reference string
+}
+
+// ManifestURL returns the manifest url of the reference.
+func (r *Reference) ManifestURL() string {
+	return fmt.Sprintf("%s://%s/v2/%s/manifests/%s", r.Scheme, r.Registry, r.Repository, r.Reference)
+}
+
+// BlobURL returns the blob url of the reference for the given digest.
+func (r *Reference) BlobURL(digest string) string {
+	return fmt.Sprintf("%s://%s/v2/%s/blobs/%s", r.Scheme, r.Registry, r.Repository, digest)
+}
+
+// ParseManifestURL parses a container image manifest URL into a reference.
+// It extracts the scheme, registry, repository, and tag or digest from the
+// provided URL.
+func ParseManifestURL(url string) (*Reference, error) {
+	matches := manifestURLRegexp.FindStringSubmatch(url)
+	if len(matches) != 5 {
+		return nil, errors.New("parse access url failed")
+	}
+
+	return &Reference{
+		Scheme:     matches[1],
+		Registry:   matches[2],
+		Repository: matches[3],
+		Reference:  matches[4],
+	}, nil
+}

--- a/pkg/oci/reference_test.go
+++ b/pkg/oci/reference_test.go
@@ -1,0 +1,87 @@
+/*
+ *     Copyright 2026 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package oci
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseManifestURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		url    string
+		expect func(t *testing.T, ref *Reference, err error)
+	}{
+		{
+			name: "manifest url with tag",
+			url:  "https://registry.example.com/v2/library/nginx/manifests/latest",
+			expect: func(t *testing.T, ref *Reference, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Equal("https", ref.Scheme)
+				assert.Equal("registry.example.com", ref.Registry)
+				assert.Equal("library/nginx", ref.Repository)
+				assert.Equal("latest", ref.Reference)
+			},
+		},
+		{
+			name: "manifest url with digest",
+			url:  "http://localhost:5000/v2/myrepo/manifests/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e",
+			expect: func(t *testing.T, ref *Reference, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Equal("http", ref.Scheme)
+				assert.Equal("localhost:5000", ref.Registry)
+				assert.Equal("myrepo", ref.Repository)
+				assert.Equal("sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e", ref.Reference)
+			},
+		},
+		{
+			name: "invalid manifest url",
+			url:  "https://registry.example.com/v2/library/nginx/blobs/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e",
+			expect: func(t *testing.T, ref *Reference, err error) {
+				assert := assert.New(t)
+				assert.Error(err)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ref, err := ParseManifestURL(tc.url)
+			tc.expect(t, ref, err)
+		})
+	}
+}
+
+func TestReferenceURLs(t *testing.T) {
+	assert := assert.New(t)
+	ref := &Reference{
+		Scheme:     "https",
+		Registry:   "registry.example.com",
+		Repository: "library/nginx",
+		Reference:  "latest",
+	}
+
+	assert.Equal("https://registry.example.com/v2/library/nginx/manifests/latest", ref.ManifestURL())
+	assert.Equal(
+		"https://registry.example.com/v2/library/nginx/blobs/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e",
+		ref.BlobURL("sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e"),
+	)
+}

--- a/pkg/oci/resolver.go
+++ b/pkg/oci/resolver.go
@@ -1,0 +1,120 @@
+/*
+ *     Copyright 2026 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package oci
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/containerd/platforms"
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/manifest/manifestlist"
+	"github.com/docker/distribution/manifest/ocischema"
+	"github.com/docker/distribution/manifest/schema1"
+	"github.com/docker/distribution/manifest/schema2"
+	registryclient "github.com/docker/distribution/registry/client"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// ResolveManifests fetches and resolves container image manifests from a registry for a specified platform.
+// It constructs an HTTP request to retrieve the manifest, handles authentication via headers, and processes the response
+// to return manifests matching the given platform. Supports single manifests and manifest lists.
+func (c *AuthClient) ResolveManifests(ctx context.Context, ref *Reference, header http.Header, platform specs.Platform) ([]distribution.Manifest, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ref.ManifestURL(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set header from the user request.
+	for key, values := range header {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+
+	// Set accept header with media types.
+	for _, mediaType := range distribution.ManifestMediaTypes() {
+		req.Header.Add("Accept", mediaType)
+	}
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	// Handle response.
+	if resp.StatusCode == http.StatusNotModified {
+		return nil, distribution.ErrManifestNotModified
+	} else if !registryclient.SuccessStatus(resp.StatusCode) {
+		return nil, registryclient.HandleErrorResponse(resp)
+	}
+
+	ctHeader := resp.Header.Get("Content-Type")
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal manifest.
+	manifest, _, err := distribution.UnmarshalManifest(ctHeader, body)
+	if err != nil {
+		return nil, err
+	}
+
+	switch v := manifest.(type) {
+	case *schema1.SignedManifest, *schema2.DeserializedManifest, *ocischema.DeserializedManifest:
+		return []distribution.Manifest{v}, nil
+	case *manifestlist.DeserializedManifestList:
+		var result []distribution.Manifest
+		for _, desc := range filterManifests(v.Manifests, platform) {
+			ref.Reference = desc.Digest.String()
+			manifests, err := c.ResolveManifests(ctx, ref, header.Clone(), platform)
+			if err != nil {
+				return nil, err
+			}
+
+			result = append(result, manifests...)
+		}
+
+		return result, nil
+	}
+
+	return nil, errors.New("unknown manifest type")
+}
+
+// filterManifests filters a list of manifest descriptors to return only those
+// matching the specified platform, using the containerd platform matcher.
+func filterManifests(manifests []manifestlist.ManifestDescriptor, platform specs.Platform) []manifestlist.ManifestDescriptor {
+	matcher := platforms.Only(platform)
+	var matches []manifestlist.ManifestDescriptor
+	for _, desc := range manifests {
+		if matcher.Match(specs.Platform{
+			Architecture: desc.Platform.Architecture,
+			OS:           desc.Platform.OS,
+			OSVersion:    desc.Platform.OSVersion,
+			OSFeatures:   desc.Platform.OSFeatures,
+			Variant:      desc.Platform.Variant,
+		}) {
+			matches = append(matches, desc)
+		}
+	}
+
+	return matches
+}

--- a/pkg/oci/resolver_test.go
+++ b/pkg/oci/resolver_test.go
@@ -1,0 +1,73 @@
+/*
+ *     Copyright 2026 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package oci
+
+import (
+	"testing"
+
+	"github.com/docker/distribution/manifest/manifestlist"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterManifests(t *testing.T) {
+	manifests := []manifestlist.ManifestDescriptor{
+		{Platform: manifestlist.PlatformSpec{OS: "linux", Architecture: "amd64"}},
+		{Platform: manifestlist.PlatformSpec{OS: "linux", Architecture: "arm64", Variant: "v8"}},
+		{Platform: manifestlist.PlatformSpec{OS: "windows", Architecture: "amd64"}},
+	}
+
+	tests := []struct {
+		name     string
+		platform specs.Platform
+		expect   func(t *testing.T, matches []manifestlist.ManifestDescriptor)
+	}{
+		{
+			name:     "match linux/amd64",
+			platform: specs.Platform{OS: "linux", Architecture: "amd64"},
+			expect: func(t *testing.T, matches []manifestlist.ManifestDescriptor) {
+				assert := assert.New(t)
+				assert.Len(matches, 1)
+				assert.Equal("amd64", matches[0].Platform.Architecture)
+				assert.Equal("linux", matches[0].Platform.OS)
+			},
+		},
+		{
+			name:     "match linux/arm64 with variant",
+			platform: specs.Platform{OS: "linux", Architecture: "arm64"},
+			expect: func(t *testing.T, matches []manifestlist.ManifestDescriptor) {
+				assert := assert.New(t)
+				assert.Len(matches, 1)
+				assert.Equal("arm64", matches[0].Platform.Architecture)
+			},
+		},
+		{
+			name:     "no match",
+			platform: specs.Platform{OS: "linux", Architecture: "riscv64"},
+			expect: func(t *testing.T, matches []manifestlist.ManifestDescriptor) {
+				assert := assert.New(t)
+				assert.Empty(matches)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.expect(t, filterManifests(manifests, tc.platform))
+		})
+	}
+}


### PR DESCRIPTION
## Description

Move the reusable manifest resolution and registry v2 authentication machinery from `internal/job/image.go` into a new exported `pkg/oci` package, with OCI-community naming conventions:

- `Reference{Scheme, Registry, Repository, Reference}` — field naming follows oras-go v2's `registry.Reference`; `ManifestURL()` / `BlobURL(digest)` / `ParseManifestURL`  (reference.go)
- `AuthClient` with `NewAuthClient` / `Do` / `AuthToken()` (Go style, no `Get` prefix) and the `WithIssuedToken` option; the bearer-token-intercepting handler is unexported (auth.go)
- `(*AuthClient).ResolveManifests` resolves single manifests and multi-platform manifest lists; platform filtering now uses the containerd `platforms.Only` matcher instead of a manual arch/os comparison, which adds standard variant compatibility semantics (resolver.go)
- Unit tests for reference parsing/urls and platform filtering

`internal/job` keeps the manager-specific parts (`ManifestRequest`, `CreatePreheatRequestsByManifestURL`, preheat request building) and delegates to `pkg/oci`. The `Image` job interface is unchanged, so the generated mocks are unaffected.

## Motivation

The dragonfly-sdk Go client (dragonflyoss/dragonfly-sdk, `client-request/go`) implements `PreheatImage` and needs the same registry auth + manifest resolution logic. Go's `internal` rule prevents importing it from `internal/job`, so this exposes the reusable core under `pkg/` — the SDK will import `d7y.io/dragonfly/v2/pkg/oci` instead of carrying a port.

## Test plan

- `go build` / `go vet` clean for `pkg/oci` and `internal/job`
- `go test ./pkg/oci/... ./internal/job/...` passes (new `TestParseManifestURL` / `TestReferenceURLs` / `TestFilterManifests`, plus the existing `TestPreheat_CreatePreheatRequestsByManifestURL` covering the moved code end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)