### PR TITLE
feat(oci): return manifest digest URLs from Resolve alongside blob URLs

### DIFF
--- a/internal/job/image.go
+++ b/internal/job/image.go
@@ -135,7 +135,7 @@ func (i *image) CreatePreheatRequestsByManifestURL(ctx context.Context, req *Man
 	// preheat request and carries the auth info in the headers, which is used
 	// as the issued token by the resolver.
 	header := nethttp.MapToHeader(req.Headers)
-	blobURLs, token, err := pkgoci.Resolve(ctx, ref,
+	_, blobURLs, token, err := pkgoci.Resolve(ctx, ref,
 		pkgoci.WithAuth(req.Username, req.Password),
 		pkgoci.WithPlatform(req.Platform),
 		pkgoci.WithHeader(header.Clone()),

--- a/pkg/idgen/task_id.go
+++ b/pkg/idgen/task_id.go
@@ -111,6 +111,22 @@ func IsBlobURL(url string) bool {
 	return blobURLRegexp.MatchString(url)
 }
 
+// manifestURLRegexp matches OCI manifest URLs, e.g. http(s)://<registry>/v2/<repository>/manifests/<reference>.
+var manifestURLRegexp = regexp.MustCompile(`^(.*)://(.*)/v2/(.*)/manifests/([^?]+)(?:\?.*)?$`)
+
+// IsManifestDigestURL reports whether the url is an OCI manifest URL whose reference is
+// a digest, e.g. http(s)://<registry>/v2/<repository>/manifests/sha256:<hex>. A manifest
+// url referenced by a tag returns false, so it falls back to the url based task id.
+func IsManifestDigestURL(url string) bool {
+	matches := manifestURLRegexp.FindStringSubmatch(url)
+	if matches == nil {
+		return false
+	}
+
+	_, err := pkgdigest.Parse(matches[4])
+	return err == nil
+}
+
 // TaskIDV1 generates v1 version of task id.
 // filter is separated by & character.
 func TaskIDV1(url string, meta *commonv1.UrlMeta) string {
@@ -201,11 +217,32 @@ func TaskIDV2ByBlobDigest(url string) (string, error) {
 	}
 }
 
+// TaskIDV2ByManifestDigest generates v2 version of task id by the digest
+// extracted from the OCI manifest url.
+func TaskIDV2ByManifestDigest(url string) (string, error) {
+	matches := manifestURLRegexp.FindStringSubmatch(url)
+	if matches == nil {
+		return "", fmt.Errorf("invalid manifest url: %s", url)
+	}
+
+	d, err := pkgdigest.Parse(matches[4])
+	if err != nil {
+		return "", err
+	}
+
+	switch d.Algorithm {
+	case pkgdigest.AlgorithmCRC32, pkgdigest.AlgorithmSHA256, pkgdigest.AlgorithmSHA512:
+		return d.Encoded, nil
+	default:
+		return "", fmt.Errorf("unsupported digest algorithm: %s", d.Algorithm)
+	}
+}
+
 // TaskIDV2 generates v2 version of task id, selecting the generator by the parameters,
 // identical to the client's task id generation. If the content is not empty, generate
 // the task id by the content. If the task id based blob digest is enabled and the url
-// is an OCI blob url, generate the task id by the blob digest. Otherwise, generate the
-// task id by the url based parameters.
+// is an OCI blob url or an OCI manifest url referenced by a digest, generate the task
+// id by the digest. Otherwise, generate the task id by the url based parameters.
 func TaskIDV2(url string, pieceLength *uint64, tag, application string, filteredQueryParams []string, content string, enableTaskIDBasedBlobDigest bool) (string, error) {
 	if content != "" {
 		return TaskIDV2ByContent(content), nil
@@ -213,6 +250,10 @@ func TaskIDV2(url string, pieceLength *uint64, tag, application string, filtered
 
 	if enableTaskIDBasedBlobDigest && IsBlobURL(url) {
 		return TaskIDV2ByBlobDigest(url)
+	}
+
+	if enableTaskIDBasedBlobDigest && IsManifestDigestURL(url) {
+		return TaskIDV2ByManifestDigest(url)
 	}
 
 	return TaskIDV2ByURLBased(url, pieceLength, tag, application, filteredQueryParams, ""), nil

--- a/pkg/idgen/task_id_test.go
+++ b/pkg/idgen/task_id_test.go
@@ -324,6 +324,77 @@ func TestIsBlobURL(t *testing.T) {
 	}
 }
 
+func TestIsManifestDigestURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		url    string
+		expect func(t *testing.T, ok bool)
+	}{
+		{
+			name: "manifest url with sha256 digest",
+			url:  "http://registry.example.com/v2/library/ubuntu/manifests/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e",
+			expect: func(t *testing.T, ok bool) {
+				assert := assert.New(t)
+				assert.True(ok)
+			},
+		},
+		{
+			name: "manifest url with nested repository",
+			url:  "https://registry.io/v2/org/team/project/manifests/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e",
+			expect: func(t *testing.T, ok bool) {
+				assert := assert.New(t)
+				assert.True(ok)
+			},
+		},
+		{
+			name: "manifest url with port and query params",
+			url:  "http://localhost:5000/v2/myrepo/manifests/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e?ns=docker.io",
+			expect: func(t *testing.T, ok bool) {
+				assert := assert.New(t)
+				assert.True(ok)
+			},
+		},
+		{
+			name: "manifest url with tag",
+			url:  "https://registry.example.com/v2/library/ubuntu/manifests/latest",
+			expect: func(t *testing.T, ok bool) {
+				assert := assert.New(t)
+				assert.False(ok)
+			},
+		},
+		{
+			name: "manifest url with invalid digest length",
+			url:  "https://registry.example.com/v2/library/ubuntu/manifests/sha256:abc",
+			expect: func(t *testing.T, ok bool) {
+				assert := assert.New(t)
+				assert.False(ok)
+			},
+		},
+		{
+			name: "blob url",
+			url:  "http://registry.example.com/v2/library/ubuntu/blobs/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e",
+			expect: func(t *testing.T, ok bool) {
+				assert := assert.New(t)
+				assert.False(ok)
+			},
+		},
+		{
+			name: "plain url",
+			url:  "https://example.com/file.txt",
+			expect: func(t *testing.T, ok bool) {
+				assert := assert.New(t)
+				assert.False(ok)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.expect(t, IsManifestDigestURL(tc.url))
+		})
+	}
+}
+
 func TestTaskIDV2ByBlobDigest(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -391,6 +462,73 @@ func TestTaskIDV2ByBlobDigest(t *testing.T) {
 	}
 }
 
+func TestTaskIDV2ByManifestDigest(t *testing.T) {
+	tests := []struct {
+		name   string
+		url    string
+		expect func(t *testing.T, d string, err error)
+	}{
+		{
+			name: "generate taskID by sha256 manifest digest",
+			url:  "http://registry.example.com/v2/library/ubuntu/manifests/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e",
+			expect: func(t *testing.T, d string, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Equal(d, "b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e")
+			},
+		},
+		{
+			name: "generate taskID by sha512 manifest digest",
+			url:  "https://registry.example.com/v2/myorg/myrepo/manifests/sha512:94381a28e8c039fedfa78de025158a068226c3ccd041b22c2c8e73fc993584e9b167d9ae32bc8b372c66701c808ab134e0768c8f16b9a3e61eec1ccf8faa9db8",
+			expect: func(t *testing.T, d string, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Equal(d, "94381a28e8c039fedfa78de025158a068226c3ccd041b22c2c8e73fc993584e9b167d9ae32bc8b372c66701c808ab134e0768c8f16b9a3e61eec1ccf8faa9db8")
+			},
+		},
+		{
+			name: "generate taskID by manifest digest with query params",
+			url:  "http://localhost:5000/v2/myrepo/manifests/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e?ns=docker.io",
+			expect: func(t *testing.T, d string, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Equal(d, "b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e")
+			},
+		},
+		{
+			name: "not a manifest url",
+			url:  "https://example.com/file.txt",
+			expect: func(t *testing.T, d string, err error) {
+				assert := assert.New(t)
+				assert.Error(err)
+			},
+		},
+		{
+			name: "invalid digest length",
+			url:  "http://registry.example.com/v2/library/ubuntu/manifests/sha256:abc",
+			expect: func(t *testing.T, d string, err error) {
+				assert := assert.New(t)
+				assert.Error(err)
+			},
+		},
+		{
+			name: "unsupported digest algorithm",
+			url:  "http://registry.example.com/v2/library/ubuntu/manifests/md5:8a04994a666b4e4b20a2fd9e5a44f44c",
+			expect: func(t *testing.T, d string, err error) {
+				assert := assert.New(t)
+				assert.Error(err)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := TaskIDV2ByManifestDigest(tc.url)
+			tc.expect(t, d, err)
+		})
+	}
+}
+
 func TestTaskIDV2(t *testing.T) {
 	tests := []struct {
 		name                        string
@@ -418,6 +556,35 @@ func TestTaskIDV2(t *testing.T) {
 				assert := assert.New(t)
 				assert.NoError(err)
 				assert.Equal(d, "b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e")
+			},
+		},
+		{
+			name:                        "generate taskID by manifest digest",
+			url:                         "http://registry.example.com/v2/library/ubuntu/manifests/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e",
+			enableTaskIDBasedBlobDigest: true,
+			expect: func(t *testing.T, d string, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Equal(d, "b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e")
+			},
+		},
+		{
+			name: "generate taskID by url based when manifest digest is disabled",
+			url:  "http://registry.example.com/v2/library/ubuntu/manifests/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e",
+			expect: func(t *testing.T, d string, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Equal(d, TaskIDV2ByURLBased("http://registry.example.com/v2/library/ubuntu/manifests/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e", nil, "foo", "bar", nil, ""))
+			},
+		},
+		{
+			name:                        "generate taskID by url based for manifest url with tag",
+			url:                         "http://registry.example.com/v2/library/ubuntu/manifests/latest",
+			enableTaskIDBasedBlobDigest: true,
+			expect: func(t *testing.T, d string, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Equal(d, TaskIDV2ByURLBased("http://registry.example.com/v2/library/ubuntu/manifests/latest", nil, "foo", "bar", nil, ""))
 			},
 		},
 		{

--- a/pkg/oci/image.go
+++ b/pkg/oci/image.go
@@ -151,10 +151,10 @@ func WithHTTPClient(client *http.Client) ResolveOption {
 	}
 }
 
-// Resolve resolves the manifest of the reference (including multi-platform
-// image indexes) from the registry and returns the blob urls (config and
-// layers) along with the authorization token for downloading them.
-func Resolve(ctx context.Context, ref *Reference, opts ...ResolveOption) (blobURLs []string, token string, err error) {
+// Resolve resolves the manifest of the reference (including multi-platform image indexes) from
+// the registry and returns the manifest urls referenced by the digests of the resolved manifests,
+// the blob urls (config and layers) and the authorization token for downloading them.
+func Resolve(ctx context.Context, ref *Reference, opts ...ResolveOption) (manifestURLs, blobURLs []string, token string, err error) {
 	options := &resolveOptions{header: make(http.Header)}
 	for _, opt := range opts {
 		opt(options)
@@ -164,7 +164,7 @@ func Resolve(ctx context.Context, ref *Reference, opts ...ResolveOption) (blobUR
 	if options.platform != "" {
 		platform, err = platforms.Parse(options.platform)
 		if err != nil {
-			return nil, "", fmt.Errorf("invalid platform format %q, expected \"os/arch\" (e.g., \"linux/amd64\"): %w", options.platform, err)
+			return nil, nil, "", fmt.Errorf("invalid platform format %q, expected \"os/arch\" (e.g., \"linux/amd64\"): %w", options.platform, err)
 		}
 	}
 
@@ -179,16 +179,16 @@ func Resolve(ctx context.Context, ref *Reference, opts ...ResolveOption) (blobUR
 
 	client, err := NewAuthClient(ref, options.httpClient, options.username, options.password, authOpts...)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to authenticate with registry: %w", err)
+		return nil, nil, "", fmt.Errorf("failed to authenticate with registry: %w", err)
 	}
 
-	manifests, err := client.ResolveManifests(ctx, ref, options.header.Clone(), platform)
+	manifests, manifestURLs, err := client.ResolveManifests(ctx, ref, options.header.Clone(), platform)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to pull image manifest: %w", err)
+		return nil, nil, "", fmt.Errorf("failed to pull image manifest: %w", err)
 	}
 
 	if len(manifests) == 0 {
-		return nil, "", fmt.Errorf("no matching manifest for platform %s", platforms.Format(platform))
+		return nil, nil, "", fmt.Errorf("no matching manifest for platform %s", platforms.Format(platform))
 	}
 
 	for _, manifest := range manifests {
@@ -197,5 +197,5 @@ func Resolve(ctx context.Context, ref *Reference, opts ...ResolveOption) (blobUR
 		}
 	}
 
-	return blobURLs, client.AuthToken(), nil
+	return manifestURLs, blobURLs, client.AuthToken(), nil
 }

--- a/pkg/oci/image_test.go
+++ b/pkg/oci/image_test.go
@@ -18,6 +18,7 @@ package oci
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -110,9 +111,6 @@ func TestParseImage(t *testing.T) {
 
 func TestResolve(t *testing.T) {
 	assert := assert.New(t)
-
-	// Mock registry: bearer challenge on /v2/, token endpoint and a schema2
-	// manifest with a config and one layer.
 	manifest := `{
 		"schemaVersion": 2,
 		"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
@@ -161,25 +159,26 @@ func TestResolve(t *testing.T) {
 	serverURL, err := url.Parse(server.URL)
 	assert.NoError(err)
 
-	// The mock registry only serves http, so parse the image with plain http.
 	ref, err := ParseImage(serverURL.Host+"/library/nginx:latest", WithPlainHTTP(true))
 	assert.NoError(err)
 
-	blobURLs, token, err := Resolve(context.Background(), ref, WithHTTPClient(&http.Client{Transport: http.DefaultTransport}))
+	manifestURLs, blobURLs, token, err := Resolve(context.Background(), ref, WithHTTPClient(&http.Client{Transport: http.DefaultTransport}))
 	assert.NoError(err)
 
+	manifestDigest := fmt.Sprintf("sha256:%x", sha256.Sum256([]byte(manifest)))
+	assert.Equal([]string{
+		fmt.Sprintf("http://%s/v2/library/nginx/manifests/%s", serverURL.Host, manifestDigest),
+	}, manifestURLs)
 	assert.Equal([]string{
 		fmt.Sprintf("http://%s/v2/library/nginx/blobs/sha256:b5b2b2c507a0944348e0303114d8d93aaaa081732b86451d9bce1f432a537bc7", serverURL.Host),
 		fmt.Sprintf("http://%s/v2/library/nginx/blobs/sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f", serverURL.Host),
 	}, blobURLs)
 	assert.Equal("Bearer test-token", token)
 
-	// An Authorization header short-circuits v2 authentication and is used as
-	// the issued token directly.
 	header := make(http.Header)
 	header.Set("Authorization", "Bearer test-token")
 
-	blobURLs, token, err = Resolve(context.Background(), ref,
+	_, blobURLs, token, err = Resolve(context.Background(), ref,
 		WithHTTPClient(&http.Client{Transport: http.DefaultTransport}),
 		WithHeader(header),
 	)
@@ -190,12 +189,137 @@ func TestResolve(t *testing.T) {
 
 func TestResolveInvalidPlatform(t *testing.T) {
 	assert := assert.New(t)
-
 	ref, err := ParseImage("127.0.0.1:1/library/nginx:latest")
 	assert.NoError(err)
 
-	// The platform is validated before any network access.
-	_, _, err = Resolve(context.Background(), ref, WithPlatform("linux-amd64"))
+	_, _, _, err = Resolve(context.Background(), ref, WithPlatform("linux-amd64"))
 	assert.Error(err)
 	assert.ErrorContains(err, "invalid platform format")
+}
+
+func TestResolveManifestList(t *testing.T) {
+	manifest := `{
+		"schemaVersion": 2,
+		"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+		"config": {
+			"mediaType": "application/vnd.docker.container.image.v1+json",
+			"size": 7023,
+			"digest": "sha256:b5b2b2c507a0944348e0303114d8d93aaaa081732b86451d9bce1f432a537bc7"
+		},
+		"layers": [
+			{
+				"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+				"size": 32654,
+				"digest": "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f"
+			}
+		]
+	}`
+	manifestDigest := fmt.Sprintf("sha256:%x", sha256.Sum256([]byte(manifest)))
+	manifestList := fmt.Sprintf(`{
+		"schemaVersion": 2,
+		"mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+		"manifests": [
+			{
+				"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+				"size": %d,
+				"digest": "%s",
+				"platform": {
+					"architecture": "amd64",
+					"os": "linux"
+				}
+			},
+			{
+				"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+				"size": 7143,
+				"digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				"platform": {
+					"architecture": "arm64",
+					"os": "linux"
+				}
+			}
+		]
+	}`, len(manifest), manifestDigest)
+
+	var server *httptest.Server
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			w.Header().Set("WWW-Authenticate", fmt.Sprintf("Bearer realm=%q,service=\"registry\"", server.URL+"/token"))
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"token":"test-token"}`)
+	})
+	mux.HandleFunc("/v2/library/nginx/manifests/latest", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.docker.distribution.manifest.list.v2+json")
+		fmt.Fprint(w, manifestList)
+	})
+	mux.HandleFunc("/v2/library/nginx/manifests/"+manifestDigest, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.docker.distribution.manifest.v2+json")
+		fmt.Fprint(w, manifest)
+	})
+	server = httptest.NewServer(mux)
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	assert.New(t).NoError(err)
+
+	tests := []struct {
+		name     string
+		platform string
+		expect   func(t *testing.T, manifestURLs, blobURLs []string, token string, err error)
+	}{
+		{
+			name:     "resolve matched platform manifest from manifest list",
+			platform: "linux/amd64",
+			expect: func(t *testing.T, manifestURLs, blobURLs []string, token string, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Equal([]string{
+					fmt.Sprintf("http://%s/v2/library/nginx/manifests/%s", serverURL.Host, manifestDigest),
+				}, manifestURLs)
+				assert.Equal([]string{
+					fmt.Sprintf("http://%s/v2/library/nginx/blobs/sha256:b5b2b2c507a0944348e0303114d8d93aaaa081732b86451d9bce1f432a537bc7", serverURL.Host),
+					fmt.Sprintf("http://%s/v2/library/nginx/blobs/sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f", serverURL.Host),
+				}, blobURLs)
+				assert.Equal("Bearer test-token", token)
+			},
+		},
+		{
+			name:     "no matching manifest for platform",
+			platform: "linux/riscv64",
+			expect: func(t *testing.T, manifestURLs, blobURLs []string, token string, err error) {
+				assert := assert.New(t)
+				assert.Error(err)
+				assert.ErrorContains(err, "no matching manifest for platform")
+			},
+		},
+		{
+			name:     "matched platform manifest is not served by the registry",
+			platform: "linux/arm64",
+			expect: func(t *testing.T, manifestURLs, blobURLs []string, token string, err error) {
+				assert := assert.New(t)
+				assert.Error(err)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+			ref, err := ParseImage(serverURL.Host+"/library/nginx:latest", WithPlainHTTP(true))
+			assert.NoError(err)
+
+			manifestURLs, blobURLs, token, err := Resolve(context.Background(), ref,
+				WithHTTPClient(&http.Client{Transport: http.DefaultTransport}),
+				WithPlatform(tc.platform),
+			)
+			tc.expect(t, manifestURLs, blobURLs, token, err)
+		})
+	}
 }

--- a/pkg/oci/resolver.go
+++ b/pkg/oci/resolver.go
@@ -34,11 +34,12 @@ import (
 
 // ResolveManifests fetches and resolves container image manifests from a registry for a specified platform.
 // It constructs an HTTP request to retrieve the manifest, handles authentication via headers, and processes the response
-// to return manifests matching the given platform. Supports single manifests and manifest lists.
-func (c *AuthClient) ResolveManifests(ctx context.Context, ref *Reference, header http.Header, platform specs.Platform) ([]distribution.Manifest, error) {
+// to return manifests matching the given platform, along with the manifest urls referenced by the digests of the
+// matched platform manifests, excluding the manifest list (image index) itself.
+func (c *AuthClient) ResolveManifests(ctx context.Context, ref *Reference, header http.Header, platform specs.Platform) ([]distribution.Manifest, []string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ref.ManifestURL(), nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Set header from the user request.
@@ -55,48 +56,51 @@ func (c *AuthClient) ResolveManifests(ctx context.Context, ref *Reference, heade
 
 	resp, err := c.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer resp.Body.Close()
 
 	// Handle response.
 	if resp.StatusCode == http.StatusNotModified {
-		return nil, distribution.ErrManifestNotModified
+		return nil, nil, distribution.ErrManifestNotModified
 	} else if !registryclient.SuccessStatus(resp.StatusCode) {
-		return nil, registryclient.HandleErrorResponse(resp)
+		return nil, nil, registryclient.HandleErrorResponse(resp)
 	}
 
 	ctHeader := resp.Header.Get("Content-Type")
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	// Unmarshal manifest.
-	manifest, _, err := distribution.UnmarshalManifest(ctHeader, body)
+	manifest, desc, err := distribution.UnmarshalManifest(ctHeader, body)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	switch v := manifest.(type) {
 	case *schema1.SignedManifest, *schema2.DeserializedManifest, *ocischema.DeserializedManifest:
-		return []distribution.Manifest{v}, nil
+		digestRef := *ref
+		digestRef.Reference = desc.Digest.String()
+		return []distribution.Manifest{v}, []string{digestRef.ManifestURL()}, nil
 	case *manifestlist.DeserializedManifestList:
 		var result []distribution.Manifest
+		var manifestURLs []string
 		for _, desc := range filterManifests(v.Manifests, platform) {
 			ref.Reference = desc.Digest.String()
-			manifests, err := c.ResolveManifests(ctx, ref, header.Clone(), platform)
+			manifests, childManifestURLs, err := c.ResolveManifests(ctx, ref, header.Clone(), platform)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 
 			result = append(result, manifests...)
+			manifestURLs = append(manifestURLs, childManifestURLs...)
 		}
 
-		return result, nil
+		return result, manifestURLs, nil
 	}
 
-	return nil, errors.New("unknown manifest type")
+	return nil, nil, errors.New("unknown manifest type")
 }
 
 // filterManifests filters a list of manifest descriptors to return only those


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Extend `Resolve` and `ResolveManifests` to also return the manifest URLs referenced by the resolved manifest digests (excluding image indexes). This enables callers to generate stable task IDs for OCI manifest preheat requests without relying on mutable tags.

Add `IsManifestDigestURL` and `TaskIDV2ByManifestDigest` to the idgen package so that `TaskIDV2` can derive a content-addressed task ID from an OCI manifest URL when `enableTaskIDBasedBlobDigest` is set, matching the existing behavior for blob URLs.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
