### PR TITLE
fix(time): avoid panic for nanosecond jitter delay

### DIFF
--- a/pkg/time/delay.go
+++ b/pkg/time/delay.go
@@ -54,11 +54,11 @@ func RandomDelayWithJitter(ctx context.Context, baseDelay time.Duration) {
 		return
 	}
 
-	var jitter time.Duration
+	delay := baseDelay
 	if jitterRange := int64(baseDelay) / 2; jitterRange > 0 {
-		jitter = time.Duration(rand.Int64N(jitterRange))
+		jitter := time.Duration(rand.Int64N(jitterRange))
+		delay = baseDelay*3/4 + jitter // delay is now between [baseDelay*3/4, baseDelay*5/4)
 	}
-	delay := baseDelay*3/4 + jitter
 
 	select {
 	case <-time.After(delay):

--- a/pkg/time/delay.go
+++ b/pkg/time/delay.go
@@ -54,7 +54,10 @@ func RandomDelayWithJitter(ctx context.Context, baseDelay time.Duration) {
 		return
 	}
 
-	jitter := time.Duration(rand.Int64N(int64(baseDelay) / 2))
+	var jitter time.Duration
+	if jitterRange := int64(baseDelay) / 2; jitterRange > 0 {
+		jitter = time.Duration(rand.Int64N(jitterRange))
+	}
 	delay := baseDelay*3/4 + jitter
 
 	select {

--- a/pkg/time/delay_test.go
+++ b/pkg/time/delay_test.go
@@ -181,6 +181,12 @@ func TestRandomDelayWithJitter(t *testing.T) {
 			expectedMin: 0,
 			expectedMax: 100 * time.Millisecond,
 		},
+		{
+			name:        "one nanosecond base delay",
+			baseDelay:   time.Nanosecond,
+			expectedMin: 0,
+			expectedMax: 100 * time.Millisecond,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

Avoid calling `rand.Int64N` with a zero bound when `baseDelay / 2` truncates to zero. For durations with a representable jitter range, behavior is unchanged. A regression case covers the one-nanosecond input.

## Related Issue

Fixes #4955

## Motivation and Context

`RandomDelayWithJitter` returns early only for non-positive durations, so positive durations should not panic. Before this change, `time.Nanosecond` produced a zero jitter bound and panicked with `invalid argument to Int64N`.

## Screenshots (if appropriate)

Not applicable.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Validation

- `go test ./pkg/time -run TestRandomDelayWithJitter -count=1`
- `go vet ./pkg/time`

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

> AI assistance disclosure: Codex was used to help identify the edge case, draft the implementation and regression test, and run the validations above. This PR is intentionally left as a draft pending the submitter's manual review.