### PR TITLE
feat(scheduler): support scope filtering in GetTask and StatImage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module d7y.io/dragonfly/v2
 go 1.25.5
 
 require (
-	d7y.io/api/v2 v2.3.0
+	d7y.io/api/v2 v2.3.2
 	github.com/Showmax/go-fqdn v1.0.0
 	github.com/VividCortex/mysqlerr v1.0.0
 	github.com/appleboy/gin-jwt/v2 v2.10.3
@@ -67,8 +67,8 @@ require (
 	golang.org/x/sys v0.47.0
 	golang.org/x/time v0.15.0
 	google.golang.org/api v0.291.0
-	google.golang.org/grpc v1.83.0
-	google.golang.org/protobuf v1.36.11
+	google.golang.org/grpc v1.83.1
+	google.golang.org/protobuf v1.36.12
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/mysql v1.4.7

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
-d7y.io/api/v2 v2.3.0 h1:4jtefp4y7Ckyv8kZjyb+E6B1zYSclaUpeh7JVagupEg=
-d7y.io/api/v2 v2.3.0/go.mod h1:dEZydwgMnLfmiwRUoFqjmYrpDnjsWth2NS8YPBsRb68=
+d7y.io/api/v2 v2.3.2 h1:CvC5G1QPpYE38Bfj1ePTooHH7XpJbrZIgneo1fSgGzI=
+d7y.io/api/v2 v2.3.2/go.mod h1:wpH5vl1BhTm10cpzJ7dqSsDXq4eyhu8iLjouQJ6ZiBQ=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 filippo.io/edwards25519 v1.1.1 h1:YpjwWWlNmGIDyXOn8zLzqiD+9TyIlPhGFG96P39uBpw=
 filippo.io/edwards25519 v1.1.1/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
@@ -1287,8 +1287,8 @@ google.golang.org/grpc v1.31.1/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
 google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
 google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
-google.golang.org/grpc v1.83.0 h1:JeNZEKJFbQxArAMl+hiytHauacDNqJUllNfmIMmpqnQ=
-google.golang.org/grpc v1.83.0/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
+google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
+google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
@@ -1302,8 +1302,8 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
-google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+google.golang.org/protobuf v1.36.12 h1:pJOKDDOyeXErUroCihFAd5LQuwXBSpVnKGrj5o/fwxc=
+google.golang.org/protobuf v1.36.12/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/job/types.go
+++ b/internal/job/types.go
@@ -83,6 +83,7 @@ type GetTaskRequest struct {
 	GroupUUID           string        `json:"group_uuid" validate:"omitempty"`
 	TaskUUID            string        `json:"task_uuid" validate:"omitempty"`
 	ConcurrentPeerCount int64         `json:"concurrent_peer_count" validate:"omitempty"`
+	Scope               string        `json:"scope" validate:"omitempty"`
 }
 
 // GetTaskResponse defines the response parameters for getting task.

--- a/scheduler/job/job.go
+++ b/scheduler/job/job.go
@@ -329,7 +329,6 @@ func (j *job) preheatV1SingleSeedPeer(ctx context.Context, req *internaljob.Preh
 func (j *job) preheatV2SingleSeedPeer(ctx context.Context, req *internaljob.PreheatRequest, log *logger.SugaredLoggerOnWith) (*internaljob.PreheatResponse, error) {
 	var mu sync.Mutex
 	preheatResp := &internaljob.PreheatResponse{}
-
 	eg, _ := errgroup.WithContext(ctx)
 	eg.SetLimit(int(req.ConcurrentTaskCount))
 	for _, url := range req.URLs {
@@ -663,7 +662,6 @@ func (j *job) PreheatAllPeers(ctx context.Context, req *internaljob.PreheatReque
 		successTasks = sync.Map{}
 		failureTasks = sync.Map{}
 	)
-
 	eg, _ := errgroup.WithContext(ctx)
 	eg.SetLimit(int(req.ConcurrentTaskCount))
 	for _, url := range req.URLs {
@@ -916,11 +914,19 @@ func (j *job) getTask(ctx context.Context, data string) (string, error) {
 	return internaljob.MarshalResponse(resp)
 }
 
-// GetTask retrieves task information from all hosts in the cluster.
+// GetTask retrieves task information from peers in the cluster. If the scope is
+// all_seed_peers, only seed peers are queried, otherwise all peers are queried.
 func (j *job) GetTask(ctx context.Context, req *internaljob.GetTaskRequest, log *logger.SugaredLoggerOnWith) (*internaljob.GetTaskResponse, error) {
-	hosts := j.resource.HostManager().LoadAll()
-	if len(hosts) == 0 {
-		log.Warn("[get-task] no hosts found")
+	var peers []*resource.Host
+	switch req.Scope {
+	case managertypes.AllSeedPeersScope:
+		peers = j.resource.HostManager().LoadAllSeeds()
+	default:
+		peers = j.resource.HostManager().LoadAll()
+	}
+
+	if len(peers) == 0 {
+		log.Warn("[get-task] no peers found")
 		return &internaljob.GetTaskResponse{
 			SchedulerClusterID: j.config.Manager.SchedulerClusterID,
 		}, nil
@@ -929,13 +935,23 @@ func (j *job) GetTask(ctx context.Context, req *internaljob.GetTaskRequest, log 
 	var mu sync.Mutex
 	resp := &internaljob.GetTaskResponse{
 		SchedulerClusterID: j.config.Manager.SchedulerClusterID,
-		Peers:              make([]*internaljob.Peer, 0, len(hosts)),
+		Peers:              make([]*internaljob.Peer, 0, len(peers)),
 	}
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.SetLimit(int(req.ConcurrentPeerCount))
-	for _, host := range hosts {
+	for _, peer := range peers {
+		var (
+			id        = peer.ID
+			hostname  = peer.Hostname
+			ip        = peer.IP
+			port      = peer.Port
+			hostType  = peer.Type.Name()
+			createdAt = peer.CreatedAt.Load()
+			updatedAt = peer.UpdatedAt.Load()
+		)
+
+		addr := net.JoinHostPort(ip, strconv.Itoa(int(port)))
 		eg.Go(func() error {
-			addr := net.JoinHostPort(host.IP, strconv.Itoa(int(host.Port)))
 			dfdaemonClient, err := j.resource.PeerClientPool().Get(addr, j.dialOptions...)
 			if err != nil {
 				log.Warnf("[get-task] get client from %s failed: %s", addr, err.Error())
@@ -954,16 +970,15 @@ func (j *job) GetTask(ctx context.Context, req *internaljob.GetTaskRequest, log 
 
 			mu.Lock()
 			resp.Peers = append(resp.Peers, &internaljob.Peer{
-				ID:         host.ID,
-				Hostname:   host.Hostname,
-				IP:         host.IP,
-				HostType:   host.Type.Name(),
-				CreatedAt:  host.CreatedAt.Load(),
-				UpdatedAt:  host.UpdatedAt.Load(),
+				ID:         id,
+				Hostname:   hostname,
+				IP:         ip,
+				HostType:   hostType,
+				CreatedAt:  createdAt,
+				UpdatedAt:  updatedAt,
 				IsFinished: localTask.GetFinishedAt() != nil,
 			})
 			mu.Unlock()
-
 			return nil
 		})
 	}

--- a/scheduler/job/job_test.go
+++ b/scheduler/job/job_test.go
@@ -17,14 +17,67 @@
 package job
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
 	logger "d7y.io/dragonfly/v2/internal/dflog"
+	internaljob "d7y.io/dragonfly/v2/internal/job"
+	managertypes "d7y.io/dragonfly/v2/manager/types"
+	"d7y.io/dragonfly/v2/scheduler/config"
 	resource "d7y.io/dragonfly/v2/scheduler/resource/standard"
 )
+
+func TestJob_GetTask(t *testing.T) {
+	tests := []struct {
+		name  string
+		scope string
+		mock  func(hostManager *resource.MockHostManager)
+	}{
+		{
+			name:  "get task from all seed peers with all_seed_peers scope",
+			scope: managertypes.AllSeedPeersScope,
+			mock: func(hostManager *resource.MockHostManager) {
+				hostManager.EXPECT().LoadAllSeeds().Return(nil).Times(1)
+			},
+		},
+		{
+			name:  "get task from all peers with all_peers scope",
+			scope: managertypes.AllPeersScope,
+			mock: func(hostManager *resource.MockHostManager) {
+				hostManager.EXPECT().LoadAll().Return(nil).Times(1)
+			},
+		},
+		{
+			name:  "get task from all peers with empty scope",
+			scope: "",
+			mock: func(hostManager *resource.MockHostManager) {
+				hostManager.EXPECT().LoadAll().Return(nil).Times(1)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctl := gomock.NewController(t)
+			defer ctl.Finish()
+
+			res := resource.NewMockResource(ctl)
+			hostManager := resource.NewMockHostManager(ctl)
+			res.EXPECT().HostManager().Return(hostManager).Times(1)
+			tc.mock(hostManager)
+
+			j := &job{resource: res, config: &config.Config{}}
+			resp, err := j.GetTask(context.Background(), &internaljob.GetTaskRequest{TaskID: "foo", Scope: tc.scope}, logger.WithPeerID("test"))
+
+			assert := assert.New(t)
+			assert.NoError(err)
+			assert.Empty(resp.Peers)
+		})
+	}
+}
 
 func TestJob_selectPeers(t *testing.T) {
 	tests := []struct {

--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -4612,6 +4612,10 @@ func (v *V2) PreheatImage(ctx context.Context, req *schedulerv2.PreheatImageRequ
 func (v *V2) StatImage(ctx context.Context, req *schedulerv2.StatImageRequest) (*schedulerv2.StatImageResponse, error) {
 	log := logger.WithStatImage(req.Url)
 
+	if req.Scope == "" {
+		req.Scope = managertypes.AllPeersScope
+	}
+
 	if req.ConcurrentLayerCount == nil {
 		concurrentLayerCount := int64(managertypes.DefaultPreheatConcurrentLayerCount)
 		req.ConcurrentLayerCount = &concurrentLayerCount
@@ -4674,6 +4678,7 @@ func (v *V2) StatImage(ctx context.Context, req *schedulerv2.StatImageRequest) (
 	filteredQueryParams := req.FilteredQueryParams
 	timeout := req.GetTimeout().AsDuration()
 	concurrentPeerCount := *req.ConcurrentPeerCount
+	scope := req.GetScope()
 
 	var mu sync.Mutex
 	peers := map[string]*schedulerv2.PeerImage{}
@@ -4687,6 +4692,7 @@ func (v *V2) StatImage(ctx context.Context, req *schedulerv2.StatImageRequest) (
 				TaskID:              taskID,
 				Timeout:             timeout,
 				ConcurrentPeerCount: concurrentPeerCount,
+				Scope:               scope,
 			}
 
 			log := logger.WithStatImageAndTaskID(url, taskID)

--- a/scheduler/service/service_v2_test.go
+++ b/scheduler/service/service_v2_test.go
@@ -3952,6 +3952,57 @@ func TestServiceV2_StatImage(t *testing.T) {
 			},
 		},
 		{
+			name: "stat layer by seed peers with all_seed_peers scope",
+			req: &schedulerv2.StatImageRequest{
+				Url:   "https://example.com/v2/image/manifests/latest",
+				Scope: managertypes.AllSeedPeersScope,
+			},
+			run: func(t *testing.T, svc *V2, req *schedulerv2.StatImageRequest, mj *jobmocks.MockJobMockRecorder, mi *internaljobmocks.MockImageMockRecorder) {
+				var wg sync.WaitGroup
+				wg.Add(1)
+				defer wg.Wait()
+
+				gomock.InOrder(
+					mi.CreatePreheatRequestsByManifestURL(gomock.Any(), gomock.Any()).Return([]*internaljob.PreheatRequest{{URLs: []string{"https://example.com/v2/image/latest/blobs/sha256:b5f4dfca35398b36f61baa60e2bf2c242401c9d7db3de9168dcf780a2feedd2d"}}}, nil).Times(1),
+					mj.GetTask(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(_ context.Context, getTaskRequest *internaljob.GetTaskRequest, _ *logger.SugaredLoggerOnWith) {
+						assert.Equal(t, managertypes.AllSeedPeersScope, getTaskRequest.Scope)
+						wg.Done()
+					}).Return(&internaljob.GetTaskResponse{Peers: []*internaljob.Peer{{IP: "127.0.0.1", Hostname: "seed-peer-1"}}}, nil).Times(1),
+				)
+
+				resp, err := svc.StatImage(context.Background(), req)
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Equal(1, len(resp.Image.Layers))
+				assert.Equal(1, len(resp.Peers))
+			},
+		},
+		{
+			name: "stat layer by peer with default scope",
+			req: &schedulerv2.StatImageRequest{
+				Url: "https://example.com/v2/image/manifests/latest",
+			},
+			run: func(t *testing.T, svc *V2, req *schedulerv2.StatImageRequest, mj *jobmocks.MockJobMockRecorder, mi *internaljobmocks.MockImageMockRecorder) {
+				var wg sync.WaitGroup
+				wg.Add(1)
+				defer wg.Wait()
+
+				gomock.InOrder(
+					mi.CreatePreheatRequestsByManifestURL(gomock.Any(), gomock.Any()).Return([]*internaljob.PreheatRequest{{URLs: []string{"https://example.com/v2/image/latest/blobs/sha256:b5f4dfca35398b36f61baa60e2bf2c242401c9d7db3de9168dcf780a2feedd2d"}}}, nil).Times(1),
+					mj.GetTask(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(_ context.Context, getTaskRequest *internaljob.GetTaskRequest, _ *logger.SugaredLoggerOnWith) {
+						assert.Equal(t, managertypes.AllPeersScope, getTaskRequest.Scope)
+						wg.Done()
+					}).Return(&internaljob.GetTaskResponse{Peers: []*internaljob.Peer{{IP: "127.0.0.1", Hostname: "peer-1"}}}, nil).Times(1),
+				)
+
+				resp, err := svc.StatImage(context.Background(), req)
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Equal(1, len(resp.Image.Layers))
+				assert.Equal(1, len(resp.Peers))
+			},
+		},
+		{
 			name: "stat layer by peer failed",
 			req: &schedulerv2.StatImageRequest{
 				Url: "https://example.com/v2/image/manifests/latest",


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a `Scope` field to `GetTaskRequest` so callers can restrict peer queries to seed peers only (`all_seed_peers`) or all peers (default). `StatImage` now forwards the request scope and defaults to `all_peers` when none is provided. Fix a closure variable capture bug in the `GetTask` loop by capturing loop variables before spawning goroutines. Also bump `d7y.io/api/v2` to v2.3.2, `grpc` to v1.83.1, and `protobuf` to v1.36.12.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
