### PR TITLE
Fix task ID generation error handling in StatImage

### DIFF
--- a/pkg/idgen/task_id_test.go
+++ b/pkg/idgen/task_id_test.go
@@ -166,6 +166,54 @@ func TestTaskIDV2ByURLBased(t *testing.T) {
 				assert.Equal(d, "b171331534b80e0bf91da38ebbfcdbf4d177898f4b9beac44f14733e3f004d4e")
 			},
 		},
+		{
+			name:        "generate taskID with sorted query params",
+			url:         "https://example.com/file.txt?z=9&b=2&a=1",
+			tag:         "foo",
+			application: "bar",
+			filters:     []string{"z"},
+			expect: func(t *testing.T, d any) {
+				assert := assert.New(t)
+				assert.Equal(d, "8b3f6e9b9b8fe20903bced565cfd1d0aaef354a4c17573f0c2c1979210443f9d")
+			},
+		},
+		{
+			name:    "generate taskID with same key query params keeping order",
+			url:     "https://example.com/file.txt?b=2&a=1&b=1",
+			filters: []string{"c"},
+			expect: func(t *testing.T, d any) {
+				assert := assert.New(t)
+				assert.Equal(d, "7c8801d0596be5e8f9449d5c4af23866c72fe5205119c0e5912981f3b16a37aa")
+			},
+		},
+		{
+			name:        "generate taskID with escaped query params",
+			url:         "https://example.com/file.txt?k=a b&m=x*y&n=c~d",
+			pieceLength: &pieceLength,
+			filters:     []string{"none"},
+			expect: func(t *testing.T, d any) {
+				assert := assert.New(t)
+				assert.Equal(d, "6196a6846023f6d3c1e4d30f6c86f3d4186e4c664a33e5692b0e04e49b26a9af")
+			},
+		},
+		{
+			name:    "generate taskID with all query params filtered",
+			url:     "https://example.com/file.txt?a=1&b=2",
+			tag:     "foo",
+			filters: []string{"a", "b"},
+			expect: func(t *testing.T, d any) {
+				assert := assert.New(t)
+				assert.Equal(d, "c8f4b41117329d54af920010394f6f607bac707e933ab2f18d372e3dd4c7fcb3")
+			},
+		},
+		{
+			name: "generate taskID with raw url when no filters",
+			url:  "https://example.com/file.txt?b=2&a=1",
+			expect: func(t *testing.T, d any) {
+				assert := assert.New(t)
+				assert.Equal(d, "980ee327518ccc5a7c30703e1a2232e8ba9047b39431f940636c85b6146f8b9a")
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/net/url/url_test.go
+++ b/pkg/net/url/url_test.go
@@ -31,6 +31,26 @@ func TestFilterQuery(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "http://www.xx.yy/path?u=f&x=y&m=z&x=s#size", url)
 
+	url, err = FilterQueryParams("https://example.com/file.txt?z=9&b=2&a=1", []string{"z"})
+	assert.Nil(t, err)
+	assert.Equal(t, "https://example.com/file.txt?a=1&b=2", url)
+
+	url, err = FilterQueryParams("https://example.com/file.txt?b=2&a=1&b=1", []string{"c"})
+	assert.Nil(t, err)
+	assert.Equal(t, "https://example.com/file.txt?a=1&b=2&b=1", url)
+
+	url, err = FilterQueryParams("https://example.com?foo=foo", []string{"foo"})
+	assert.Nil(t, err)
+	assert.Equal(t, "https://example.com", url)
+
+	url, err = FilterQueryParams("https://example.com/file.txt?k=a b&m=x*y&n=c~d", []string{"none"})
+	assert.Nil(t, err)
+	assert.Equal(t, "https://example.com/file.txt?k=a+b&m=x%2Ay&n=c~d", url)
+
+	url, err = FilterQueryParams("https://example.com/file.txt?a=1;x&b=2", []string{"none"})
+	assert.Nil(t, err)
+	assert.Equal(t, "https://example.com/file.txt?b=2", url)
+
 	url, err = FilterQueryParams(":error_url", []string{"x", "m"})
 	assert.NotNil(t, err)
 	assert.Equal(t, "", url)

--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -4681,6 +4681,16 @@ func (v *V2) StatImage(ctx context.Context, req *schedulerv2.StatImageRequest) (
 	scope := req.GetScope()
 	enableTaskIDBasedBlobDigest := req.GetEnableTaskIdBasedBlobDigest()
 
+	taskIDs := make(map[string]string, len(layers[0].URLs))
+	for _, url := range layers[0].URLs {
+		taskID, err := idgen.TaskIDV2(url, pieceLength, tag, application, filteredQueryParams, "", enableTaskIDBasedBlobDigest)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "failed to generate task id for layer %s: %s", url, err)
+		}
+
+		taskIDs[url] = taskID
+	}
+
 	var mu sync.Mutex
 	peers := map[string]*schedulerv2.PeerImage{}
 	eg, ctx := errgroup.WithContext(ctx)
@@ -4688,12 +4698,7 @@ func (v *V2) StatImage(ctx context.Context, req *schedulerv2.StatImageRequest) (
 	for _, url := range layers[0].URLs {
 		resp.Image.Layers = append(resp.Image.Layers, &schedulerv2.Layer{Url: url})
 		eg.Go(func() error {
-			taskID, err := idgen.TaskIDV2(url, pieceLength, tag, application, filteredQueryParams, "", enableTaskIDBasedBlobDigest)
-			if err != nil {
-				log.Errorf("generate task id failed: %s", err.Error())
-				return nil
-			}
-
+			taskID := taskIDs[url]
 			getTaskRequest := &internaljob.GetTaskRequest{
 				TaskID:              taskID,
 				Timeout:             timeout,

--- a/scheduler/service/service_v2_test.go
+++ b/scheduler/service/service_v2_test.go
@@ -4029,6 +4029,22 @@ func TestServiceV2_StatImage(t *testing.T) {
 			},
 		},
 		{
+			name: "stat layer by peer with invalid blob digest",
+			req: &schedulerv2.StatImageRequest{
+				Url:                         "https://example.com/v2/image/manifests/latest",
+				EnableTaskIdBasedBlobDigest: true,
+			},
+			run: func(t *testing.T, svc *V2, req *schedulerv2.StatImageRequest, mj *jobmocks.MockJobMockRecorder, mi *internaljobmocks.MockImageMockRecorder) {
+				mi.CreatePreheatRequestsByManifestURL(gomock.Any(), gomock.Any()).Return([]*internaljob.PreheatRequest{{URLs: []string{"https://example.com/v2/image/latest/blobs/md5:8a04994a666b4e4b20a2fd9e5a44f44c"}}}, nil).Times(1)
+
+				resp, err := svc.StatImage(context.Background(), req)
+				assert := assert.New(t)
+				assert.Nil(resp)
+				assert.ErrorContains(err, "failed to generate task id for layer https://example.com/v2/image/latest/blobs/md5:8a04994a666b4e4b20a2fd9e5a44f44c")
+				assert.Equal(codes.InvalidArgument, status.Code(err))
+			},
+		},
+		{
 			name: "stat layer by peer failed",
 			req: &schedulerv2.StatImageRequest{
 				Url: "https://example.com/v2/image/manifests/latest",


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Previously, task ID generation errors in StatImage goroutines were silently swallowed, causing the request to proceed with an empty task ID. Now errors are returned immediately with an InvalidArgument status before spawning goroutines.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
