### PR TITLE
fix(scheduler): clear stale seed peer snapshots

### DIFF
--- a/scheduler/resource/standard/seed_peer.go
+++ b/scheduler/resource/standard/seed_peer.go
@@ -94,13 +94,14 @@ type seedPeer struct {
 	// dialOpts is the options for grpc dial.
 	dialOptions []grpc.DialOption
 
+	// mu protects hosts and hashring, which are replaced together by refresh.
+	mu sync.RWMutex
+
 	// hosts is the list of seed peers.
 	hosts *sync.Map
 
 	// hashring is the hashring constructed from seed peers.
 	hashring *consistent.Consistent
-
-	snapshotMutex sync.RWMutex
 
 	// done is the channel to stop the seed peer service.
 	done chan struct{}
@@ -287,22 +288,19 @@ func (s *seedPeer) TriggerTask(ctx context.Context, rg *http.Range, task *Task) 
 
 // Select selects a seed peer by the task id.
 func (s *seedPeer) Select(ctx context.Context, taskID string) (*Host, error) {
-	// The synchronization of the hash ring is handled by the refreshSeedPeers periodically and asynchronously.
-	s.snapshotMutex.RLock()
-	hosts := s.hosts
-	hashring := s.hashring
-	s.snapshotMutex.RUnlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
-	if len(hashring.Members()) == 0 {
-		return nil, fmt.Errorf("no seed peer available")
+	if len(s.hashring.Members()) == 0 {
+		return nil, fmt.Errorf("no available seed peer")
 	}
 
-	addr, err := hashring.Get(taskID)
+	addr, err := s.hashring.Get(taskID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to select seed peer: %w", err)
 	}
 
-	host, ok := hosts.Load(addr)
+	host, ok := s.hosts.Load(addr)
 	if !ok {
 		return nil, fmt.Errorf("failed to load host: %s", addr)
 	}
@@ -312,10 +310,10 @@ func (s *seedPeer) Select(ctx context.Context, taskID string) (*Host, error) {
 
 // HasAvailable returns whether there is any available seed peer.
 func (s *seedPeer) HasAvailable() bool {
-	s.snapshotMutex.RLock()
-	hashring := s.hashring
-	s.snapshotMutex.RUnlock()
-	return len(hashring.Members()) > 0
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return len(s.hashring.Members()) > 0
 }
 
 // Initialize seed peer.
@@ -352,6 +350,8 @@ func (s *seedPeer) initSeedPeer(ctx context.Context, rg *http.Range, task *Task,
 	return peer, nil
 }
 
+// refresh refreshes the hosts and hashring of seed peers, and clears
+// them when no seed peer is found in host manager.
 func (s *seedPeer) refresh(ctx context.Context) {
 	hosts := s.hostManager.LoadAllSeeds()
 	if len(hosts) == 0 {
@@ -359,7 +359,6 @@ func (s *seedPeer) refresh(ctx context.Context) {
 	}
 
 	healthyHosts := &sync.Map{}
-	// Do the health check for each seed peer.
 	for _, host := range hosts {
 		addr := net.JoinHostPort(host.IP, strconv.Itoa(int(host.Port)))
 		if err := healthclient.Check(ctx, addr, s.dialOptions...); err != nil {
@@ -368,16 +367,17 @@ func (s *seedPeer) refresh(ctx context.Context) {
 			healthyHosts.Store(addr, host)
 		}
 	}
+
 	hashring := consistent.New()
 	healthyHosts.Range(func(addr, _ any) bool {
 		hashring.Add(addr.(string))
 		return true
 	})
 
-	s.snapshotMutex.Lock()
+	s.mu.Lock()
 	s.hosts = healthyHosts
 	s.hashring = hashring
-	s.snapshotMutex.Unlock()
+	s.mu.Unlock()
 }
 
 // Serve serves the seed peer service.

--- a/scheduler/resource/standard/seed_peer.go
+++ b/scheduler/resource/standard/seed_peer.go
@@ -100,6 +100,8 @@ type seedPeer struct {
 	// hashring is the hashring constructed from seed peers.
 	hashring *consistent.Consistent
 
+	snapshotMutex sync.RWMutex
+
 	// done is the channel to stop the seed peer service.
 	done chan struct{}
 }
@@ -286,16 +288,21 @@ func (s *seedPeer) TriggerTask(ctx context.Context, rg *http.Range, task *Task) 
 // Select selects a seed peer by the task id.
 func (s *seedPeer) Select(ctx context.Context, taskID string) (*Host, error) {
 	// The synchronization of the hash ring is handled by the refreshSeedPeers periodically and asynchronously.
-	if len(s.hashring.Members()) == 0 {
+	s.snapshotMutex.RLock()
+	hosts := s.hosts
+	hashring := s.hashring
+	s.snapshotMutex.RUnlock()
+
+	if len(hashring.Members()) == 0 {
 		return nil, fmt.Errorf("no seed peer available")
 	}
 
-	addr, err := s.hashring.Get(taskID)
+	addr, err := hashring.Get(taskID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to select seed peer: %w", err)
 	}
 
-	host, ok := s.hosts.Load(addr)
+	host, ok := hosts.Load(addr)
 	if !ok {
 		return nil, fmt.Errorf("failed to load host: %s", addr)
 	}
@@ -305,7 +312,10 @@ func (s *seedPeer) Select(ctx context.Context, taskID string) (*Host, error) {
 
 // HasAvailable returns whether there is any available seed peer.
 func (s *seedPeer) HasAvailable() bool {
-	return len(s.hashring.Members()) > 0
+	s.snapshotMutex.RLock()
+	hashring := s.hashring
+	s.snapshotMutex.RUnlock()
+	return len(hashring.Members()) > 0
 }
 
 // Initialize seed peer.
@@ -346,7 +356,6 @@ func (s *seedPeer) refresh(ctx context.Context) {
 	hosts := s.hostManager.LoadAllSeeds()
 	if len(hosts) == 0 {
 		logger.Warnf("no seed peer found in host manager")
-		return
 	}
 
 	healthyHosts := &sync.Map{}
@@ -359,15 +368,16 @@ func (s *seedPeer) refresh(ctx context.Context) {
 			healthyHosts.Store(addr, host)
 		}
 	}
-	s.hosts = healthyHosts
-
 	hashring := consistent.New()
-	s.hosts.Range(func(addr, _ any) bool {
+	healthyHosts.Range(func(addr, _ any) bool {
 		hashring.Add(addr.(string))
 		return true
 	})
 
+	s.snapshotMutex.Lock()
+	s.hosts = healthyHosts
 	s.hashring = hashring
+	s.snapshotMutex.Unlock()
 }
 
 // Serve serves the seed peer service.

--- a/scheduler/resource/standard/seed_peer_test.go
+++ b/scheduler/resource/standard/seed_peer_test.go
@@ -18,18 +18,66 @@ package standard
 
 import (
 	"context"
+	"net"
 	"reflect"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	gomock "go.uber.org/mock/gomock"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
 	commonv2 "d7y.io/api/v2/pkg/apis/common/v2"
 	dfdaemonv2 "d7y.io/api/v2/pkg/apis/dfdaemon/v2"
 	schedulerv1 "d7y.io/api/v2/pkg/apis/scheduler/v1"
+	logger "d7y.io/dragonfly/v2/internal/dflog"
 	dfdaemonclientmocks "d7y.io/dragonfly/v2/pkg/rpc/dfdaemon/client/mocks"
 )
+
+func mockSeedHost(port int32) *Host {
+	return NewHost(
+		mockRawSeedHost.ID, mockRawSeedHost.IP, mockRawSeedHost.Name, mockRawSeedHost.Hostname,
+		port, mockRawSeedHost.DownloadPort, mockRawSeedHost.ProxyPort, mockRawSeedHost.Type)
+}
+
+func mockSeedHostServer(t *testing.T) *Host {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	svr := grpc.NewServer()
+	healthpb.RegisterHealthServer(svr, health.NewServer())
+	go func() {
+		if err := svr.Serve(lis); err != nil {
+			logger.Errorf("failed to serve the health service: %v", err)
+		}
+	}()
+	t.Cleanup(svr.Stop)
+
+	return mockSeedHost(int32(lis.Addr().(*net.TCPAddr).Port))
+}
+
+func mockUnreachableSeedHost(t *testing.T) *Host {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	port := int32(lis.Addr().(*net.TCPAddr).Port)
+	if err := lis.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	return mockSeedHost(port)
+}
 
 func TestSeedPeer_newSeedPeer(t *testing.T) {
 	tests := []struct {
@@ -61,74 +109,115 @@ func TestSeedPeer_newSeedPeer(t *testing.T) {
 func TestSeedPeer_refresh(t *testing.T) {
 	tests := []struct {
 		name   string
-		expect func(t *testing.T)
+		hosts  func(t *testing.T) []*Host
+		mock   func(m *MockHostManagerMockRecorder, hosts []*Host)
+		expect func(t *testing.T, seedPeer *seedPeer, hosts []*Host)
 	}{
 		{
-			name: "clears cached seed peers when host manager is empty",
-			expect: func(t *testing.T) {
-				// Given a seed peer cache containing a host that is no longer in HostManager.
-				ctl := gomock.NewController(t)
-				hostManager := NewMockHostManager(ctl)
-				peerManager := NewMockPeerManager(ctl)
-				clientPool := dfdaemonclientmocks.NewMockPool(ctl)
-				hostManager.EXPECT().LoadAllSeeds().Return([]*Host{})
-
-				seedPeer := newSeedPeer(peerManager, hostManager, clientPool).(*seedPeer)
-				const staleAddress = "127.0.0.1:4000"
-				seedPeer.hosts.Store(staleAddress, &Host{})
-				seedPeer.hashring.Add(staleAddress)
-
-				// When the seed peer cache is refreshed from the empty HostManager.
+			name: "refresh healthy seed peer",
+			hosts: func(t *testing.T) []*Host {
+				return []*Host{mockSeedHostServer(t)}
+			},
+			mock: func(m *MockHostManagerMockRecorder, hosts []*Host) {
+				m.LoadAllSeeds().Return(hosts)
+			},
+			expect: func(t *testing.T, seedPeer *seedPeer, hosts []*Host) {
+				assert := assert.New(t)
 				seedPeer.refresh(context.Background())
+				assert.True(seedPeer.HasAvailable())
 
-				// Then the stale seed peer is no longer available or selectable.
-				seedPeer.snapshotMutex.RLock()
-				hosts := seedPeer.hosts
-				seedPeer.snapshotMutex.RUnlock()
-				_, found := hosts.Load(staleAddress)
-				assert.False(t, found)
-				assert.False(t, seedPeer.HasAvailable())
-				_, err := seedPeer.Select(context.Background(), mockTaskID)
-				assert.EqualError(t, err, "no seed peer available")
+				host, err := seedPeer.Select(context.Background(), mockTaskID)
+				assert.NoError(err)
+				assert.Equal(hosts[0].ID, host.ID)
 			},
 		},
 		{
-			name: "is safe during concurrent selection",
-			expect: func(t *testing.T) {
-				// Given a seed peer cache that repeatedly refreshes to an empty snapshot.
-				ctl := gomock.NewController(t)
-				hostManager := NewMockHostManager(ctl)
-				peerManager := NewMockPeerManager(ctl)
-				clientPool := dfdaemonclientmocks.NewMockPool(ctl)
-				hostManager.EXPECT().LoadAllSeeds().Return([]*Host{}).AnyTimes()
-				seedPeer := newSeedPeer(peerManager, hostManager, clientPool).(*seedPeer)
+			name: "filter unhealthy seed peer",
+			hosts: func(t *testing.T) []*Host {
+				return []*Host{mockUnreachableSeedHost(t)}
+			},
+			mock: func(m *MockHostManagerMockRecorder, hosts []*Host) {
+				m.LoadAllSeeds().Return(hosts)
+			},
+			expect: func(t *testing.T, seedPeer *seedPeer, hosts []*Host) {
+				assert := assert.New(t)
+				seedPeer.refresh(context.Background())
+				assert.False(seedPeer.HasAvailable())
 
-				// When refresh and selection run concurrently.
-				var waitGroup sync.WaitGroup
-				waitGroup.Add(2)
+				_, err := seedPeer.Select(context.Background(), mockTaskID)
+				assert.EqualError(err, "no available seed peer")
+			},
+		},
+		{
+			name: "clear stale seed peers when host manager is empty",
+			hosts: func(t *testing.T) []*Host {
+				return []*Host{}
+			},
+			mock: func(m *MockHostManagerMockRecorder, hosts []*Host) {
+				m.LoadAllSeeds().Return(hosts)
+			},
+			expect: func(t *testing.T, seedPeer *seedPeer, hosts []*Host) {
+				assert := assert.New(t)
+				mockAddr := "127.0.0.1:4000"
+				seedPeer.hosts.Store(mockAddr, &Host{})
+				seedPeer.hashring.Add(mockAddr)
+
+				seedPeer.refresh(context.Background())
+				_, loaded := seedPeer.hosts.Load(mockAddr)
+				assert.False(loaded)
+				assert.False(seedPeer.HasAvailable())
+
+				_, err := seedPeer.Select(context.Background(), mockTaskID)
+				assert.EqualError(err, "no available seed peer")
+			},
+		},
+		{
+			name: "refresh and select concurrently",
+			hosts: func(t *testing.T) []*Host {
+				return []*Host{}
+			},
+			mock: func(m *MockHostManagerMockRecorder, hosts []*Host) {
+				m.LoadAllSeeds().Return(hosts).AnyTimes()
+			},
+			expect: func(t *testing.T, seedPeer *seedPeer, hosts []*Host) {
+				var wg sync.WaitGroup
+				wg.Add(2)
 				go func() {
-					defer waitGroup.Done()
+					defer wg.Done()
 					for range 100 {
 						seedPeer.refresh(context.Background())
 					}
 				}()
+
 				go func() {
-					defer waitGroup.Done()
+					defer wg.Done()
 					for range 100 {
 						seedPeer.HasAvailable()
-						_, _ = seedPeer.Select(context.Background(), mockTaskID)
+						if _, err := seedPeer.Select(context.Background(), mockTaskID); err == nil {
+							assert.Fail(t, "select should fail when no seed peer is available")
+						}
 					}
 				}()
 
-				// Then all concurrent operations complete without a data race.
-				waitGroup.Wait()
+				wg.Wait()
 			},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.expect(t)
+			ctl := gomock.NewController(t)
+			defer ctl.Finish()
+			hostManager := NewMockHostManager(ctl)
+			peerManager := NewMockPeerManager(ctl)
+			clientPool := dfdaemonclientmocks.NewMockPool(ctl)
+
+			hosts := tc.hosts(t)
+			tc.mock(hostManager.EXPECT(), hosts)
+
+			seedPeer := newSeedPeer(peerManager, hostManager, clientPool,
+				grpc.WithTransportCredentials(insecure.NewCredentials())).(*seedPeer)
+			tc.expect(t, seedPeer, hosts)
 		})
 	}
 }
@@ -142,7 +231,7 @@ func TestSeedPeer_TriggerDownloadTask(t *testing.T) {
 			name: "trigger download task failed",
 			expect: func(t *testing.T, err error) {
 				assert := assert.New(t)
-				assert.EqualError(err, "no seed peer available")
+				assert.EqualError(err, "no available seed peer")
 			},
 		},
 	}
@@ -170,7 +259,7 @@ func TestSeedPeer_TriggerTask(t *testing.T) {
 			name: "start obtain seed stream failed",
 			expect: func(t *testing.T, peer *Peer, result *schedulerv1.PeerResult, err error) {
 				assert := assert.New(t)
-				assert.EqualError(err, "no seed peer available")
+				assert.EqualError(err, "no available seed peer")
 			},
 		},
 	}

--- a/scheduler/resource/standard/seed_peer_test.go
+++ b/scheduler/resource/standard/seed_peer_test.go
@@ -19,6 +19,7 @@ package standard
 import (
 	"context"
 	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -53,6 +54,81 @@ func TestSeedPeer_newSeedPeer(t *testing.T) {
 			clientPool := dfdaemonclientmocks.NewMockPool(ctl)
 
 			tc.expect(t, newSeedPeer(peerManager, hostManager, clientPool))
+		})
+	}
+}
+
+func TestSeedPeer_refresh(t *testing.T) {
+	tests := []struct {
+		name   string
+		expect func(t *testing.T)
+	}{
+		{
+			name: "clears cached seed peers when host manager is empty",
+			expect: func(t *testing.T) {
+				// Given a seed peer cache containing a host that is no longer in HostManager.
+				ctl := gomock.NewController(t)
+				hostManager := NewMockHostManager(ctl)
+				peerManager := NewMockPeerManager(ctl)
+				clientPool := dfdaemonclientmocks.NewMockPool(ctl)
+				hostManager.EXPECT().LoadAllSeeds().Return([]*Host{})
+
+				seedPeer := newSeedPeer(peerManager, hostManager, clientPool).(*seedPeer)
+				const staleAddress = "127.0.0.1:4000"
+				seedPeer.hosts.Store(staleAddress, &Host{})
+				seedPeer.hashring.Add(staleAddress)
+
+				// When the seed peer cache is refreshed from the empty HostManager.
+				seedPeer.refresh(context.Background())
+
+				// Then the stale seed peer is no longer available or selectable.
+				seedPeer.snapshotMutex.RLock()
+				hosts := seedPeer.hosts
+				seedPeer.snapshotMutex.RUnlock()
+				_, found := hosts.Load(staleAddress)
+				assert.False(t, found)
+				assert.False(t, seedPeer.HasAvailable())
+				_, err := seedPeer.Select(context.Background(), mockTaskID)
+				assert.EqualError(t, err, "no seed peer available")
+			},
+		},
+		{
+			name: "is safe during concurrent selection",
+			expect: func(t *testing.T) {
+				// Given a seed peer cache that repeatedly refreshes to an empty snapshot.
+				ctl := gomock.NewController(t)
+				hostManager := NewMockHostManager(ctl)
+				peerManager := NewMockPeerManager(ctl)
+				clientPool := dfdaemonclientmocks.NewMockPool(ctl)
+				hostManager.EXPECT().LoadAllSeeds().Return([]*Host{}).AnyTimes()
+				seedPeer := newSeedPeer(peerManager, hostManager, clientPool).(*seedPeer)
+
+				// When refresh and selection run concurrently.
+				var waitGroup sync.WaitGroup
+				waitGroup.Add(2)
+				go func() {
+					defer waitGroup.Done()
+					for range 100 {
+						seedPeer.refresh(context.Background())
+					}
+				}()
+				go func() {
+					defer waitGroup.Done()
+					for range 100 {
+						seedPeer.HasAvailable()
+						_, _ = seedPeer.Select(context.Background(), mockTaskID)
+					}
+				}()
+
+				// Then all concurrent operations complete without a data race.
+				waitGroup.Wait()
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.expect(t)
 		})
 	}
 }


### PR DESCRIPTION
Refresh and atomically publish an empty seed peer snapshot when no seeds remain, preventing stale hosts from being selected.

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request improves the thread safety and reliability of the seed peer selection mechanism in the scheduler by introducing proper synchronization and enhancing test coverage. The main changes include adding a mutex to protect shared state, ensuring atomic updates during refresh, and adding tests to verify correct behavior under concurrent access and when the host manager is empty.

**Thread safety improvements:**

* Added a `sync.RWMutex` (`snapshotMutex`) to the `seedPeer` struct and used it to protect access to the `hosts` and `hashring` fields in `Select`, `HasAvailable`, and `refresh` methods, preventing data races during concurrent operations. [[1]](diffhunk://#diff-3a2c4c6ea7497d3cc956eafaf6b9d7434e2db45b76be2baea52cf2ca0f1121a2R103-R104) [[2]](diffhunk://#diff-3a2c4c6ea7497d3cc956eafaf6b9d7434e2db45b76be2baea52cf2ca0f1121a2L289-R305) [[3]](diffhunk://#diff-3a2c4c6ea7497d3cc956eafaf6b9d7434e2db45b76be2baea52cf2ca0f1121a2L308-R318) [[4]](diffhunk://#diff-3a2c4c6ea7497d3cc956eafaf6b9d7434e2db45b76be2baea52cf2ca0f1121a2L362-R380)

**Atomic updates and correctness:**

* Modified the `refresh` method to update `hosts` and `hashring` atomically under a write lock, ensuring that selection operations always see a consistent snapshot of seed peers.

**Test coverage improvements:**

* Added tests to verify that the seed peer cache is cleared when the host manager returns no seeds, and to ensure that concurrent refresh and selection operations are safe and free of data races.

**Minor code quality improvements:**

* Added necessary imports (e.g., `sync`) to support new concurrency logic in tests.
* Removed an unnecessary early return in `refresh` to ensure the cache is properly cleared when no hosts are found.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/dragonflyoss/dragonfly/issues/4960
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
