### PR TITLE
build: support riscv64 release artifacts

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,6 +23,10 @@ builds:
     goarch:
       - amd64
       - arm64
+      - riscv64
+    ignore:
+      - goos: darwin
+        goarch: riscv64
     ldflags:
       - -X d7y.io/dragonfly/v2/version.Major={{ .Major }}
       - -X d7y.io/dragonfly/v2/version.Minor={{ .Minor }}
@@ -43,6 +47,10 @@ builds:
     goarch:
       - amd64
       - arm64
+      - riscv64
+    ignore:
+      - goos: darwin
+        goarch: riscv64
     ldflags:
       - -X d7y.io/dragonfly/v2/version.Major={{ .Major }}
       - -X d7y.io/dragonfly/v2/version.Minor={{ .Minor }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the `.goreleaser.yml` configuration to expand support for additional architectures and to handle platform-specific exclusions.

Build configuration updates:

* Added `riscv64` to the `goarch` list for both build sections, enabling builds for the RISC-V 64-bit architecture. [[1]](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689R26-R29) [[2]](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689R50-R53)
* Introduced an `ignore` rule to skip building for `darwin/riscv64`, which is not supported, preventing build failures on unsupported platforms. [[1]](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689R26-R29) [[2]](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689R50-R53)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
support riscv64 release artifacts
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
https://github.com/BraveY/dragonfly/actions/runs/32464056302/job/96716819960
<img width="2242" height="988" alt="image" src="https://github.com/user-attachments/assets/8dffd4b4-bd2d-4f0b-b806-d11641813cd8" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

