### PR TITLE
perf(scheduler): honor stream context in schedule retry backoff

### DIFF
--- a/pkg/time/delay.go
+++ b/pkg/time/delay.go
@@ -50,12 +50,17 @@ func ExponentialDelayWithJitter(ctx context.Context, attempt uint, baseDelay, ma
 // RandomDelayWithJitter sleeps for a duration within ±25% of baseDelay to add jitter.
 // This helps prevent thundering herd when multiple clients retry simultaneously.
 // Example: baseDelay=2s results in sleep time between [1.5s, 2.5s).
-func RandomDelayWithJitter(baseDelay time.Duration) {
+// It returns early if the context is canceled.
+func RandomDelayWithJitter(ctx context.Context, baseDelay time.Duration) {
 	if baseDelay <= 0 {
 		return
 	}
 
 	jitter := time.Duration(rand.Int64N(int64(baseDelay) / 2))
 	delay := baseDelay*3/4 + jitter
-	time.Sleep(delay)
+
+	select {
+	case <-time.After(delay):
+	case <-ctx.Done():
+	}
 }

--- a/pkg/time/delay.go
+++ b/pkg/time/delay.go
@@ -25,7 +25,7 @@ import (
 
 // ExponentialDelayWithJitter is an exponential backoff strategy with jitter for retries. It calculates delay based on the attempt number,
 // adds jitter, and sleeps for that duration, capped at maxDelay.
-func ExponentialDelayWithJitter(ctx context.Context, attempt uint, baseDelay, maxDelay time.Duration) error {
+func ExponentialDelayWithJitter(ctx context.Context, attempt uint, baseDelay, maxDelay time.Duration) {
 	var delay time.Duration
 	if baseDelay > 0 {
 		delay = maxDelay
@@ -41,9 +41,7 @@ func ExponentialDelayWithJitter(ctx context.Context, attempt uint, baseDelay, ma
 
 	select {
 	case <-time.After(delay):
-		return nil
 	case <-ctx.Done():
-		return ctx.Err()
 	}
 }
 

--- a/pkg/time/delay_test.go
+++ b/pkg/time/delay_test.go
@@ -137,13 +137,10 @@ func TestExponentialDelayWithJitter(t *testing.T) {
 
 			for i := range iterations {
 				start := time.Now()
-				if err := ExponentialDelayWithJitter(context.TODO(), tt.attempt, tt.baseDelay, tt.maxDelay); err != nil {
-					t.Fatalf("ExponentialDelayWithJitter returned error: %v", err)
-				}
-
-				duration := time.Since(start)
+				ExponentialDelayWithJitter(context.TODO(), tt.attempt, tt.baseDelay, tt.maxDelay)
 
 				// Allow some failures due to system scheduling
+				duration := time.Since(start)
 				if duration >= tt.expectedMin && duration <= tt.expectedMax {
 					successCount++
 				} else {

--- a/pkg/time/delay_test.go
+++ b/pkg/time/delay_test.go
@@ -194,7 +194,7 @@ func TestRandomDelayWithJitter(t *testing.T) {
 
 			for i := range iterations {
 				start := time.Now()
-				RandomDelayWithJitter(tt.baseDelay)
+				RandomDelayWithJitter(context.Background(), tt.baseDelay)
 				duration := time.Since(start)
 
 				// Allow some failures due to system scheduling
@@ -210,5 +210,16 @@ func TestRandomDelayWithJitter(t *testing.T) {
 				t.Errorf("Too many iterations out of range: %d/%d successful", successCount, iterations)
 			}
 		})
+	}
+}
+
+func TestRandomDelayWithJitter_ContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	RandomDelayWithJitter(ctx, time.Minute)
+	if duration := time.Since(start); duration > time.Second {
+		t.Errorf("RandomDelayWithJitter did not return early on canceled context: took %v", duration)
 	}
 }

--- a/scheduler/scheduling/scheduling.go
+++ b/scheduler/scheduling/scheduling.go
@@ -190,7 +190,7 @@ func (s *scheduling) ScheduleCandidateParents(ctx context.Context, peer *standar
 			peer.Log.Infof("scheduling failed in %d times, because of candidate parents not found", n)
 
 			// Sleep with context-aware timeout to avoid blocking on cancellation.
-			pkgtime.RandomDelayWithJitter(s.config.RetryInterval)
+			pkgtime.RandomDelayWithJitter(ctx, s.config.RetryInterval)
 			continue
 		}
 
@@ -205,7 +205,7 @@ func (s *scheduling) ScheduleCandidateParents(ctx context.Context, peer *standar
 			peer.Log.Infof("scheduling failed in %d times, because of no candidate parent edges could be added", n)
 
 			// Sleep with context-aware timeout to avoid blocking on cancellation.
-			pkgtime.RandomDelayWithJitter(s.config.RetryInterval)
+			pkgtime.RandomDelayWithJitter(ctx, s.config.RetryInterval)
 			continue
 		}
 
@@ -341,7 +341,7 @@ func (s *scheduling) ScheduleParentAndCandidateParents(ctx context.Context, peer
 			peer.Log.Error(err)
 
 			// Sleep with context-aware timeout to avoid blocking on cancellation.
-			pkgtime.RandomDelayWithJitter(s.config.RetryInterval)
+			pkgtime.RandomDelayWithJitter(ctx, s.config.RetryInterval)
 			continue
 		}
 
@@ -352,7 +352,7 @@ func (s *scheduling) ScheduleParentAndCandidateParents(ctx context.Context, peer
 			peer.Log.Infof("scheduling failed in %d times, because of candidate parents not found", n)
 
 			// Sleep with context-aware timeout to avoid blocking on cancellation.
-			pkgtime.RandomDelayWithJitter(s.config.RetryInterval)
+			pkgtime.RandomDelayWithJitter(ctx, s.config.RetryInterval)
 			continue
 		}
 
@@ -367,7 +367,7 @@ func (s *scheduling) ScheduleParentAndCandidateParents(ctx context.Context, peer
 			peer.Log.Infof("scheduling failed in %d times, because of no candidate parent edges could be added", n)
 
 			// Sleep with context-aware timeout to avoid blocking on cancellation.
-			pkgtime.RandomDelayWithJitter(s.config.RetryInterval)
+			pkgtime.RandomDelayWithJitter(ctx, s.config.RetryInterval)
 			continue
 		}
 

--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -1370,12 +1370,7 @@ func (v *V2) handleRegisterPeerRequest(ctx context.Context, stream schedulerv2.S
 	//     the concurrency of back-to-source tasks for seed peers. Therefore, there is no risk of a
 	//     thundering herd against the source, and the delay is unnecessary.
 	if peer.Host.Type != types.HostTypeSuperSeed {
-		if err := pkgtime.ExponentialDelayWithJitter(ctx, uint(host.ConcurrentRegisterCount.Load()), baseDelayForRegisterPeer, maxDelayForRegisterPeer); err != nil {
-			// Collect RegisterPeerFailureCount metrics.
-			metrics.RegisterPeerFailureCount.WithLabelValues(priority.String(), peer.Task.Type.String(),
-				peer.Host.Type.Name()).Inc()
-			return status.Error(codes.Internal, err.Error())
-		}
+		pkgtime.ExponentialDelayWithJitter(ctx, uint(host.ConcurrentRegisterCount.Load()), baseDelayForRegisterPeer, maxDelayForRegisterPeer)
 	}
 
 	blocklist := set.NewSafeSet[string]()

--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -1479,7 +1479,7 @@ func (v *V2) handleRegisterPeerRequest(ctx context.Context, stream schedulerv2.S
 
 		// Record the start time.
 		start := time.Now()
-		if err := v.scheduling.ScheduleCandidateParents(context.Background(), peer, peer.BlockParents); err != nil {
+		if err := v.scheduling.ScheduleCandidateParents(ctx, peer, peer.BlockParents); err != nil {
 			// Collect RegisterPeerFailureCount metrics.
 			metrics.RegisterPeerFailureCount.WithLabelValues(priority.String(), peer.Task.Type.String(),
 				peer.Host.Type.Name()).Inc()
@@ -1548,7 +1548,7 @@ func (v *V2) handleDownloadPeerBackToSourceStartedRequest(ctx context.Context, p
 }
 
 // handleReschedulePeerRequest handles ReschedulePeerRequest of AnnouncePeerRequest.
-func (v *V2) handleReschedulePeerRequest(_ context.Context, peerID string, candidateParents []*commonv2.Peer) error {
+func (v *V2) handleReschedulePeerRequest(ctx context.Context, peerID string, candidateParents []*commonv2.Peer) error {
 	peer, loaded := v.resource.PeerManager().Load(peerID)
 	if !loaded {
 		return status.Errorf(codes.NotFound, "peer %s not found", peerID)
@@ -1561,7 +1561,7 @@ func (v *V2) handleReschedulePeerRequest(_ context.Context, peerID string, candi
 
 	// Record the start time.
 	start := time.Now()
-	if err := v.scheduling.ScheduleCandidateParents(context.Background(), peer, peer.BlockParents); err != nil {
+	if err := v.scheduling.ScheduleCandidateParents(ctx, peer, peer.BlockParents); err != nil {
 		return status.Error(codes.FailedPrecondition, err.Error())
 	}
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

The schedule retry loops check ctx.Done at the top of each attempt, but the backoff between attempts was an uncancellable time.Sleep and the v2 handlers passed context.Background, so a disconnected client kept its scheduling goroutine retrying for the full RetryLimit, about 2.5 seconds with the defaults.

Make RandomDelayWithJitter return early when the context is canceled, matching ExponentialDelayWithJitter, and pass the stream context from the v2 handlers. Cancellation is then handled by the existing check at the top of the retry loop.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
