### PR TITLE
refactor(oci): export DefaultHTTPClient for external use

### DIFF
--- a/pkg/oci/image.go
+++ b/pkg/oci/image.go
@@ -32,8 +32,8 @@ import (
 // defaultRegistryTimeout is the default timeout for registry requests.
 const defaultRegistryTimeout = 1 * time.Minute
 
-// defaultHTTPClient returns the default http client for registry requests.
-func defaultHTTPClient() *http.Client {
+// DefaultHTTPClient returns the default http client for registry requests.
+func DefaultHTTPClient() *http.Client {
 	return &http.Client{
 		Timeout: defaultRegistryTimeout,
 		Transport: &http.Transport{
@@ -169,7 +169,7 @@ func Resolve(ctx context.Context, ref *Reference, opts ...ResolveOption) (blobUR
 	}
 
 	if options.httpClient == nil {
-		options.httpClient = defaultHTTPClient()
+		options.httpClient = DefaultHTTPClient()
 	}
 
 	var authOpts []Option


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Makes the default HTTP client constructor accessible outside the package so callers can reuse the same timeout and transport configuration.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
