### PR TITLE
refactor(idgen): introduce unified TaskIDV2 helper and wire it throughout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module d7y.io/dragonfly/v2
 go 1.25.5
 
 require (
-	d7y.io/api/v2 v2.3.2
+	d7y.io/api/v2 v2.3.3
 	github.com/Showmax/go-fqdn v1.0.0
 	github.com/VividCortex/mysqlerr v1.0.0
 	github.com/appleboy/gin-jwt/v2 v2.10.3

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
-d7y.io/api/v2 v2.3.2 h1:CvC5G1QPpYE38Bfj1ePTooHH7XpJbrZIgneo1fSgGzI=
-d7y.io/api/v2 v2.3.2/go.mod h1:wpH5vl1BhTm10cpzJ7dqSsDXq4eyhu8iLjouQJ6ZiBQ=
+d7y.io/api/v2 v2.3.3 h1:6P6vtq55hofqFrVPknTBrtCa+18kitx5R+9bSpRodp8=
+d7y.io/api/v2 v2.3.3/go.mod h1:wpH5vl1BhTm10cpzJ7dqSsDXq4eyhu8iLjouQJ6ZiBQ=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 filippo.io/edwards25519 v1.1.1 h1:YpjwWWlNmGIDyXOn8zLzqiD+9TyIlPhGFG96P39uBpw=
 filippo.io/edwards25519 v1.1.1/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=

--- a/manager/job/task.go
+++ b/manager/job/task.go
@@ -62,10 +62,17 @@ func (t *task) CreateGetTask(ctx context.Context, schedulers []models.Scheduler,
 	defer span.End()
 
 	taskID := json.TaskID
-	if json.URL != "" {
-		taskID = idgen.TaskIDV2ByURLBased(json.URL, json.PieceLength, json.Tag, json.Application, idgen.ParseFilteredQueryParams(json.FilteredQueryParams), "")
-	} else if json.ContentForCalculatingTaskID != nil {
-		taskID = idgen.TaskIDV2ByContent(*json.ContentForCalculatingTaskID)
+	if json.URL != "" || json.ContentForCalculatingTaskID != nil {
+		var content string
+		if json.ContentForCalculatingTaskID != nil {
+			content = *json.ContentForCalculatingTaskID
+		}
+
+		var err error
+		taskID, err = idgen.TaskIDV2(json.URL, json.PieceLength, json.Tag, json.Application, idgen.ParseFilteredQueryParams(json.FilteredQueryParams), content, false)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	queues, err := getSchedulerQueues(schedulers)
@@ -131,10 +138,17 @@ func (t *task) CreateDeleteTask(ctx context.Context, schedulers []models.Schedul
 	defer span.End()
 
 	taskID := json.TaskID
-	if json.URL != "" {
-		taskID = idgen.TaskIDV2ByURLBased(json.URL, json.PieceLength, json.Tag, json.Application, idgen.ParseFilteredQueryParams(json.FilteredQueryParams), "")
-	} else if json.ContentForCalculatingTaskID != nil {
-		taskID = idgen.TaskIDV2ByContent(*json.ContentForCalculatingTaskID)
+	if json.URL != "" || json.ContentForCalculatingTaskID != nil {
+		var content string
+		if json.ContentForCalculatingTaskID != nil {
+			content = *json.ContentForCalculatingTaskID
+		}
+
+		var err error
+		taskID, err = idgen.TaskIDV2(json.URL, json.PieceLength, json.Tag, json.Application, idgen.ParseFilteredQueryParams(json.FilteredQueryParams), content, false)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	queues, err := getSchedulerQueues(schedulers)

--- a/pkg/idgen/task_id.go
+++ b/pkg/idgen/task_id.go
@@ -201,6 +201,23 @@ func TaskIDV2ByBlobDigest(url string) (string, error) {
 	}
 }
 
+// TaskIDV2 generates v2 version of task id, selecting the generator by the parameters,
+// identical to the client's task id generation. If the content is not empty, generate
+// the task id by the content. If the task id based blob digest is enabled and the url
+// is an OCI blob url, generate the task id by the blob digest. Otherwise, generate the
+// task id by the url based parameters.
+func TaskIDV2(url string, pieceLength *uint64, tag, application string, filteredQueryParams []string, content string, enableTaskIDBasedBlobDigest bool) (string, error) {
+	if content != "" {
+		return TaskIDV2ByContent(content), nil
+	}
+
+	if enableTaskIDBasedBlobDigest && IsBlobURL(url) {
+		return TaskIDV2ByBlobDigest(url)
+	}
+
+	return TaskIDV2ByURLBased(url, pieceLength, tag, application, filteredQueryParams, ""), nil
+}
+
 // PersistentCacheTaskIDByContent generates persistent cache task id by content.
 func PersistentCacheTaskIDByContent(content string) string {
 	return pkgdigest.SHA256FromStrings(content)

--- a/pkg/idgen/task_id_test.go
+++ b/pkg/idgen/task_id_test.go
@@ -342,3 +342,70 @@ func TestTaskIDV2ByBlobDigest(t *testing.T) {
 		})
 	}
 }
+
+func TestTaskIDV2(t *testing.T) {
+	tests := []struct {
+		name                        string
+		url                         string
+		content                     string
+		enableTaskIDBasedBlobDigest bool
+		expect                      func(t *testing.T, d string, err error)
+	}{
+		{
+			name:                        "generate taskID by content",
+			url:                         "http://registry.example.com/v2/library/ubuntu/blobs/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e",
+			content:                     "This is a content",
+			enableTaskIDBasedBlobDigest: true,
+			expect: func(t *testing.T, d string, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Equal(d, TaskIDV2ByContent("This is a content"))
+			},
+		},
+		{
+			name:                        "generate taskID by blob digest",
+			url:                         "http://registry.example.com/v2/library/ubuntu/blobs/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e",
+			enableTaskIDBasedBlobDigest: true,
+			expect: func(t *testing.T, d string, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Equal(d, "b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e")
+			},
+		},
+		{
+			name: "generate taskID by url based when blob digest is disabled",
+			url:  "http://registry.example.com/v2/library/ubuntu/blobs/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e",
+			expect: func(t *testing.T, d string, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Equal(d, TaskIDV2ByURLBased("http://registry.example.com/v2/library/ubuntu/blobs/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e", nil, "foo", "bar", nil, ""))
+			},
+		},
+		{
+			name:                        "generate taskID by url based for non blob url",
+			url:                         "https://example.com/file.txt",
+			enableTaskIDBasedBlobDigest: true,
+			expect: func(t *testing.T, d string, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Equal(d, TaskIDV2ByURLBased("https://example.com/file.txt", nil, "foo", "bar", nil, ""))
+			},
+		},
+		{
+			name:                        "unsupported digest algorithm",
+			url:                         "http://registry.example.com/v2/library/ubuntu/blobs/md5:8a04994a666b4e4b20a2fd9e5a44f44c",
+			enableTaskIDBasedBlobDigest: true,
+			expect: func(t *testing.T, d string, err error) {
+				assert := assert.New(t)
+				assert.Error(err)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := TaskIDV2(tc.url, nil, "foo", "bar", nil, tc.content, tc.enableTaskIDBasedBlobDigest)
+			tc.expect(t, d, err)
+		})
+	}
+}

--- a/scheduler/job/job.go
+++ b/scheduler/job/job.go
@@ -267,7 +267,11 @@ func (j *job) PreheatSingleSeedPeer(ctx context.Context, req *internaljob.Prehea
 
 // preheatV1SingleSeedPeer preheats job by v1 grpc protocol.
 func (j *job) preheatV1SingleSeedPeer(ctx context.Context, req *internaljob.PreheatRequest, log *logger.SugaredLoggerOnWith) (*internaljob.PreheatResponse, error) {
-	taskID := idgen.TaskIDV2ByURLBased(req.URL, req.PieceLength, req.Tag, req.Application, idgen.ParseFilteredQueryParams(req.FilteredQueryParams), "")
+	taskID, err := idgen.TaskIDV2(req.URL, req.PieceLength, req.Tag, req.Application, idgen.ParseFilteredQueryParams(req.FilteredQueryParams), "", false)
+	if err != nil {
+		return nil, err
+	}
+
 	urlMeta := &commonv1.UrlMeta{
 		Tag:         req.Tag,
 		Filter:      req.FilteredQueryParams,
@@ -359,7 +363,11 @@ func (j *job) preheatV2SingleSeedPeer(ctx context.Context, req *internaljob.Preh
 // preheatV2SingleSeedPeerByURL preheats job by v2 grpc protocol for single seed peer by URL.
 func (j *job) preheatV2SingleSeedPeerByURL(ctx context.Context, url string, req *internaljob.PreheatRequest, log *logger.SugaredLoggerOnWith) (*internaljob.PreheatResponse, error) {
 	filteredQueryParams := idgen.ParseFilteredQueryParams(req.FilteredQueryParams)
-	taskID := idgen.TaskIDV2ByURLBased(url, req.PieceLength, req.Tag, req.Application, filteredQueryParams, "")
+	taskID, err := idgen.TaskIDV2(url, req.PieceLength, req.Tag, req.Application, filteredQueryParams, "", false)
+	if err != nil {
+		return nil, err
+	}
+
 	advertiseIP := j.config.Server.AdvertiseIP.String()
 
 	selected, err := j.resource.SeedPeer().Select(ctx, taskID)
@@ -454,7 +462,11 @@ func (j *job) PreheatAllSeedPeers(ctx context.Context, req *internaljob.PreheatR
 				addr := net.JoinHostPort(ip, strconv.Itoa(int(port)))
 				peg.Go(func() error {
 					filteredQueryParams := idgen.ParseFilteredQueryParams(req.FilteredQueryParams)
-					taskID := idgen.TaskIDV2ByURLBased(url, req.PieceLength, req.Tag, req.Application, filteredQueryParams, "")
+					taskID, err := idgen.TaskIDV2(url, req.PieceLength, req.Tag, req.Application, filteredQueryParams, "", false)
+					if err != nil {
+						return err
+					}
+
 					hostID := idgen.HostID(ip, hostname, true)
 					compositeID := fmt.Sprintf("%s-%s", taskID, hostID)
 					log := logger.WithPreheatJobAndHost(req.GroupUUID, req.TaskUUID, taskID, url, idgen.HostID(ip, hostname, true), hostname, ip)
@@ -678,7 +690,11 @@ func (j *job) PreheatAllPeers(ctx context.Context, req *internaljob.PreheatReque
 				addr := net.JoinHostPort(ip, strconv.Itoa(int(port)))
 				peg.Go(func() error {
 					filteredQueryParams := idgen.ParseFilteredQueryParams(req.FilteredQueryParams)
-					taskID := idgen.TaskIDV2ByURLBased(url, req.PieceLength, req.Tag, req.Application, filteredQueryParams, "")
+					taskID, err := idgen.TaskIDV2(url, req.PieceLength, req.Tag, req.Application, filteredQueryParams, "", false)
+					if err != nil {
+						return err
+					}
+
 					hostID := idgen.HostID(ip, hostname, false)
 					compositeID := fmt.Sprintf("%s-%s", taskID, hostID)
 					log := logger.WithPreheatJobAndHost(req.GroupUUID, req.TaskUUID, taskID, url, idgen.HostID(ip, hostname, true), hostname, ip)

--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -4679,6 +4679,7 @@ func (v *V2) StatImage(ctx context.Context, req *schedulerv2.StatImageRequest) (
 	timeout := req.GetTimeout().AsDuration()
 	concurrentPeerCount := *req.ConcurrentPeerCount
 	scope := req.GetScope()
+	enableTaskIDBasedBlobDigest := req.GetEnableTaskIdBasedBlobDigest()
 
 	var mu sync.Mutex
 	peers := map[string]*schedulerv2.PeerImage{}
@@ -4687,7 +4688,12 @@ func (v *V2) StatImage(ctx context.Context, req *schedulerv2.StatImageRequest) (
 	for _, url := range layers[0].URLs {
 		resp.Image.Layers = append(resp.Image.Layers, &schedulerv2.Layer{Url: url})
 		eg.Go(func() error {
-			taskID := idgen.TaskIDV2ByURLBased(url, pieceLength, tag, application, filteredQueryParams, "")
+			taskID, err := idgen.TaskIDV2(url, pieceLength, tag, application, filteredQueryParams, "", enableTaskIDBasedBlobDigest)
+			if err != nil {
+				log.Errorf("generate task id failed: %s", err.Error())
+				return nil
+			}
+
 			getTaskRequest := &internaljob.GetTaskRequest{
 				TaskID:              taskID,
 				Timeout:             timeout,
@@ -4782,8 +4788,13 @@ func (v *V2) PreheatFile(ctx context.Context, req *schedulerv2.PreheatFileReques
 
 	var urls []string
 	if strings.HasSuffix(req.GetUrl(), "/") {
+		taskID, err := idgen.TaskIDV2(req.GetUrl(), req.PieceLength, req.GetTag(), req.GetApplication(), req.FilteredQueryParams, "", false)
+		if err != nil {
+			return status.Errorf(codes.InvalidArgument, "failed to generate task id: %s", err)
+		}
+
 		listResp, err := v.job.ListTaskEntries(ctx, &internaljob.ListTaskEntriesRequest{
-			TaskID:           idgen.TaskIDV2ByURLBased(req.GetUrl(), req.PieceLength, req.GetTag(), req.GetApplication(), req.FilteredQueryParams, ""),
+			TaskID:           taskID,
 			Url:              req.GetUrl(),
 			Timeout:          req.GetTimeout(),
 			Header:           req.GetHeader(),
@@ -4908,8 +4919,13 @@ func (v *V2) StatFile(ctx context.Context, req *schedulerv2.StatFileRequest) (*s
 
 	var urls []string
 	if strings.HasSuffix(req.GetUrl(), "/") {
+		taskID, err := idgen.TaskIDV2(req.GetUrl(), req.PieceLength, req.GetTag(), req.GetApplication(), req.FilteredQueryParams, "", false)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "failed to generate task id: %s", err)
+		}
+
 		listResp, err := v.job.ListTaskEntries(ctx, &internaljob.ListTaskEntriesRequest{
-			TaskID:           idgen.TaskIDV2ByURLBased(req.GetUrl(), req.PieceLength, req.GetTag(), req.GetApplication(), req.FilteredQueryParams, ""),
+			TaskID:           taskID,
 			Url:              req.GetUrl(),
 			Timeout:          req.GetTimeout(),
 			Header:           req.GetHeader(),
@@ -4945,7 +4961,12 @@ func (v *V2) StatFile(ctx context.Context, req *schedulerv2.StatFileRequest) (*s
 	eg, ctx := errgroup.WithContext(ctx)
 	for _, url := range urls {
 		eg.Go(func() error {
-			taskID := idgen.TaskIDV2ByURLBased(url, req.PieceLength, req.GetTag(), req.GetApplication(), req.FilteredQueryParams, "")
+			taskID, err := idgen.TaskIDV2(url, req.PieceLength, req.GetTag(), req.GetApplication(), req.FilteredQueryParams, "", false)
+			if err != nil {
+				log.Errorf("generate task id failed: %s", err.Error())
+				return nil
+			}
+
 			getTaskRequest := &internaljob.GetTaskRequest{
 				TaskID:              taskID,
 				Timeout:             req.GetTimeout().AsDuration(),

--- a/scheduler/service/service_v2_test.go
+++ b/scheduler/service/service_v2_test.go
@@ -4003,6 +4003,32 @@ func TestServiceV2_StatImage(t *testing.T) {
 			},
 		},
 		{
+			name: "stat layer by peer with task id based blob digest",
+			req: &schedulerv2.StatImageRequest{
+				Url:                         "https://example.com/v2/image/manifests/latest",
+				EnableTaskIdBasedBlobDigest: true,
+			},
+			run: func(t *testing.T, svc *V2, req *schedulerv2.StatImageRequest, mj *jobmocks.MockJobMockRecorder, mi *internaljobmocks.MockImageMockRecorder) {
+				var wg sync.WaitGroup
+				wg.Add(1)
+				defer wg.Wait()
+
+				gomock.InOrder(
+					mi.CreatePreheatRequestsByManifestURL(gomock.Any(), gomock.Any()).Return([]*internaljob.PreheatRequest{{URLs: []string{"https://example.com/v2/image/latest/blobs/sha256:b5f4dfca35398b36f61baa60e2bf2c242401c9d7db3de9168dcf780a2feedd2d"}}}, nil).Times(1),
+					mj.GetTask(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(_ context.Context, getTaskRequest *internaljob.GetTaskRequest, _ *logger.SugaredLoggerOnWith) {
+						assert.Equal(t, "b5f4dfca35398b36f61baa60e2bf2c242401c9d7db3de9168dcf780a2feedd2d", getTaskRequest.TaskID)
+						wg.Done()
+					}).Return(&internaljob.GetTaskResponse{Peers: []*internaljob.Peer{{IP: "127.0.0.1", Hostname: "seed-peer-1"}}}, nil).Times(1),
+				)
+
+				resp, err := svc.StatImage(context.Background(), req)
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Equal(1, len(resp.Image.Layers))
+				assert.Equal(1, len(resp.Peers))
+			},
+		},
+		{
 			name: "stat layer by peer failed",
 			req: &schedulerv2.StatImageRequest{
 				Url: "https://example.com/v2/image/manifests/latest",


### PR DESCRIPTION



<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a new `TaskIDV2` function that selects the appropriate task ID generation strategy (content-based, blob-digest-based, or URL-based) mirroring the client's logic. Replace all direct calls to `TaskIDV2ByURLBased` and `TaskIDV2ByContent` in the manager job, scheduler job, and scheduler service with this single entry point. Also propagate the `enableTaskIdBasedBlobDigest` flag from `StatImageRequest` so OCI blob layers are hashed by their digest when the feature is enabled. Bump `d7y.io/api/v2` to v2.3.3 to pick up the new proto field.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
