### PR TITLE
use bcrypt.DefaultCost for password hashing

### DIFF
--- a/manager/permission/rbac/rbac.go
+++ b/manager/permission/rbac/rbac.go
@@ -151,7 +151,7 @@ func InitRBAC(e *casbin.Enforcer, g *gin.Engine, db *gorm.DB) error {
 			logger.Warnf("seed the root user with the default password, set %s to override it", DragonflyInitialRootPasswordEnvName)
 		}
 
-		encryptedPasswordBytes, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
+		encryptedPasswordBytes, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 		if err != nil {
 			return err
 		}

--- a/manager/service/user.go
+++ b/manager/service/user.go
@@ -95,7 +95,7 @@ func (s *service) ResetPassword(ctx context.Context, id uint, json types.ResetPa
 		return err
 	}
 
-	encryptedPasswordBytes, err := bcrypt.GenerateFromPassword([]byte(json.NewPassword), bcrypt.MinCost)
+	encryptedPasswordBytes, err := bcrypt.GenerateFromPassword([]byte(json.NewPassword), bcrypt.DefaultCost)
 	if err != nil {
 		return err
 	}
@@ -110,7 +110,7 @@ func (s *service) ResetPassword(ctx context.Context, id uint, json types.ResetPa
 }
 
 func (s *service) SignUp(ctx context.Context, json types.SignUpRequest) (*models.User, error) {
-	encryptedPasswordBytes, err := bcrypt.GenerateFromPassword([]byte(json.Password), bcrypt.MinCost)
+	encryptedPasswordBytes, err := bcrypt.GenerateFromPassword([]byte(json.Password), bcrypt.DefaultCost)
 	if err != nil {
 		return nil, err
 	}

--- a/manager/service/user_test.go
+++ b/manager/service/user_test.go
@@ -59,6 +59,10 @@ func TestService_SignUp(t *testing.T) {
 				assert.NotEqual("dragonfly", user.EncryptedPassword)
 				assert.NoError(bcrypt.CompareHashAndPassword([]byte(user.EncryptedPassword), []byte("dragonfly")))
 
+				cost, err := bcrypt.Cost([]byte(user.EncryptedPassword))
+				assert.NoError(err)
+				assert.GreaterOrEqual(cost, bcrypt.DefaultCost)
+
 				roles, err := s.enforcer.GetRolesForUser(fmt.Sprint(user.ID))
 				assert.NoError(err)
 				assert.Equal([]string{rbac.GuestRole}, roles)


### PR DESCRIPTION
## Description

The manager hashes passwords with `bcrypt.MinCost`, the library's testing floor:

    bcrypt.Cost(hash) == 4   // bcrypt.MinCost, vs bcrypt.DefaultCost == 10

Three sites do it: `SignUp` and `ResetPassword` in `manager/service/user.go`, and the
seeded root user in `rbac.InitRBAC`. So every stored manager credential, including the
admin/root password, is orders of magnitude cheaper to brute-force offline if the user
table leaks. Switched all three to `bcrypt.DefaultCost`.

Existing hashes keep verifying since the cost is embedded in the hash; only newly
created/reset passwords get the stronger work factor.

## Related Issue

## Motivation and Context

`bcrypt.MinCost` (4) is meant for tests, not password storage. `bcrypt.DefaultCost`
is the value the library recommends for real use.

## Screenshots (if appropriate)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
